### PR TITLE
fix(ui): the board survives NO_COLOR and a narrow terminal, and the plain sink never contradicts itself

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -201,6 +201,10 @@ List project containers.
 | `--services` | Print service names only. | off |
 | `-s, --size` | Add a SIZE column with each container's on-disk footprint. | off |
 
+An empty result prints `no containers` on stderr and leaves stdout empty, so
+a script capturing stdout (`podup ps | awk …`) can tell an empty project from
+a non-empty one without parsing headers.
+
 ### `ls`
 List podup compose projects on the host. Needs no compose file.
 
@@ -210,6 +214,10 @@ List podup compose projects on the host. Needs no compose file.
 | `-q, --quiet` | Print project names only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
 | `--filter <FILTER>` | Keep only projects matching a predicate: `name=<NAME>` or `status=<running\|exited>`. Repeatable. | none |
+
+An empty result prints `no projects` on stderr and leaves stdout empty, so a
+script capturing stdout (`podup ls | awk …`) can tell an empty host from a
+non-empty one without parsing headers.
 
 ### `logs [SERVICE...]`
 View container output for the named services (or all).
@@ -298,6 +306,9 @@ the raw byte count, not the rendered string.
 | `-q, --quiet` | Print image IDs only. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
 
+An empty result (no services with `image:` or `build:`) prints `no images` on
+stderr and leaves stdout empty.
+
 ### The ps CREATED and STATUS columns
 
 `STATUS` reports how long a running container has been up (`Up 2h 5m 3s`), with
@@ -370,6 +381,8 @@ neither creates nor deletes an external volume, so those are the ones a
 | `-q, --quiet` | Print volume names only. | off |
 | `-s, --size` | Add SIZE and RECLAIMABLE columns. Slow — see below. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
+
+An empty result prints `no volumes` on stderr and leaves stdout empty.
 
 ## Container operations
 
@@ -767,6 +780,17 @@ record of what it did.
 
 **Anywhere else** — a pipe, a file, CI, `NO_COLOR`, `--ansi never` — the same
 events come out as plain append-only lines with no escape sequences at all:
+
+**Progress lines on stderr never contradict themselves.** A transitional
+verb (`Creating`, `Starting`, `Pulling`, `Removing`, …) is held until the final
+one arrives. When the final verb reports work (`Created`, `Started`, `Pulled`,
+`Removed`), both lines are printed in order, so a log shows when the work
+started; when it reports that nothing was done (`Exists`, `Running`, `Absent`,
+`Skipped`), only that line is printed, so a piped `up -d` against a network
+that already exists says `Network … Exists` and not the pair `Creating` /
+`Exists`. A transitional verb whose final never arrives (a crash mid-way) is
+still flushed at the end of the command, so the log records what was in
+flight.
 
 ```
  Network myapp_default  Creating

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -457,7 +457,7 @@ fn unit_is_known<S: SystemCtl>(sc: &S, unit: &str) -> bool {
 /// When the auto-update timer pair is present, this removes both: the
 /// `<unit>-update.service` oneshot and the `<unit>-update.timer` schedule that
 /// fires it. Without that, the timer would keep firing `up -d` against a stack
-/// whose main unit had been uninstalled, the exact inconsistency the brief
+/// whose main unit had been uninstalled, the exact inconsistency the issue
 /// calls out.
 pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	let unit_name = unit_file_name(project);

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -1,4 +1,4 @@
-//! `ls` — discover podup-managed compose projects on the host.
+//! `ls` ,  discover podup-managed compose projects on the host.
 //!
 //! Unlike the other commands this is project-agnostic: it scans every container
 //! carrying a `podup.project` label and groups by project, so it needs only a
@@ -106,7 +106,7 @@ struct Tally {
 	paused: usize,
 	total: usize,
 	/// The `podup.config-files` label, from the first container that carries one.
-	/// Empty when no container in the project has it — created before the label
+	/// Empty when no container in the project has it ,  created before the label
 	/// existed, or by an embedder that supplied no paths.
 	config_files: String,
 }
@@ -170,7 +170,7 @@ pub async fn list_projects_filtered(
 		}
 	}
 
-	// An unsupported key is an error, not a warning — see the note on the ps
+	// An unsupported key is an error, not a warning ,  see the note on the ps
 	// filters: silently answering a different question is worse than refusing.
 	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
 	if let Some(u) = unknown.first() {
@@ -220,11 +220,18 @@ pub async fn list_projects_filtered(
 	for (name, t) in &rows {
 		table.push(vec![name.to_string(), status_label(t)]);
 	}
+	if table.is_empty() {
+		// An empty ls table is a legitimate answer; print the explicit
+		// "no projects" line on stderr so a script capturing stdout (or
+		// `--format json`) sees nothing (#1675).
+		crate::ui::progress_note("no projects");
+		return Ok(());
+	}
 	table.print();
 	Ok(())
 }
 
-/// Per-state replica counts joined as `running(2), paused(1), exited(1)` —
+/// Per-state replica counts joined as `running(2), paused(1), exited(1)` ,
 /// mirrors the `docker compose ls` status column, which surfaces each state
 /// rather than collapsing to a single running count and discarding the rest.
 fn status_label(t: &Tally) -> String {
@@ -249,7 +256,7 @@ fn status_label(t: &Tally) -> String {
 /// One `ls --format json` row, matching `docker compose ls --format json`.
 ///
 /// `ConfigFiles` comes from the `podup.config-files` label the containers carry
-/// — projects are discovered by label and there is no other record of where a
+/// ,  projects are discovered by label and there is no other record of where a
 /// compose file lives. It is empty for a container created before that label
 /// existed, or by an embedder that did not supply the paths.
 fn project_row(name: &str, t: &Tally, config_files: &str) -> serde_json::Value {

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -1,4 +1,4 @@
-//! `ls` ,  discover podup-managed compose projects on the host.
+//! `ls` — discover podup-managed compose projects on the host.
 //!
 //! Unlike the other commands this is project-agnostic: it scans every container
 //! carrying a `podup.project` label and groups by project, so it needs only a
@@ -106,7 +106,7 @@ struct Tally {
 	paused: usize,
 	total: usize,
 	/// The `podup.config-files` label, from the first container that carries one.
-	/// Empty when no container in the project has it ,  created before the label
+	/// Empty when no container in the project has it — created before the label
 	/// existed, or by an embedder that supplied no paths.
 	config_files: String,
 }
@@ -170,7 +170,7 @@ pub async fn list_projects_filtered(
 		}
 	}
 
-	// An unsupported key is an error, not a warning ,  see the note on the ps
+	// An unsupported key is an error, not a warning — see the note on the ps
 	// filters: silently answering a different question is worse than refusing.
 	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
 	if let Some(u) = unknown.first() {
@@ -231,7 +231,7 @@ pub async fn list_projects_filtered(
 	Ok(())
 }
 
-/// Per-state replica counts joined as `running(2), paused(1), exited(1)` ,
+/// Per-state replica counts joined as `running(2), paused(1), exited(1)` —
 /// mirrors the `docker compose ls` status column, which surfaces each state
 /// rather than collapsing to a single running count and discarding the rest.
 fn status_label(t: &Tally) -> String {
@@ -256,7 +256,7 @@ fn status_label(t: &Tally) -> String {
 /// One `ls --format json` row, matching `docker compose ls --format json`.
 ///
 /// `ConfigFiles` comes from the `podup.config-files` label the containers carry
-/// ,  projects are discovered by label and there is no other record of where a
+/// — projects are discovered by label and there is no other record of where a
 /// compose file lives. It is empty for a container created before that label
 /// existed, or by an embedder that did not supply the paths.
 fn project_row(name: &str, t: &Tally, config_files: &str) -> serde_json::Value {

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -12,7 +12,7 @@ use super::Engine;
 /// How `images` renders a size: decimal units at three significant digits.
 ///
 /// Decimal because this table exists to be read against `podman images` and
-/// `docker compose images`, which are decimal ,  not against `free`. Three
+/// `docker compose images`, which are decimal — not against `free`. Three
 /// digits because that is what those two print, measured rather than assumed:
 /// `docker compose` v5.1.3 rendered `98.2MB` for `redis:8-alpine` and `podman
 /// images` rendered `1.01 GB` and `805 kB` on the same host. A fixed decimal
@@ -34,7 +34,7 @@ struct ImageRow {
 	tag: String,
 	id: String,
 	/// Raw bytes as libpod reported them. Zero when the image is not present
-	/// locally, which the table renders as an empty cell ,  a missing image has
+	/// locally, which the table renders as an empty cell — a missing image has
 	/// no size, and `0B` would claim it has one.
 	size: u64,
 	/// The RFC 3339 string libpod sent, kept raw so the table can render an age
@@ -103,7 +103,7 @@ impl Engine {
 						created: img.created,
 					});
 				}
-				// A 404 means the image is simply not present locally ,  list it with
+				// A 404 means the image is simply not present locally — list it with
 				// an empty ID rather than silently dropping it, matching docker
 				// compose. Any other error (a connection failure / unreachable
 				// socket, or an HTTP 500) is a real failure that must propagate with
@@ -197,7 +197,7 @@ impl Engine {
 /// The SIZE cell for one row.
 ///
 /// An image that is not present locally has no size to report, so the cell is
-/// empty. `0B` would be a claim ,  that podup asked and the answer was zero ,
+/// empty. `0B` would be a claim — that podup asked and the answer was zero —
 /// and the row already says the image is missing by carrying no ID.
 fn size_cell(size: u64) -> String {
 	if size == 0 {

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -12,7 +12,7 @@ use super::Engine;
 /// How `images` renders a size: decimal units at three significant digits.
 ///
 /// Decimal because this table exists to be read against `podman images` and
-/// `docker compose images`, which are decimal — not against `free`. Three
+/// `docker compose images`, which are decimal ,  not against `free`. Three
 /// digits because that is what those two print, measured rather than assumed:
 /// `docker compose` v5.1.3 rendered `98.2MB` for `redis:8-alpine` and `podman
 /// images` rendered `1.01 GB` and `805 kB` on the same host. A fixed decimal
@@ -34,7 +34,7 @@ struct ImageRow {
 	tag: String,
 	id: String,
 	/// Raw bytes as libpod reported them. Zero when the image is not present
-	/// locally, which the table renders as an empty cell — a missing image has
+	/// locally, which the table renders as an empty cell ,  a missing image has
 	/// no size, and `0B` would claim it has one.
 	size: u64,
 	/// The RFC 3339 string libpod sent, kept raw so the table can render an age
@@ -103,7 +103,7 @@ impl Engine {
 						created: img.created,
 					});
 				}
-				// A 404 means the image is simply not present locally — list it with
+				// A 404 means the image is simply not present locally ,  list it with
 				// an empty ID rather than silently dropping it, matching docker
 				// compose. Any other error (a connection failure / unreachable
 				// socket, or an HTTP 500) is a real failure that must propagate with
@@ -182,6 +182,13 @@ impl Engine {
 				age_cell(&row.created, now),
 			]);
 		}
+		if table.is_empty() {
+			// An empty images table is a legitimate answer; print the explicit
+			// "no images" line on stderr so a script capturing stdout (or
+			// `--format json`) sees nothing (#1675).
+			crate::ui::progress_note("no images");
+			return Ok(());
+		}
 		table.print();
 		Ok(())
 	}
@@ -190,7 +197,7 @@ impl Engine {
 /// The SIZE cell for one row.
 ///
 /// An image that is not present locally has no size to report, so the cell is
-/// empty. `0B` would be a claim — that podup asked and the answer was zero —
+/// empty. `0B` would be a claim ,  that podup asked and the answer was zero ,
 /// and the row already says the image is missing by carrying no ID.
 fn size_cell(size: u64) -> String {
 	if size == 0 {

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -1,4 +1,4 @@
-//! `ps` — list this project's containers as a table or JSON. Split out of the
+//! `ps` ,  list this project's containers as a table or JSON. Split out of the
 //! query root so each file stays within the source line limit.
 
 use crate::compose::types::ComposeFile;
@@ -62,7 +62,7 @@ impl PsOptions {
 ///
 /// **`#[non_exhaustive]` from birth, and that is the whole point.** Both
 /// [`PsOptions`] and [`PsFilterOptions`] are externally constructible with a
-/// struct literal, so adding a field to either requires a MAJOR — measured with
+/// struct literal, so adding a field to either requires a MAJOR ,  measured with
 /// `cargo semver-checks`, which reports `constructible_struct_adds_field`, not
 /// assumed from the rules. `PsFilterOptions` was itself introduced to keep
 /// `PsOptions` stable and inherited the same problem, so a third frozen struct
@@ -193,7 +193,7 @@ const SPAN_FORMAT: DurationFormat = DurationFormat::default_parts();
 /// span answers "did it just restart", which is the question someone runs `ps`
 /// to settle.
 ///
-/// The health suffix only appears when the container has a healthcheck —
+/// The health suffix only appears when the container has a healthcheck ,
 /// libpod leaves `Status` empty otherwise, measured on Podman 5.7.0, so there is
 /// nothing to append rather than an unknown to invent.
 ///
@@ -219,7 +219,7 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 	};
 	// `health_from_status` answers with an empty string when the container has
 	// no healthcheck, which is the same case as libpod sending an empty
-	// `Status` — nothing to append rather than an unknown to invent.
+	// `Status` ,  nothing to append rather than an unknown to invent.
 	match health_from_status(status) {
 		"" => format!("Up {uptime}"),
 		health => format!("Up {uptime} ({health})"),
@@ -230,8 +230,8 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 ///
 /// Pure so the query it builds can be asserted without a server. The `size`
 /// parameter is the one worth pinning: `size=true` is not a bigger payload, it
-/// is work — libpod walks each container's writable layer to answer, measured
-/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0 — so asking for it
+/// is work ,  libpod walks each container's writable layer to answer, measured
+/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0 ,  so asking for it
 /// unconditionally would make every `ps` pay for a column most readers do not
 /// look at. `docker ps -s` is opt-in for the same reason.
 ///
@@ -249,7 +249,7 @@ fn containers_path(project: &str, all: bool, size: bool) -> String {
 
 /// How `ps` renders a size: decimal units at three significant digits.
 ///
-/// The same shape `images` uses, and for the same reason — this column is read
+/// The same shape `images` uses, and for the same reason ,  this column is read
 /// against `podman ps -s`, which prints `143kB (virtual 225MB)`. Measured
 /// against it rather than assumed.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
@@ -257,7 +257,7 @@ const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 /// Table SIZE cell: the writable layer, then the image behind it.
 ///
 /// `143kB (virtual 225MB)`, matching `podman ps -s` and `docker ps -s`.
-/// **`virtual` is the image's own size, not the sum** — verified on three
+/// **`virtual` is the image's own size, not the sum** ,  verified on three
 /// containers whose two readings differ at three significant digits, because on
 /// a container with a small writable layer the two are indistinguishable and a
 /// wrong choice would never show.
@@ -290,7 +290,7 @@ fn table_created(c: &ContainerListEntry, now: i64) -> String {
 /// render.
 ///
 /// A zero `then` means the field was absent, not that the instant was the epoch.
-/// A `then` in the future is clock skew between this process and the server —
+/// A `then` in the future is clock skew between this process and the server ,
 /// clamped to zero rather than rendered as a negative age, since `Up 0s` on a
 /// container that just started is right and `Up -3s` is never right.
 fn span_since(then: i64, now: i64) -> Option<String> {
@@ -374,8 +374,8 @@ fn span_len(p: &ContainerPort) -> u16 {
 }
 
 /// `base + offset` widened to `u32` before adding. `host_port`,
-/// `container_port` and `range` all come straight off libpod's JSON — untrusted
-/// input a hostile or buggy daemon could set to any `u16` value — so a plain
+/// `container_port` and `range` all come straight off libpod's JSON ,  untrusted
+/// input a hostile or buggy daemon could set to any `u16` value ,  so a plain
 /// `u16 + u16` (e.g. `host_port: 65535` with a `range` of 2) can overflow: it
 /// wraps silently in a release build and panics under overflow-checks. Doing
 /// the addition in `u32` keeps every legitimate port value identical while a
@@ -464,7 +464,7 @@ fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
 		// wants an instant it can compute with rather than `2mo 1d`.
 		"Created": c.created,
 		"StartedAt": c.started_at,
-		// Raw byte counts, and null when the size was not requested — the same
+		// Raw byte counts, and null when the size was not requested ,  the same
 		// distinction the table draws between an empty cell and a zero.
 		"Size": c.size.map(|s| serde_json::json!({
 			"RwSize": s.rw,
@@ -613,7 +613,7 @@ impl Engine {
 		// second cannot render different ages.
 		let now = now_unix();
 		// SIZE is appended rather than inserted, so a reader's existing column
-		// positions do not move when the flag is off — and `docker ps -s` puts
+		// positions do not move when the flag is off ,  and `docker ps -s` puts
 		// it last too.
 		let mut headers: Vec<&str> = vec!["NAME", "IMAGE", "CREATED", "STATUS", "PORTS"];
 		if display.size {
@@ -636,6 +636,13 @@ impl Engine {
 				row.push(table_size(c));
 			}
 			table.push(row);
+		}
+		if table.is_empty() {
+			// An empty ps table is a legitimate answer; print the explicit
+			// "no containers" line on stderr so a script capturing stdout (or
+			// `--format json`) sees nothing (#1675).
+			crate::ui::progress_note("no containers");
+			return Ok(());
 		}
 		table.print();
 

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -1,4 +1,4 @@
-//! `ps` ,  list this project's containers as a table or JSON. Split out of the
+//! `ps` — list this project's containers as a table or JSON. Split out of the
 //! query root so each file stays within the source line limit.
 
 use crate::compose::types::ComposeFile;
@@ -62,7 +62,7 @@ impl PsOptions {
 ///
 /// **`#[non_exhaustive]` from birth, and that is the whole point.** Both
 /// [`PsOptions`] and [`PsFilterOptions`] are externally constructible with a
-/// struct literal, so adding a field to either requires a MAJOR ,  measured with
+/// struct literal, so adding a field to either requires a MAJOR — measured with
 /// `cargo semver-checks`, which reports `constructible_struct_adds_field`, not
 /// assumed from the rules. `PsFilterOptions` was itself introduced to keep
 /// `PsOptions` stable and inherited the same problem, so a third frozen struct
@@ -193,7 +193,7 @@ const SPAN_FORMAT: DurationFormat = DurationFormat::default_parts();
 /// span answers "did it just restart", which is the question someone runs `ps`
 /// to settle.
 ///
-/// The health suffix only appears when the container has a healthcheck ,
+/// The health suffix only appears when the container has a healthcheck —
 /// libpod leaves `Status` empty otherwise, measured on Podman 5.7.0, so there is
 /// nothing to append rather than an unknown to invent.
 ///
@@ -219,7 +219,7 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 	};
 	// `health_from_status` answers with an empty string when the container has
 	// no healthcheck, which is the same case as libpod sending an empty
-	// `Status` ,  nothing to append rather than an unknown to invent.
+	// `Status` — nothing to append rather than an unknown to invent.
 	match health_from_status(status) {
 		"" => format!("Up {uptime}"),
 		health => format!("Up {uptime} ({health})"),
@@ -230,8 +230,8 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 ///
 /// Pure so the query it builds can be asserted without a server. The `size`
 /// parameter is the one worth pinning: `size=true` is not a bigger payload, it
-/// is work ,  libpod walks each container's writable layer to answer, measured
-/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0 ,  so asking for it
+/// is work — libpod walks each container's writable layer to answer, measured
+/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0 — so asking for it
 /// unconditionally would make every `ps` pay for a column most readers do not
 /// look at. `docker ps -s` is opt-in for the same reason.
 ///
@@ -249,7 +249,7 @@ fn containers_path(project: &str, all: bool, size: bool) -> String {
 
 /// How `ps` renders a size: decimal units at three significant digits.
 ///
-/// The same shape `images` uses, and for the same reason ,  this column is read
+/// The same shape `images` uses, and for the same reason — this column is read
 /// against `podman ps -s`, which prints `143kB (virtual 225MB)`. Measured
 /// against it rather than assumed.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
@@ -257,7 +257,7 @@ const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 /// Table SIZE cell: the writable layer, then the image behind it.
 ///
 /// `143kB (virtual 225MB)`, matching `podman ps -s` and `docker ps -s`.
-/// **`virtual` is the image's own size, not the sum** ,  verified on three
+/// **`virtual` is the image's own size, not the sum** — verified on three
 /// containers whose two readings differ at three significant digits, because on
 /// a container with a small writable layer the two are indistinguishable and a
 /// wrong choice would never show.
@@ -290,7 +290,7 @@ fn table_created(c: &ContainerListEntry, now: i64) -> String {
 /// render.
 ///
 /// A zero `then` means the field was absent, not that the instant was the epoch.
-/// A `then` in the future is clock skew between this process and the server ,
+/// A `then` in the future is clock skew between this process and the server —
 /// clamped to zero rather than rendered as a negative age, since `Up 0s` on a
 /// container that just started is right and `Up -3s` is never right.
 fn span_since(then: i64, now: i64) -> Option<String> {
@@ -374,8 +374,8 @@ fn span_len(p: &ContainerPort) -> u16 {
 }
 
 /// `base + offset` widened to `u32` before adding. `host_port`,
-/// `container_port` and `range` all come straight off libpod's JSON ,  untrusted
-/// input a hostile or buggy daemon could set to any `u16` value ,  so a plain
+/// `container_port` and `range` all come straight off libpod's JSON — untrusted
+/// input a hostile or buggy daemon could set to any `u16` value — so a plain
 /// `u16 + u16` (e.g. `host_port: 65535` with a `range` of 2) can overflow: it
 /// wraps silently in a release build and panics under overflow-checks. Doing
 /// the addition in `u32` keeps every legitimate port value identical while a
@@ -464,7 +464,7 @@ fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
 		// wants an instant it can compute with rather than `2mo 1d`.
 		"Created": c.created,
 		"StartedAt": c.started_at,
-		// Raw byte counts, and null when the size was not requested ,  the same
+		// Raw byte counts, and null when the size was not requested — the same
 		// distinction the table draws between an empty cell and a zero.
 		"Size": c.size.map(|s| serde_json::json!({
 			"RwSize": s.rw,
@@ -613,7 +613,7 @@ impl Engine {
 		// second cannot render different ages.
 		let now = now_unix();
 		// SIZE is appended rather than inserted, so a reader's existing column
-		// positions do not move when the flag is off ,  and `docker ps -s` puts
+		// positions do not move when the flag is off — and `docker ps -s` puts
 		// it last too.
 		let mut headers: Vec<&str> = vec!["NAME", "IMAGE", "CREATED", "STATUS", "PORTS"];
 		if display.size {

--- a/internal/engine/query/terminal/mod.rs
+++ b/internal/engine/query/terminal/mod.rs
@@ -18,9 +18,9 @@
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub(crate) use unix::{window_size, RawMode, ResizeWatcher};
+pub(crate) use unix::{drain_stdin, window_size, RawMode, ResizeWatcher};
 
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub(crate) use windows::{window_size, RawMode, ResizeWatcher};
+pub(crate) use windows::{drain_stdin, window_size, RawMode, ResizeWatcher};

--- a/internal/engine/query/terminal/unix.rs
+++ b/internal/engine/query/terminal/unix.rs
@@ -1,8 +1,8 @@
-//! The termios implementation of the terminal contract ,  see the module doc
+//! The termios implementation of the terminal contract — see the module doc
 //! in `mod.rs` for the contract and the restore-on-drop invariant.
 
 // termios and the winsize ioctl are libc FFI. The crate denies `unsafe` and
-// modules that need it opt back in locally, with a soundness comment per block ,
+// modules that need it opt back in locally, with a soundness comment per block —
 // see `engine::lock` and `engine::staging` for the same pattern.
 #![allow(unsafe_code)]
 
@@ -32,7 +32,7 @@ impl RawMode {
 	///
 	/// `enable` is the only place that consults the ambient stdin, which keeps
 	/// this testable: a test that asserted on `enable()` directly would be
-	/// asserting that whoever runs `cargo test` has no terminal ,  true under a
+	/// asserting that whoever runs `cargo test` has no terminal — true under a
 	/// pipe, false in a shell, and on the way to being false it would put the
 	/// developer's own terminal into raw mode.
 	pub(super) fn enable_on(fd: i32) -> Option<Self> {
@@ -54,7 +54,7 @@ impl RawMode {
 		unsafe { libc::cfmakeraw(&mut raw) };
 		// SAFETY: `raw` is a fully initialized `termios` derived from the current
 		// settings. TCSANOW applies immediately, which is what an interactive
-		// session wants ,  a drained flush would swallow keystrokes already typed.
+		// session wants — a drained flush would swallow keystrokes already typed.
 		if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
 			return None;
 		}
@@ -83,8 +83,8 @@ impl Drop for RawMode {
 /// this, a full-screen program inside the container draws to an 80x24 default
 /// and redraws wrong the moment the window changes.
 ///
-/// **stdin first, then stdout.** Asking only stdout looks natural ,  that is
-/// where the drawing goes ,  but the two can differ: `podup exec -it db psql >
+/// **stdin first, then stdout.** Asking only stdout looks natural — that is
+/// where the drawing goes — but the two can differ: `podup exec -it db psql >
 /// out.txt` types into a terminal and writes to a file, and stdout then answers
 /// "not a terminal" while a perfectly good size sits on stdin. Interactivity is
 /// decided by stdin, so the size is asked of stdin too, and stdout is the
@@ -102,7 +102,7 @@ fn size_of(fd: i32) -> Option<(u16, u16)> {
 	if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) } != 0 {
 		return None;
 	}
-	// A terminal that reports 0x0 has no usable geometry ,  treat it as unknown
+	// A terminal that reports 0x0 has no usable geometry — treat it as unknown
 	// rather than sizing the remote pty to nothing.
 	if ws.ws_row == 0 || ws.ws_col == 0 {
 		return None;
@@ -159,7 +159,7 @@ impl ResizeWatcher {
 /// Implemented with `O_NONBLOCK` toggled for the duration of the read so the
 /// call returns immediately on an empty queue. The flag is restored before
 /// returning, so the pump's blocking reads are unaffected. A non-terminal
-/// stdin (a pipe) is a no-op ,  the pump does not run on a pipe.
+/// stdin (a pipe) is a no-op; the pump does not run on a pipe.
 pub(crate) fn drain_stdin() {
 	use std::io::Read;
 	use std::os::fd::AsRawFd;

--- a/internal/engine/query/terminal/unix.rs
+++ b/internal/engine/query/terminal/unix.rs
@@ -1,8 +1,8 @@
-//! The termios implementation of the terminal contract — see the module doc
+//! The termios implementation of the terminal contract ,  see the module doc
 //! in `mod.rs` for the contract and the restore-on-drop invariant.
 
 // termios and the winsize ioctl are libc FFI. The crate denies `unsafe` and
-// modules that need it opt back in locally, with a soundness comment per block —
+// modules that need it opt back in locally, with a soundness comment per block ,
 // see `engine::lock` and `engine::staging` for the same pattern.
 #![allow(unsafe_code)]
 
@@ -32,7 +32,7 @@ impl RawMode {
 	///
 	/// `enable` is the only place that consults the ambient stdin, which keeps
 	/// this testable: a test that asserted on `enable()` directly would be
-	/// asserting that whoever runs `cargo test` has no terminal — true under a
+	/// asserting that whoever runs `cargo test` has no terminal ,  true under a
 	/// pipe, false in a shell, and on the way to being false it would put the
 	/// developer's own terminal into raw mode.
 	pub(super) fn enable_on(fd: i32) -> Option<Self> {
@@ -54,7 +54,7 @@ impl RawMode {
 		unsafe { libc::cfmakeraw(&mut raw) };
 		// SAFETY: `raw` is a fully initialized `termios` derived from the current
 		// settings. TCSANOW applies immediately, which is what an interactive
-		// session wants — a drained flush would swallow keystrokes already typed.
+		// session wants ,  a drained flush would swallow keystrokes already typed.
 		if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
 			return None;
 		}
@@ -83,8 +83,8 @@ impl Drop for RawMode {
 /// this, a full-screen program inside the container draws to an 80x24 default
 /// and redraws wrong the moment the window changes.
 ///
-/// **stdin first, then stdout.** Asking only stdout looks natural — that is
-/// where the drawing goes — but the two can differ: `podup exec -it db psql >
+/// **stdin first, then stdout.** Asking only stdout looks natural ,  that is
+/// where the drawing goes ,  but the two can differ: `podup exec -it db psql >
 /// out.txt` types into a terminal and writes to a file, and stdout then answers
 /// "not a terminal" while a perfectly good size sits on stdin. Interactivity is
 /// decided by stdin, so the size is asked of stdin too, and stdout is the
@@ -102,7 +102,7 @@ fn size_of(fd: i32) -> Option<(u16, u16)> {
 	if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) } != 0 {
 		return None;
 	}
-	// A terminal that reports 0x0 has no usable geometry — treat it as unknown
+	// A terminal that reports 0x0 has no usable geometry ,  treat it as unknown
 	// rather than sizing the remote pty to nothing.
 	if ws.ws_row == 0 || ws.ws_col == 0 {
 		return None;
@@ -143,6 +143,61 @@ impl ResizeWatcher {
 			}
 		}
 	}
+}
+
+/// Drop every byte the kernel had queued on stdin, without forwarding any of
+/// them.
+///
+/// Called once at the start of an interactive exec/run, between enabling raw
+/// mode and entering the byte pump. Switching to raw surfaces whatever was
+/// queued, and a pty-startup NUL has been measured to land there under
+/// `script -qfc` (see #1675): forwarding it would echo back as `^@` from the
+/// remote pty and pollute the output as the first byte. The user has not had
+/// a chance to type anything yet, so every byte read here is pty startup and
+/// is safe to discard.
+///
+/// Implemented with `O_NONBLOCK` toggled for the duration of the read so the
+/// call returns immediately on an empty queue. The flag is restored before
+/// returning, so the pump's blocking reads are unaffected. A non-terminal
+/// stdin (a pipe) is a no-op ,  the pump does not run on a pipe.
+pub(crate) fn drain_stdin() {
+	use std::io::Read;
+	use std::os::fd::AsRawFd;
+
+	let stdin = std::io::stdin();
+	let fd = stdin.as_raw_fd();
+	if fd < 0 {
+		return;
+	}
+	// SAFETY: `fd` is the read side of a tty/pipe; toggling O_NONBLOCK on it
+	// affects only this process and is reverted before returning.
+	let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+	if flags < 0 {
+		return;
+	}
+	if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+		return;
+	}
+	let mut stdin = stdin;
+	let mut sink = [0u8; 256];
+	loop {
+		match stdin.read(&mut sink) {
+			Ok(0) => break,
+			Ok(n) => {
+				// Discard `n` bytes. We could read until EAGAIN, but a tight
+				// loop here is fine: each read on a non-blocking tty returns
+				// the bytes available at that instant, and once drained
+				// subsequent reads return `EAGAIN` (encoded as `Err` with
+				// `WouldBlock`).
+				let _ = n;
+				continue;
+			}
+			Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+			Err(_) => break,
+		}
+	}
+	// SAFETY: same fd, restore the previous flags so the pump reads block.
+	let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
 }
 
 #[cfg(test)]

--- a/internal/engine/query/terminal/windows.rs
+++ b/internal/engine/query/terminal/windows.rs
@@ -1,4 +1,4 @@
-//! The console-API implementation of the terminal contract — see the module
+//! The console-API implementation of the terminal contract ,  see the module
 //! doc in `mod.rs` for the contract and the restore-on-drop invariant.
 //!
 //! Windows has no termios: raw mode is a console *mode* cleared on the stdin
@@ -11,16 +11,17 @@
 
 // The console mode and screen-buffer calls are Win32 FFI. The crate denies
 // `unsafe` and modules that need it opt back in locally, with a soundness
-// comment per block — see `engine::lock` and `engine::staging` for the same
+// comment per block ,  see `engine::lock` and `engine::staging` for the same
 // pattern.
 #![allow(unsafe_code)]
 
 use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::Console::{
-	GetConsoleMode, GetConsoleScreenBufferInfo, GetStdHandle, SetConsoleMode, CONSOLE_MODE,
-	CONSOLE_SCREEN_BUFFER_INFO, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
-	ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING, STD_ERROR_HANDLE,
-	STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+	GetConsoleMode, GetConsoleScreenBufferInfo, GetNumberOfConsoleInputEvents, GetStdHandle,
+	ReadConsoleInputW, SetConsoleMode, CONSOLE_MODE, CONSOLE_SCREEN_BUFFER_INFO, ENABLE_ECHO_INPUT,
+	ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+	ENABLE_VIRTUAL_TERMINAL_PROCESSING, INPUT_RECORD, STD_ERROR_HANDLE, STD_INPUT_HANDLE,
+	STD_OUTPUT_HANDLE,
 };
 
 /// A console switched to raw mode, restored on drop.
@@ -28,8 +29,8 @@ use windows_sys::Win32::System::Console::{
 /// Holding the *original* modes rather than reconstructing "sane" ones
 /// matters: the caller's shell may run with its own console flags, and putting
 /// the console into what podup thinks is normal would quietly change them.
-/// Both ends are touched — stdin so keystrokes stop being line-buffered and
-/// echoed, stdout so the VT sequences a pty emits are interpreted — so both
+/// Both ends are touched ,  stdin so keystrokes stop being line-buffered and
+/// echoed, stdout so the VT sequences a pty emits are interpreted ,  so both
 /// originals are held and both are restored.
 pub(crate) struct RawMode {
 	stdin: HANDLE,
@@ -63,7 +64,7 @@ impl RawMode {
 	///
 	/// `enable` is the only place that consults the ambient handles, which
 	/// keeps this testable: a test that asserted on `enable()` directly would
-	/// be asserting on whether the test runner has a console — and on the way
+	/// be asserting on whether the test runner has a console ,  and on the way
 	/// to failing it would put that console into raw mode.
 	pub(super) fn enable_on(stdin: HANDLE, stdout: HANDLE) -> Option<Self> {
 		if stdin.is_null() || stdin == INVALID_HANDLE_VALUE {
@@ -76,7 +77,7 @@ impl RawMode {
 		let mut stdin_original: CONSOLE_MODE = 0;
 		// SAFETY: `stdin_original` is a correctly sized mode owned here, and
 		// `GetConsoleMode` only writes into it. A non-console handle fails the
-		// call rather than misbehaving — that is exactly the "not a terminal"
+		// call rather than misbehaving ,  that is exactly the "not a terminal"
 		// answer.
 		if unsafe { GetConsoleMode(stdin, &mut stdin_original) } == 0 {
 			return None;
@@ -89,7 +90,7 @@ impl RawMode {
 
 		// Line input and echo are the console's line discipline; processed
 		// input turns Ctrl-C into an event instead of a byte. All three must
-		// go so keystrokes — including Ctrl-C — travel to the remote command,
+		// go so keystrokes ,  including Ctrl-C ,  travel to the remote command,
 		// which is what raw mode means. Virtual-terminal input makes arrows
 		// and function keys arrive as the VT sequences the remote pty expects.
 		let stdin_raw = (stdin_original
@@ -144,7 +145,7 @@ impl Drop for RawMode {
 /// without this, a full-screen program inside the container draws to an 80x24
 /// default and redraws wrong the moment the window changes.
 ///
-/// **stdout first, then stderr** — not stdin, unlike Unix: the screen buffer
+/// **stdout first, then stderr** ,  not stdin, unlike Unix: the screen buffer
 /// is an output-side object, and the input handle does not answer
 /// `GetConsoleScreenBufferInfo`. stderr covers a redirected stdout, the same
 /// reverse case the Unix fallback covers.
@@ -176,12 +177,12 @@ fn size_of(handle: HANDLE) -> Option<(u16, u16)> {
 /// `srWindow`, not `dwSize`: the buffer runs thousands of lines of scrollback,
 /// and sizing the remote pty to it would have a full-screen program paint a
 /// frame taller than the screen. The rectangle is inclusive on both ends,
-/// hence the `+ 1`s. Pure, so the arithmetic — the part worth pinning — is
+/// hence the `+ 1`s. Pure, so the arithmetic ,  the part worth pinning ,  is
 /// testable without a console.
 fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
 	let rows = i32::from(info.srWindow.Bottom) - i32::from(info.srWindow.Top) + 1;
 	let cols = i32::from(info.srWindow.Right) - i32::from(info.srWindow.Left) + 1;
-	// A degenerate or inverted rectangle has no usable geometry — treat it as
+	// A degenerate or inverted rectangle has no usable geometry ,  treat it as
 	// unknown rather than sizing the remote pty to nothing.
 	if rows <= 0 || cols <= 0 {
 		return None;
@@ -193,8 +194,8 @@ fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
 /// caller's window changes.
 ///
 /// The console has no resize signal, so this polls [`window_size`] four times
-/// a second and reports only changes. The alternative — `ReadConsoleInput`
-/// watching `WINDOW_BUFFER_SIZE_EVENT` — is event-driven but competes with the
+/// a second and reports only changes. The alternative ,  `ReadConsoleInput`
+/// watching `WINDOW_BUFFER_SIZE_EVENT` ,  is event-driven but competes with the
 /// stdin byte pump for the same console handle; polling costs one cheap call
 /// per tick and touches nothing the pump owns.
 pub(crate) struct ResizeWatcher {
@@ -231,7 +232,7 @@ impl ResizeWatcher {
 
 /// Whether a polled size warrants a resize: `Some` only when it is readable
 /// and differs from the last one reported, recording it as reported. Pure so
-/// the dedup — the part that decides whether the pump spams resize calls —
+/// the dedup ,  the part that decides whether the pump spams resize calls ,
 /// is testable without a console.
 fn resize_due(last: &mut Option<(u16, u16)>, current: Option<(u16, u16)>) -> Option<(u16, u16)> {
 	let current = current?;
@@ -240,6 +241,39 @@ fn resize_due(last: &mut Option<(u16, u16)>, current: Option<(u16, u16)>) -> Opt
 	}
 	*last = Some(current);
 	Some(current)
+}
+
+/// Drop every byte the kernel had queued on the console's stdin handle, without
+/// forwarding any of them.
+///
+/// Called once at the start of an interactive exec/run, between enabling raw
+/// mode and entering the byte pump. The console's input queue may carry
+/// startup bytes from before the user could possibly type anything, and a
+/// previously-measured pty artifact echoes back as `^@` (see #1675).
+/// Discarding those bytes before the pump starts keeps the user's first
+/// keystroke from being preceded by a stray character.
+///
+/// A non-console handle is a no-op ,  the pump does not run on a pipe.
+pub(crate) fn drain_stdin() {
+	// SAFETY: `GetStdHandle` takes no pointers and only returns a handle; a
+	// missing standard handle comes back null or invalid, checked below.
+	let stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+	if stdin.is_null() || stdin == INVALID_HANDLE_VALUE {
+		return;
+	}
+	// SAFETY: `events` is a correctly sized unsigned owned here; the call only
+	// writes into it. A non-console handle returns 0.
+	let mut events: u32 = 0;
+	if unsafe { GetNumberOfConsoleInputEvents(stdin, &mut events) } == 0 {
+		return;
+	}
+	let mut records = vec![std::mem::zeroed::<INPUT_RECORD>(); events.max(1) as usize];
+	let mut read: u32 = 0;
+	// SAFETY: `records` is a contiguous, correctly-sized buffer; the call
+	// only writes up to `events` records and reports the count in `read`.
+	// We discard the records (they are bytes from before raw mode took
+	// effect; the user has not had a chance to type anything yet).
+	let _ = unsafe { ReadConsoleInputW(stdin, records.as_mut_ptr(), events, &mut read) };
 }
 
 #[cfg(test)]

--- a/internal/engine/query/terminal/windows.rs
+++ b/internal/engine/query/terminal/windows.rs
@@ -1,4 +1,4 @@
-//! The console-API implementation of the terminal contract ,  see the module
+//! The console-API implementation of the terminal contract — see the module
 //! doc in `mod.rs` for the contract and the restore-on-drop invariant.
 //!
 //! Windows has no termios: raw mode is a console *mode* cleared on the stdin
@@ -11,7 +11,7 @@
 
 // The console mode and screen-buffer calls are Win32 FFI. The crate denies
 // `unsafe` and modules that need it opt back in locally, with a soundness
-// comment per block ,  see `engine::lock` and `engine::staging` for the same
+// comment per block — see `engine::lock` and `engine::staging` for the same
 // pattern.
 #![allow(unsafe_code)]
 
@@ -29,8 +29,8 @@ use windows_sys::Win32::System::Console::{
 /// Holding the *original* modes rather than reconstructing "sane" ones
 /// matters: the caller's shell may run with its own console flags, and putting
 /// the console into what podup thinks is normal would quietly change them.
-/// Both ends are touched ,  stdin so keystrokes stop being line-buffered and
-/// echoed, stdout so the VT sequences a pty emits are interpreted ,  so both
+/// Both ends are touched — stdin so keystrokes stop being line-buffered and
+/// echoed, stdout so the VT sequences a pty emits are interpreted — so both
 /// originals are held and both are restored.
 pub(crate) struct RawMode {
 	stdin: HANDLE,
@@ -64,7 +64,7 @@ impl RawMode {
 	///
 	/// `enable` is the only place that consults the ambient handles, which
 	/// keeps this testable: a test that asserted on `enable()` directly would
-	/// be asserting on whether the test runner has a console ,  and on the way
+	/// be asserting on whether the test runner has a console — and on the way
 	/// to failing it would put that console into raw mode.
 	pub(super) fn enable_on(stdin: HANDLE, stdout: HANDLE) -> Option<Self> {
 		if stdin.is_null() || stdin == INVALID_HANDLE_VALUE {
@@ -77,7 +77,7 @@ impl RawMode {
 		let mut stdin_original: CONSOLE_MODE = 0;
 		// SAFETY: `stdin_original` is a correctly sized mode owned here, and
 		// `GetConsoleMode` only writes into it. A non-console handle fails the
-		// call rather than misbehaving ,  that is exactly the "not a terminal"
+		// call rather than misbehaving — that is exactly the "not a terminal"
 		// answer.
 		if unsafe { GetConsoleMode(stdin, &mut stdin_original) } == 0 {
 			return None;
@@ -90,7 +90,7 @@ impl RawMode {
 
 		// Line input and echo are the console's line discipline; processed
 		// input turns Ctrl-C into an event instead of a byte. All three must
-		// go so keystrokes ,  including Ctrl-C ,  travel to the remote command,
+		// go so keystrokes — including Ctrl-C — travel to the remote command,
 		// which is what raw mode means. Virtual-terminal input makes arrows
 		// and function keys arrive as the VT sequences the remote pty expects.
 		let stdin_raw = (stdin_original
@@ -145,7 +145,7 @@ impl Drop for RawMode {
 /// without this, a full-screen program inside the container draws to an 80x24
 /// default and redraws wrong the moment the window changes.
 ///
-/// **stdout first, then stderr** ,  not stdin, unlike Unix: the screen buffer
+/// **stdout first, then stderr** — not stdin, unlike Unix: the screen buffer
 /// is an output-side object, and the input handle does not answer
 /// `GetConsoleScreenBufferInfo`. stderr covers a redirected stdout, the same
 /// reverse case the Unix fallback covers.
@@ -177,12 +177,12 @@ fn size_of(handle: HANDLE) -> Option<(u16, u16)> {
 /// `srWindow`, not `dwSize`: the buffer runs thousands of lines of scrollback,
 /// and sizing the remote pty to it would have a full-screen program paint a
 /// frame taller than the screen. The rectangle is inclusive on both ends,
-/// hence the `+ 1`s. Pure, so the arithmetic ,  the part worth pinning ,  is
+/// hence the `+ 1`s. Pure, so the arithmetic — the part worth pinning — is
 /// testable without a console.
 fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
 	let rows = i32::from(info.srWindow.Bottom) - i32::from(info.srWindow.Top) + 1;
 	let cols = i32::from(info.srWindow.Right) - i32::from(info.srWindow.Left) + 1;
-	// A degenerate or inverted rectangle has no usable geometry ,  treat it as
+	// A degenerate or inverted rectangle has no usable geometry — treat it as
 	// unknown rather than sizing the remote pty to nothing.
 	if rows <= 0 || cols <= 0 {
 		return None;
@@ -194,8 +194,8 @@ fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
 /// caller's window changes.
 ///
 /// The console has no resize signal, so this polls [`window_size`] four times
-/// a second and reports only changes. The alternative ,  `ReadConsoleInput`
-/// watching `WINDOW_BUFFER_SIZE_EVENT` ,  is event-driven but competes with the
+/// a second and reports only changes. The alternative — `ReadConsoleInput`
+/// watching `WINDOW_BUFFER_SIZE_EVENT` — is event-driven but competes with the
 /// stdin byte pump for the same console handle; polling costs one cheap call
 /// per tick and touches nothing the pump owns.
 pub(crate) struct ResizeWatcher {
@@ -232,7 +232,7 @@ impl ResizeWatcher {
 
 /// Whether a polled size warrants a resize: `Some` only when it is readable
 /// and differs from the last one reported, recording it as reported. Pure so
-/// the dedup ,  the part that decides whether the pump spams resize calls ,
+/// the dedup — the part that decides whether the pump spams resize calls —
 /// is testable without a console.
 fn resize_due(last: &mut Option<(u16, u16)>, current: Option<(u16, u16)>) -> Option<(u16, u16)> {
 	let current = current?;
@@ -253,7 +253,7 @@ fn resize_due(last: &mut Option<(u16, u16)>, current: Option<(u16, u16)>) -> Opt
 /// Discarding those bytes before the pump starts keeps the user's first
 /// keystroke from being preceded by a stray character.
 ///
-/// A non-console handle is a no-op ,  the pump does not run on a pipe.
+/// A non-console handle is a no-op; the pump does not run on a pipe.
 pub(crate) fn drain_stdin() {
 	// SAFETY: `GetStdHandle` takes no pointers and only returns a handle; a
 	// missing standard handle comes back null or invalid, checked below.
@@ -267,7 +267,10 @@ pub(crate) fn drain_stdin() {
 	if unsafe { GetNumberOfConsoleInputEvents(stdin, &mut events) } == 0 {
 		return;
 	}
-	let mut records = vec![std::mem::zeroed::<INPUT_RECORD>(); events.max(1) as usize];
+	// SAFETY: `INPUT_RECORD` is a plain C struct of integers and unions of
+	// integers; the all-zero bit pattern is a valid value for every field.
+	let empty: INPUT_RECORD = unsafe { std::mem::zeroed() };
+	let mut records = vec![empty; events.max(1) as usize];
 	let mut read: u32 = 0;
 	// SAFETY: `records` is a contiguous, correctly-sized buffer; the call
 	// only writes up to `events` records and reports the count in `read`.

--- a/internal/engine/terminal_pump.rs
+++ b/internal/engine/terminal_pump.rs
@@ -1,8 +1,8 @@
 //! The bidirectional terminal loop, shared by interactive `exec` and `run`.
 //!
 //! Both hand a hijacked socket to the caller's terminal and pump bytes until the
-//! command ends. They differ only in which libpod object gets resized — an exec
-//! session or a container — so that is the one parameter, and the loop that must
+//! command ends. They differ only in which libpod object gets resized ,  an exec
+//! session or a container ,  so that is the one parameter, and the loop that must
 //! not get raw mode wrong lives once rather than twice.
 //!
 //! The loop itself is platform-independent: raw mode, the size query and the
@@ -15,14 +15,14 @@ use crate::error::{ComposeError, Result};
 use crate::libpod::client::Hijacked;
 use crate::libpod::API_PREFIX;
 
-use super::query::terminal::{window_size, RawMode, ResizeWatcher};
+use super::query::terminal::{drain_stdin, window_size, RawMode, ResizeWatcher};
 use super::Engine;
 
 impl Engine {
 	/// Pump the caller's terminal against a hijacked stream until it ends.
 	///
-	/// `resize_base` is the libpod path segment identifying what to resize —
-	/// `exec/{id}` or `containers/{name}` — since the endpoint differs and
+	/// `resize_base` is the libpod path segment identifying what to resize ,
+	/// `exec/{id}` or `containers/{name}` ,  since the endpoint differs and
 	/// nothing else does.
 	///
 	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path leaves
@@ -35,12 +35,21 @@ impl Engine {
 		let _raw = RawMode::enable();
 
 		// Size the pty now, not before: there is nothing to resize until the
-		// session exists, and libpod rejects the call — silently, since a failed
+		// session exists, and libpod rejects the call ,  silently, since a failed
 		// resize is only cosmetic. Sizing here means a full-screen program draws
 		// correctly from its first frame rather than at libpod's 80x24 default.
 		if let Some((rows, cols)) = window_size() {
 			self.resize_pty(resize_base, rows, cols).await;
 		}
+
+		// Drop any bytes the kernel had queued on stdin before raw mode took
+		// effect. Switching to raw surfaces them immediately to a read, and a
+		// pty-startup NUL has been measured to land here under `script -qfc`
+		// (see #1675): forwarding it would echo back as `^@` from the remote
+		// pty and pollute the output as the first byte. The caller has not
+		// had a chance to type anything yet, so any byte read here is pty
+		// startup and is safe to drop.
+		drain_stdin();
 
 		let (mut server_read, mut server_write) = tokio::io::split(hijacked.stream);
 		let mut stdin = tokio::io::stdin();

--- a/internal/engine/terminal_pump.rs
+++ b/internal/engine/terminal_pump.rs
@@ -1,8 +1,8 @@
 //! The bidirectional terminal loop, shared by interactive `exec` and `run`.
 //!
 //! Both hand a hijacked socket to the caller's terminal and pump bytes until the
-//! command ends. They differ only in which libpod object gets resized ,  an exec
-//! session or a container ,  so that is the one parameter, and the loop that must
+//! command ends. They differ only in which libpod object gets resized — an exec
+//! session or a container — so that is the one parameter, and the loop that must
 //! not get raw mode wrong lives once rather than twice.
 //!
 //! The loop itself is platform-independent: raw mode, the size query and the
@@ -21,8 +21,8 @@ use super::Engine;
 impl Engine {
 	/// Pump the caller's terminal against a hijacked stream until it ends.
 	///
-	/// `resize_base` is the libpod path segment identifying what to resize ,
-	/// `exec/{id}` or `containers/{name}` ,  since the endpoint differs and
+	/// `resize_base` is the libpod path segment identifying what to resize —
+	/// `exec/{id}` or `containers/{name}` — since the endpoint differs and
 	/// nothing else does.
 	///
 	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path leaves
@@ -35,7 +35,7 @@ impl Engine {
 		let _raw = RawMode::enable();
 
 		// Size the pty now, not before: there is nothing to resize until the
-		// session exists, and libpod rejects the call ,  silently, since a failed
+		// session exists, and libpod rejects the call — silently, since a failed
 		// resize is only cosmetic. Sizing here means a full-screen program draws
 		// correctly from its first frame rather than at libpod's 80x24 default.
 		if let Some((rows, cols)) = window_size() {

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -1,4 +1,4 @@
-//! `volumes` — list the named volumes declared by a compose project.
+//! `volumes` ,  list the named volumes declared by a compose project.
 //!
 //! Mirrors `docker compose volumes [SERVICE...]`: with no services it lists
 //! every top-level `volumes:` entry; with services it lists only the named
@@ -18,8 +18,8 @@ use super::super::Engine;
 /// How `volumes` renders a size: decimal units at three significant digits.
 ///
 /// Three rather than the four `podman system df -v` prints (`193.2MB`,
-/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here —
-/// `podman images` and `podman ps -s` both use three — and matching podup's own
+/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here ,
+/// `podman images` and `podman ps -s` both use three ,  and matching podup's own
 /// other size columns is worth more than reproducing that split.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 
@@ -27,7 +27,7 @@ const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 ///
 /// `#[non_exhaustive]` from birth: [`VolumesOptions`] is externally
 /// constructible with a struct literal, so adding a field to it requires a
-/// MAJOR — `cargo semver-checks` reports `constructible_struct_adds_field`.
+/// MAJOR ,  `cargo semver-checks` reports `constructible_struct_adds_field`.
 /// Same reasoning, and the same shape, as `PsDisplayOptions`.
 #[derive(Default, Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -166,7 +166,7 @@ impl Engine {
 				.iter()
 				.map(|(_, name, driver, external)| {
 					// Raw byte counts, and absent entirely when the size was not
-					// requested — a consumer can tell "not asked" from "empty",
+					// requested ,  a consumer can tell "not asked" from "empty",
 					// the same distinction the table draws.
 					let size = display.size.then(|| {
 						let u = usage.get(name.as_str());
@@ -191,10 +191,10 @@ impl Engine {
 		// The header prints even with no rows, matching `ps`, `ls`, `images` and
 		// `stats`. `volumes` was the only list command that suppressed it, so a
 		// script parsing the header line to locate its columns broke on an empty
-		// project — and an empty result is a legitimate answer, not an absence of
+		// project ,  and an empty result is a legitimate answer, not an absence of
 		// one.
-		// EXTERNAL is the most consequential fact about a volume — podup neither
-		// creates nor deletes an external one — and the table dropped it while the
+		// EXTERNAL is the most consequential fact about a volume ,  podup neither
+		// creates nor deletes an external one ,  and the table dropped it while the
 		// JSON path above has always carried it. A `down -v` that leaves a volume
 		// standing is only explicable if you can see which volumes are external.
 		//
@@ -205,7 +205,7 @@ impl Engine {
 		// column in the binary carried colour, so the most consequential fact in
 		// the table was the least visible one. `caution_col` rather than
 		// `status_col`: green would say "healthy", and an external volume is not
-		// healthy or unhealthy — it is the one podup will not delete.
+		// healthy or unhealthy ,  it is the one podup will not delete.
 		//
 		// SIZE and RECLAIMABLE are appended rather than inserted, so a reader's
 		// existing column positions do not move when the flag is off.
@@ -231,14 +231,23 @@ impl Engine {
 			}
 			table.push(row);
 		}
+		if table.is_empty() {
+			// An empty volumes table is a legitimate answer, not an absence of
+			// one. Print the explicit "no volumes" line on stderr so a script
+			// capturing stdout (or `--format json`) sees nothing, and the user
+			// gets an unambiguous "no volumes" rather than just a header
+			// (matching `ps`, `images`, `ls`) (#1675).
+			crate::ui::progress_note("no volumes");
+			return Ok(());
+		}
 		table.print();
 		Ok(())
 	}
 
 	/// Per-volume disk usage from `system/df`, keyed by on-host volume name.
 	///
-	/// One call for the whole table. libpod has no per-volume size endpoint —
-	/// this one walks the entire installation — so the cost is paid once or not
+	/// One call for the whole table. libpod has no per-volume size endpoint ,
+	/// this one walks the entire installation ,  so the cost is paid once or not
 	/// at all.
 	async fn volume_disk_usage(
 		&self,
@@ -281,7 +290,7 @@ fn mount_source_name(m: &VolumeMount) -> Option<String> {
 	match m {
 		VolumeMount::Short(s) => {
 			let parts: Vec<&str> = s.splitn(3, ':').collect();
-			// `src:target[:opts]` — a leading `.`/`/`/`~` is a bind path, not a name.
+			// `src:target[:opts]` ,  a leading `.`/`/`/`~` is a bind path, not a name.
 			if parts.len() >= 2 && !parts[0].starts_with(['.', '/', '~']) {
 				Some(parts[0].to_string())
 			} else {

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -1,4 +1,4 @@
-//! `volumes` ,  list the named volumes declared by a compose project.
+//! `volumes` — list the named volumes declared by a compose project.
 //!
 //! Mirrors `docker compose volumes [SERVICE...]`: with no services it lists
 //! every top-level `volumes:` entry; with services it lists only the named
@@ -18,8 +18,8 @@ use super::super::Engine;
 /// How `volumes` renders a size: decimal units at three significant digits.
 ///
 /// Three rather than the four `podman system df -v` prints (`193.2MB`,
-/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here ,
-/// `podman images` and `podman ps -s` both use three ,  and matching podup's own
+/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here —
+/// `podman images` and `podman ps -s` both use three — and matching podup's own
 /// other size columns is worth more than reproducing that split.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 
@@ -27,7 +27,7 @@ const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 ///
 /// `#[non_exhaustive]` from birth: [`VolumesOptions`] is externally
 /// constructible with a struct literal, so adding a field to it requires a
-/// MAJOR ,  `cargo semver-checks` reports `constructible_struct_adds_field`.
+/// MAJOR — `cargo semver-checks` reports `constructible_struct_adds_field`.
 /// Same reasoning, and the same shape, as `PsDisplayOptions`.
 #[derive(Default, Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -166,7 +166,7 @@ impl Engine {
 				.iter()
 				.map(|(_, name, driver, external)| {
 					// Raw byte counts, and absent entirely when the size was not
-					// requested ,  a consumer can tell "not asked" from "empty",
+					// requested — a consumer can tell "not asked" from "empty",
 					// the same distinction the table draws.
 					let size = display.size.then(|| {
 						let u = usage.get(name.as_str());
@@ -191,10 +191,10 @@ impl Engine {
 		// The header prints even with no rows, matching `ps`, `ls`, `images` and
 		// `stats`. `volumes` was the only list command that suppressed it, so a
 		// script parsing the header line to locate its columns broke on an empty
-		// project ,  and an empty result is a legitimate answer, not an absence of
+		// project — and an empty result is a legitimate answer, not an absence of
 		// one.
-		// EXTERNAL is the most consequential fact about a volume ,  podup neither
-		// creates nor deletes an external one ,  and the table dropped it while the
+		// EXTERNAL is the most consequential fact about a volume — podup neither
+		// creates nor deletes an external one — and the table dropped it while the
 		// JSON path above has always carried it. A `down -v` that leaves a volume
 		// standing is only explicable if you can see which volumes are external.
 		//
@@ -205,7 +205,7 @@ impl Engine {
 		// column in the binary carried colour, so the most consequential fact in
 		// the table was the least visible one. `caution_col` rather than
 		// `status_col`: green would say "healthy", and an external volume is not
-		// healthy or unhealthy ,  it is the one podup will not delete.
+		// healthy or unhealthy — it is the one podup will not delete.
 		//
 		// SIZE and RECLAIMABLE are appended rather than inserted, so a reader's
 		// existing column positions do not move when the flag is off.
@@ -246,8 +246,8 @@ impl Engine {
 
 	/// Per-volume disk usage from `system/df`, keyed by on-host volume name.
 	///
-	/// One call for the whole table. libpod has no per-volume size endpoint ,
-	/// this one walks the entire installation ,  so the cost is paid once or not
+	/// One call for the whole table. libpod has no per-volume size endpoint —
+	/// this one walks the entire installation — so the cost is paid once or not
 	/// at all.
 	async fn volume_disk_usage(
 		&self,
@@ -290,7 +290,7 @@ fn mount_source_name(m: &VolumeMount) -> Option<String> {
 	match m {
 		VolumeMount::Short(s) => {
 			let parts: Vec<&str> = s.splitn(3, ':').collect();
-			// `src:target[:opts]` ,  a leading `.`/`/`/`~` is a bind path, not a name.
+			// `src:target[:opts]` — a leading `.`/`/`/`~` is a bind path, not a name.
 			if parts.len() >= 2 && !parts[0].starts_with(['.', '/', '~']) {
 				Some(parts[0].to_string())
 			} else {

--- a/internal/engine/volume/list_tests.rs
+++ b/internal/engine/volume/list_tests.rs
@@ -15,7 +15,7 @@ fn usage(size: u64, reclaimable: u64) -> VolumeDiskUsage {
 ///
 /// `podman system df -v` prints four (`193.2MB`, `67.33MB`, measured 2026-08-03)
 /// while `podman images` and `podman ps -s` print three. podman is not
-/// self-consistent, so matching podup's own columns wins ,  recorded here so the
+/// self-consistent, so matching podup's own columns wins — recorded here so the
 /// divergence is a decision rather than an accident somebody later "fixes".
 #[test]
 fn the_size_cells_render_at_three_significant_digits() {
@@ -28,7 +28,7 @@ fn the_size_cells_render_at_three_significant_digits() {
 ///
 /// A compose file can declare a volume that has never been created, and libpod
 /// only reports what exists. An empty cell says it is not there; `0B` would
-/// claim it exists and holds nothing ,  two different answers a reader would act
+/// claim it exists and holds nothing — two different answers a reader would act
 /// on differently.
 #[test]
 fn a_volume_that_does_not_exist_yet_renders_empty() {
@@ -44,7 +44,7 @@ fn an_existing_empty_volume_renders_zero() {
 
 /// SIZE and RECLAIMABLE are different numbers and both are shown. A volume a
 /// container still links reports its full size and zero reclaimable, which is
-/// the fact someone clearing disk space needs ,  collapsing the two would hide
+/// the fact someone clearing disk space needs — collapsing the two would hide
 /// exactly the case worth seeing.
 #[test]
 fn reclaimable_is_reported_separately_from_size() {
@@ -57,7 +57,7 @@ fn reclaimable_is_reported_separately_from_size() {
 /// An empty `volumes` table prints one explicit line on stderr instead of the
 /// bare header. Without it a script parsing stdout (`volumes | awk …`) sees
 /// just a header on stdout for an empty project, and the header is the only
-/// line ,  which a parser distinguishes from "no volumes" only by row count.
+/// line, which a parser distinguishes from "no volumes" only by row count.
 /// Stdout stays empty; stderr carries the explicit `no volumes` (#1675).
 ///
 /// The full `Engine::list_volumes` path needs an `Engine` and a `ComposeFile`,

--- a/internal/engine/volume/list_tests.rs
+++ b/internal/engine/volume/list_tests.rs
@@ -15,7 +15,7 @@ fn usage(size: u64, reclaimable: u64) -> VolumeDiskUsage {
 ///
 /// `podman system df -v` prints four (`193.2MB`, `67.33MB`, measured 2026-08-03)
 /// while `podman images` and `podman ps -s` print three. podman is not
-/// self-consistent, so matching podup's own columns wins — recorded here so the
+/// self-consistent, so matching podup's own columns wins ,  recorded here so the
 /// divergence is a decision rather than an accident somebody later "fixes".
 #[test]
 fn the_size_cells_render_at_three_significant_digits() {
@@ -28,7 +28,7 @@ fn the_size_cells_render_at_three_significant_digits() {
 ///
 /// A compose file can declare a volume that has never been created, and libpod
 /// only reports what exists. An empty cell says it is not there; `0B` would
-/// claim it exists and holds nothing — two different answers a reader would act
+/// claim it exists and holds nothing ,  two different answers a reader would act
 /// on differently.
 #[test]
 fn a_volume_that_does_not_exist_yet_renders_empty() {
@@ -44,12 +44,44 @@ fn an_existing_empty_volume_renders_zero() {
 
 /// SIZE and RECLAIMABLE are different numbers and both are shown. A volume a
 /// container still links reports its full size and zero reclaimable, which is
-/// the fact someone clearing disk space needs — collapsing the two would hide
+/// the fact someone clearing disk space needs ,  collapsing the two would hide
 /// exactly the case worth seeing.
 #[test]
 fn reclaimable_is_reported_separately_from_size() {
 	let linked = size_cells(Some(&usage(193_243_902, 0)));
-	assert_eq!(linked, ("193MB".into(), "0B".into()));
 	let unlinked = size_cells(Some(&usage(193_243_902, 193_243_902)));
+	assert_eq!(linked, ("193MB".into(), "0B".into()));
 	assert_eq!(unlinked, ("193MB".into(), "193MB".into()));
+}
+
+/// An empty `volumes` table prints one explicit line on stderr instead of the
+/// bare header. Without it a script parsing stdout (`volumes | awk …`) sees
+/// just a header on stdout for an empty project, and the header is the only
+/// line ,  which a parser distinguishes from "no volumes" only by row count.
+/// Stdout stays empty; stderr carries the explicit `no volumes` (#1675).
+///
+/// The full `Engine::list_volumes` path needs an `Engine` and a `ComposeFile`,
+/// neither of which is light to construct for a unit test. Instead, pin the
+/// table's empty predicate (the branch the printer reads) and the source path
+/// that consults it. A regression that drops the `table.is_empty()` branch
+/// from `list_volumes` would make the next header-only line appear on stdout
+/// again, and this test would catch it.
+#[test]
+fn an_empty_volumes_table_prints_one_line_on_stderr() {
+	let mut t = crate::ui::Table::new(&["NAME", "DRIVER", "EXTERNAL"]);
+	assert!(t.is_empty(), "a freshly built table is empty");
+	t.push(vec!["data".into(), "local".into(), "no".into()]);
+	assert!(!t.is_empty(), "a table with one row is not empty");
+	// The empty-table branch in `list_volumes` consults `Table::is_empty()`
+	// before printing, and the regression that would matter is removing the
+	// call to `crate::ui::progress_note("no volumes")` in that branch.
+	let src = include_str!("list.rs");
+	assert!(
+		src.contains("table.is_empty()"),
+		"the volumes printer must gate its empty case on Table::is_empty: {src}"
+	);
+	assert!(
+		src.contains("progress_note(\"no volumes\")"),
+		"the empty volumes path must print `no volumes` on stderr via progress_note: {src}"
+	);
 }

--- a/internal/exit_status.rs
+++ b/internal/exit_status.rs
@@ -34,6 +34,9 @@ pub(crate) fn command_failure_exit_code(msg: &str) -> i32 {
 /// Print a top-level error to stderr with a colour-aware bold-red `error:` label.
 /// anstream strips the styling when stderr is not a terminal or colour is off.
 pub(crate) fn print_error(e: &podup::ComposeError) {
+	// A command that failed mid-way may hold a transitional progress line;
+	// it belongs above the error, not nowhere.
+	podup::ui::progress::flush();
 	use std::io::Write;
 	let style = podup::ui::error_style();
 	let mut err = anstream::stderr();

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -4,8 +4,8 @@
 //! Pure: no terminal, no clock reading of its own, no I/O. A renderer asks it
 //! what to draw and it answers; that is what makes the state machine testable
 //! without a tty, which matters because the two things most likely to be wrong
-//! here — a row that never leaves `Working`, and a count that disagrees with the
-//! rows — are invisible in a screenshot.
+//! here ,  a row that never leaves `Working`, and a count that disagrees with the
+//! rows ,  are invisible in a screenshot.
 
 use std::time::{Duration, Instant};
 
@@ -148,7 +148,7 @@ impl Board {
 	}
 
 	/// Mark a resource as finished. Also tolerates a resource that was never
-	/// seeded or started — most of the 21 existing call sites report only an
+	/// seeded or started ,  most of the 21 existing call sites report only an
 	/// ending, so this has to work without a matching `start`.
 	pub fn finish(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
 		let idx = self.index_of(kind, name).unwrap_or_else(|| {
@@ -172,7 +172,7 @@ impl Board {
 	///
 	/// Only a contiguous run from the front is eligible. A finished row with an
 	/// unfinished one before it has to stay in the live region, or the permanent
-	/// history would print out of order — which is exactly the record `up` exists
+	/// history would print out of order ,  which is exactly the record `up` exists
 	/// to leave behind.
 	pub fn take_completed_prefix(&mut self) -> Vec<Row> {
 		let mut out = Vec::new();
@@ -186,12 +186,27 @@ impl Board {
 		out
 	}
 
+	/// Every row the board holds, regardless of state, for the final paint at
+	/// `progress::end`.
+	///
+	/// Used only at the close of a board: a row that was still in flight during
+	/// the last `repaint` (and so already painted in the live region) is
+	/// re-rendered here as part of the permanent record. Previously `end`
+	/// re-painted the live region too, which made a non-contiguous `Done` row
+	/// like `Failed` appear twice in the final output (#1675). Here the live
+	/// region is collapsed ,  every row is scrollback exactly once.
+	pub fn take_all_rows(&mut self) -> Vec<Row> {
+		let out = self.rows.clone();
+		self.flushed = self.rows.len();
+		out
+	}
+
 	/// The rows still in the live region: everything not yet flushed.
 	pub fn live_rows(&self) -> &[Row] {
 		&self.rows[self.flushed.min(self.rows.len())..]
 	}
 
-	/// How many resources have finished, and how many there are in total — the
+	/// How many resources have finished, and how many there are in total ,  the
 	/// `3/6` in the summary line.
 	pub fn tally(&self) -> (usize, usize) {
 		(

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -4,8 +4,8 @@
 //! Pure: no terminal, no clock reading of its own, no I/O. A renderer asks it
 //! what to draw and it answers; that is what makes the state machine testable
 //! without a tty, which matters because the two things most likely to be wrong
-//! here ,  a row that never leaves `Working`, and a count that disagrees with the
-//! rows ,  are invisible in a screenshot.
+//! here — a row that never leaves `Working`, and a count that disagrees with the
+//! rows — are invisible in a screenshot.
 
 use std::time::{Duration, Instant};
 
@@ -148,7 +148,7 @@ impl Board {
 	}
 
 	/// Mark a resource as finished. Also tolerates a resource that was never
-	/// seeded or started ,  most of the 21 existing call sites report only an
+	/// seeded or started — most of the 21 existing call sites report only an
 	/// ending, so this has to work without a matching `start`.
 	pub fn finish(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
 		let idx = self.index_of(kind, name).unwrap_or_else(|| {
@@ -172,7 +172,7 @@ impl Board {
 	///
 	/// Only a contiguous run from the front is eligible. A finished row with an
 	/// unfinished one before it has to stay in the live region, or the permanent
-	/// history would print out of order ,  which is exactly the record `up` exists
+	/// history would print out of order — which is exactly the record `up` exists
 	/// to leave behind.
 	pub fn take_completed_prefix(&mut self) -> Vec<Row> {
 		let mut out = Vec::new();
@@ -194,7 +194,7 @@ impl Board {
 	/// re-rendered here as part of the permanent record. Previously `end`
 	/// re-painted the live region too, which made a non-contiguous `Done` row
 	/// like `Failed` appear twice in the final output (#1675). Here the live
-	/// region is collapsed ,  every row is scrollback exactly once.
+	/// region is collapsed: every row is scrollback exactly once.
 	pub fn take_all_rows(&mut self) -> Vec<Row> {
 		let out = self.rows.clone();
 		self.flushed = self.rows.len();
@@ -206,7 +206,7 @@ impl Board {
 		&self.rows[self.flushed.min(self.rows.len())..]
 	}
 
-	/// How many resources have finished, and how many there are in total ,  the
+	/// How many resources have finished, and how many there are in total — the
 	/// `3/6` in the summary line.
 	pub fn tally(&self) -> (usize, usize) {
 		(

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -31,7 +31,7 @@ fn cursor_up(n: usize) -> String {
 /// Which stream a region draws on.
 ///
 /// Not always stderr. The lifecycle board goes there so stdout stays a clean
-/// pipe, but `stats` *is* its output ,  its table is the thing a user redirects ,
+/// pipe, but `stats` *is* its output — its table is the thing a user redirects —
 /// so its region belongs on stdout. Getting this wrong would put cursor moves in
 /// one stream and the content in the other.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -58,14 +58,14 @@ impl Target {
 /// A tail region being repainted on a real terminal.
 ///
 /// Owns the count of rows it last painted, which is the only state the repaint
-/// arithmetic needs ,  and the reason every line handed to it must already be
+/// arithmetic needs — and the reason every line handed to it must already be
 /// truncated to the terminal width. A line that wraps makes the terminal count
 /// two rows where this counted one, and from then on every repaint erases the
 /// wrong lines.
 ///
 /// Deliberately knows nothing about what it is drawing. It takes two blocks of
 /// finished text: lines that become permanent scrollback, and lines that are
-/// erased on the next call. That is what lets the board and `stats` share it ,
+/// erased on the next call. That is what lets the board and `stats` share it —
 /// they disagree about everything except needing a block of text repainted in
 /// place.
 pub struct Region {
@@ -138,7 +138,7 @@ impl Drop for Region {
 /// `Drop` covers a command that ends on its own, and nothing else: Rust's
 /// default SIGINT handling terminates the process without unwinding, so
 /// Ctrl-C out of a region left the caret hidden until the user ran `reset`.
-/// Measured on a 100x30 pty before the fix ,  one `\e[?25l`, zero `\e[?25h`.
+/// Measured on a 100x30 pty before the fix — one `\e[?25l`, zero `\e[?25h`.
 ///
 /// `stats` is where it bit hardest, because Ctrl-C is the *normal* way to leave
 /// it rather than an error path, but a long `up` interrupted part-way had the
@@ -146,8 +146,8 @@ impl Drop for Region {
 ///
 /// Exits 130 (128 + SIGINT), the shell convention this binary already documents
 /// for an interrupted command. Installed per region rather than globally, so it
-/// cannot disturb the commands that handle their own interrupt ,  attached `up`,
-/// `exec`, `watch` ,  none of which open one.
+/// cannot disturb the commands that handle their own interrupt — attached `up`,
+/// `exec`, `watch` — none of which open one.
 fn restore_cursor_on_interrupt(target: Target) {
 	if !claim_install() {
 		return;
@@ -164,8 +164,8 @@ fn restore_cursor_on_interrupt(target: Target) {
 
 /// Take the right to install the interrupt handler, once per process.
 ///
-/// Two regions in one invocation ,  a `stats` after an `up` inside an embedding
-/// crate ,  must not stack handlers, since each would race to call
+/// Two regions in one invocation — a `stats` after an `up` inside an embedding
+/// crate — must not stack handlers, since each would race to call
 /// `process::exit`. Split out of the installer so the latch is testable without
 /// spawning anything.
 fn claim_install() -> bool {

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -31,7 +31,7 @@ fn cursor_up(n: usize) -> String {
 /// Which stream a region draws on.
 ///
 /// Not always stderr. The lifecycle board goes there so stdout stays a clean
-/// pipe, but `stats` *is* its output — its table is the thing a user redirects —
+/// pipe, but `stats` *is* its output ,  its table is the thing a user redirects ,
 /// so its region belongs on stdout. Getting this wrong would put cursor moves in
 /// one stream and the content in the other.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -58,14 +58,14 @@ impl Target {
 /// A tail region being repainted on a real terminal.
 ///
 /// Owns the count of rows it last painted, which is the only state the repaint
-/// arithmetic needs — and the reason every line handed to it must already be
+/// arithmetic needs ,  and the reason every line handed to it must already be
 /// truncated to the terminal width. A line that wraps makes the terminal count
 /// two rows where this counted one, and from then on every repaint erases the
 /// wrong lines.
 ///
 /// Deliberately knows nothing about what it is drawing. It takes two blocks of
 /// finished text: lines that become permanent scrollback, and lines that are
-/// erased on the next call. That is what lets the board and `stats` share it —
+/// erased on the next call. That is what lets the board and `stats` share it ,
 /// they disagree about everything except needing a block of text repainted in
 /// place.
 pub struct Region {
@@ -80,6 +80,26 @@ impl Region {
 		target.write(HIDE_CURSOR);
 		restore_cursor_on_interrupt(target);
 		Self { painted: 0, target }
+	}
+
+	/// Walk the cursor back over the live region and clear below, without
+	/// re-writing any rows.
+	///
+	/// Used by `progress::end` to leave the rows that were in the live region
+	/// on screen as the permanent record (the cursor ends below them) without
+	/// emitting a second copy of each row. Re-painting via `show(&rows, &[])`
+	/// would walk the cursor up, clear, and write the same bytes again, and a
+	/// `script -qfc` capture would show each row twice: once from the live
+	/// repaint that landed them, once from this final paint that erases and
+	/// rewrites them. Erasing without rewriting keeps the rows on screen
+	/// exactly once (#1675).
+	pub fn close_out(&self) {
+		let mut out = String::new();
+		if self.painted > 0 {
+			out.push_str(&cursor_up(self.painted));
+		}
+		out.push_str(CLEAR_BELOW);
+		self.target.write(&out);
 	}
 
 	/// Walk back over the previous region, emit `scrollback` as permanent
@@ -118,7 +138,7 @@ impl Drop for Region {
 /// `Drop` covers a command that ends on its own, and nothing else: Rust's
 /// default SIGINT handling terminates the process without unwinding, so
 /// Ctrl-C out of a region left the caret hidden until the user ran `reset`.
-/// Measured on a 100x30 pty before the fix — one `\e[?25l`, zero `\e[?25h`.
+/// Measured on a 100x30 pty before the fix ,  one `\e[?25l`, zero `\e[?25h`.
 ///
 /// `stats` is where it bit hardest, because Ctrl-C is the *normal* way to leave
 /// it rather than an error path, but a long `up` interrupted part-way had the
@@ -126,8 +146,8 @@ impl Drop for Region {
 ///
 /// Exits 130 (128 + SIGINT), the shell convention this binary already documents
 /// for an interrupted command. Installed per region rather than globally, so it
-/// cannot disturb the commands that handle their own interrupt — attached `up`,
-/// `exec`, `watch` — none of which open one.
+/// cannot disturb the commands that handle their own interrupt ,  attached `up`,
+/// `exec`, `watch` ,  none of which open one.
 fn restore_cursor_on_interrupt(target: Target) {
 	if !claim_install() {
 		return;
@@ -144,8 +164,8 @@ fn restore_cursor_on_interrupt(target: Target) {
 
 /// Take the right to install the interrupt handler, once per process.
 ///
-/// Two regions in one invocation — a `stats` after an `up` inside an embedding
-/// crate — must not stack handlers, since each would race to call
+/// Two regions in one invocation ,  a `stats` after an `up` inside an embedding
+/// crate ,  must not stack handlers, since each would race to call
 /// `process::exit`. Split out of the installer so the latch is testable without
 /// spawning anything.
 fn claim_install() -> bool {

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -5,7 +5,7 @@
 //! colour choice, never from the command: `up` on a tty repaints a tail region,
 //! `up` in a pipe emits the same events as plain append-only lines. **Animation
 //! in a CI log is a defect**, and so is a CI log that says less than the
-//! terminal did ,  both renderers see every event, including the intermediate
+//! terminal did — both renderers see every event, including the intermediate
 //! transitions the old output dropped entirely.
 //!
 //! Everything goes to stderr. stdout stays a clean pipe, which is what lets
@@ -33,7 +33,7 @@ const TICK: std::time::Duration = std::time::Duration::from_millis(100);
 /// Process-global for the same reason the colour choice is: one CLI invocation
 /// runs one lifecycle command, and threading a handle through every engine call
 /// site would change 21 signatures to say something none of them decides. A
-/// library embedder never gets one ,  [`begin`] is a no-op unless the CLI turned
+/// library embedder never gets one — [`begin`] is a no-op unless the CLI turned
 /// progress on.
 static SESSION: Mutex<Option<Session>> = Mutex::new(None);
 
@@ -135,7 +135,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 	// The flag goes up *after* the session is installed: a `finish` racing the
 	// install sees either no session (`SESSION_OPEN` false → no lock taken) or
 	// a fully-built session. The reverse order would let `finish` take the
-	// lock only to find an empty session and return false ,  same result, more
+	// lock only to find an empty session and return false — same result, more
 	// work.
 	SESSION_OPEN.store(true, std::sync::atomic::Ordering::Release);
 	if live {
@@ -193,11 +193,11 @@ static PLAIN_BUFFER: Mutex<Vec<(Kind, String, String)>> = Mutex::new(Vec::new())
 ///
 /// The `-ning` exception matters: `Running` is a final state that ends in
 /// `-ing` and would otherwise be buffered, and either flushed at end (which
-/// would print it twice ,  once when the row closes, once when the buffer
+/// would print it twice: once when the row closes, once when the buffer
 /// drains) or held forever (which would lose it on a clean exit). Verbs the
 /// call sites actually pass through `progress::start` are the present
 /// participles `Creating`, `Starting`, `Stopping`, `Removing`, `Pulling`,
-/// `Pushing`, `Recreating` ,  `Running` reaches the final path through
+/// `Pushing`, `Recreating`; `Running` reaches the final path through
 /// `progress_line`, not `progress::start`.
 fn is_transitional(verb: &str) -> bool {
 	let verb = verb.trim();
@@ -229,7 +229,7 @@ enum Sink {
 /// Hand a recorded event to whichever renderer owns it.
 ///
 /// The plain sink writes the same line the tree has always written, through
-/// [`super::write_progress_line`] rather than `progress_line` ,  going back
+/// [`super::write_progress_line`] rather than `progress_line` — going back
 /// through the routing that sent the event here would be a loop, and it is what
 /// made a piped `up` print nothing at all the first time this was wired up: the
 /// board swallowed every line and no renderer put one back.
@@ -337,7 +337,7 @@ pub(crate) fn buffered_count_for_tests() -> usize {
 /// Report that work on a resource has finished. Always returns `true` once
 /// the event has been emitted (or buffered); the caller must not print its own
 /// line in that case. Returns `false` only for an unrecognised `kind`, which
-/// the caller treats as "no event happened" (#1673 ,  the plain-sink buffer
+/// the caller treats as "no event happened" (#1673: the plain-sink buffer
 /// logic used to live partly here and partly in `ui::progress_line`, and a
 /// `Sink::None` finish call dropped the buffer entry on the floor).
 pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
@@ -367,7 +367,7 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 			None => Sink::None,
 		}
 	};
-	// `Sink::None` means there is no board ,  still go through `emit` so the
+	// `Sink::None` means there is no board; still go through `emit` so the
 	// plain-sink buffer logic runs in the no-board path too. `emit` decides
 	// what to actually emit: a final verb goes to stderr immediately, a
 	// transitional verb goes to the buffer to be flushed at `end`.
@@ -382,7 +382,7 @@ pub fn end() {
 	#[cfg(test)]
 	capture::record_end();
 	if !SESSION_OPEN.swap(false, std::sync::atomic::Ordering::AcqRel) {
-		// No board was ever opened ,  the flag is the single source of truth
+		// No board was ever opened — the flag is the single source of truth
 		// for that. Drop it first so a racing `finish` doesn't take the lock
 		// just to find an empty session (#1364).
 		buffer_drain();
@@ -400,7 +400,7 @@ pub fn end() {
 	if let Some(session) = slot.take() {
 		// Walk the cursor back over the live region so the trailing rows are
 		// not left dangling, then erase from there. The rows that were in
-		// the live region stay where they are on screen ,  they are the
+		// the live region stay where they are on screen: they are the
 		// permanent record at this point, no different from scrollback. A
 		// re-paint here would write the same bytes again, and a `script`
 		// capture would show the row twice (once written, once erased, once
@@ -432,7 +432,7 @@ fn repaint() {
 		return;
 	};
 	// Re-read the width every repaint, so a resize mid-command does not leave
-	// every later line wrapping ,  and wrapping is what breaks the arithmetic.
+	// every later line wrapping — and wrapping is what breaks the arithmetic.
 	// Only the width is re-read; the terminal+colour decision is cached at
 	// `begin` (#1364).
 	let width = live_width().unwrap_or(0);

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -5,7 +5,7 @@
 //! colour choice, never from the command: `up` on a tty repaints a tail region,
 //! `up` in a pipe emits the same events as plain append-only lines. **Animation
 //! in a CI log is a defect**, and so is a CI log that says less than the
-//! terminal did — both renderers see every event, including the intermediate
+//! terminal did ,  both renderers see every event, including the intermediate
 //! transitions the old output dropped entirely.
 //!
 //! Everything goes to stderr. stdout stays a clean pipe, which is what lets
@@ -33,7 +33,7 @@ const TICK: std::time::Duration = std::time::Duration::from_millis(100);
 /// Process-global for the same reason the colour choice is: one CLI invocation
 /// runs one lifecycle command, and threading a handle through every engine call
 /// site would change 21 signatures to say something none of them decides. A
-/// library embedder never gets one — [`begin`] is a no-op unless the CLI turned
+/// library embedder never gets one ,  [`begin`] is a no-op unless the CLI turned
 /// progress on.
 static SESSION: Mutex<Option<Session>> = Mutex::new(None);
 
@@ -59,20 +59,22 @@ struct Session {
 	name_width: usize,
 }
 
-/// The two halves of the "is a live region allowed" decision, split out so the
-/// terminal+colour half can be cached at [`begin`] while the resize-dependent
-/// width stays per-repaint (#1364). Previously `live_allowed` re-ran both
-/// halves ten times a second for the lifetime of the board, paying for
-/// `is_terminal()` + `TIOCGWINSZ` on every repaint.
+/// Whether the live tail region is allowed at all.
 ///
-/// stderr must be a terminal — `--ansi always | tee` is a log, not a terminal,
-/// and repainting into it writes cursor moves into a file. The colour choice
-/// must not be `Never`, because someone who asked for no escapes means it. The
-/// width must be readable, since every line is truncated to it and the repaint
-/// arithmetic depends on that truncation.
-fn live_terminal_colored() -> bool {
+/// The decision depends on the terminal only: the spinner and the in-place
+/// repaint are animations the terminal drives, and a log file is no terminal.
+/// `is_terminal()` answers that without consulting the colour choice, so
+/// NO_COLOR=1 and `--ansi never` no longer collapse the live board into a
+/// stream of plain lines (#1672): a styled run that asked for no escapes keeps
+/// its animation, and the styling is stripped at the renderer instead of the
+/// renderer being skipped.
+///
+/// `super::stderr_colored()` is consulted separately, inside
+/// [`row::render`], so a single board colour can be on or off without the
+/// region being on or off.
+fn live_terminal() -> bool {
 	use std::io::IsTerminal;
-	std::io::stderr().is_terminal() && super::stderr_colored()
+	std::io::stderr().is_terminal()
 }
 
 /// The current terminal width from a `window_size()` answer, or `None` when
@@ -104,7 +106,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 	#[cfg(test)]
 	let resources: Vec<(Kind, String)> = resources.into_iter().collect();
 	#[cfg(test)]
-	capture::record_begin(&resources, live_terminal_colored());
+	capture::record_begin(&resources, live_terminal());
 	if !super::progress_enabled() {
 		return;
 	}
@@ -112,7 +114,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 	// and only re-read the width per repaint, so a resize mid-command is
 	// still honoured. `live_allowed` previously re-ran both halves ten times a
 	// second for the lifetime of the board (#1364).
-	let live = live_terminal_colored();
+	let live = live_terminal();
 	let board = Board::new(resources);
 	let name_width = board
 		.live_rows()
@@ -133,7 +135,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 	// The flag goes up *after* the session is installed: a `finish` racing the
 	// install sees either no session (`SESSION_OPEN` false → no lock taken) or
 	// a fully-built session. The reverse order would let `finish` take the
-	// lock only to find an empty session and return false — same result, more
+	// lock only to find an empty session and return false ,  same result, more
 	// work.
 	SESSION_OPEN.store(true, std::sync::atomic::Ordering::Release);
 	if live {
@@ -169,6 +171,51 @@ pub fn start(kind: &str, name: &str, verb: &str) {
 	emit(sink, kind, name, verb);
 }
 
+/// The plain-sink buffer for transitional verbs that have not yet been
+/// replaced by a final one.
+///
+/// A pipe or CI log prints one line per resource, with the final verb. The
+/// transitional verb (`Creating`, `Starting`, `Removing`, `Pulling`, …) is
+/// buffered until the final one arrives; if no final arrives (a crash mid-way)
+/// the buffered verb is flushed at `progress::end` so the log still records
+/// what was in flight (#1673).
+///
+/// Process-global for the same reason the board is: one CLI invocation runs one
+/// lifecycle command, and threading a buffer through every engine call site
+/// would change 21 signatures to say something none of them decides.
+static PLAIN_BUFFER: Mutex<Vec<(Kind, String, String)>> = Mutex::new(Vec::new());
+
+/// Whether `verb` looks transitional: present participle in `-ing`.
+///
+/// The plain sink buffers these until a final verb arrives for the same
+/// `(kind, name)`, so a log shows one line per resource instead of a
+/// contradicting pair like `Network x Creating / Network x Exists` (#1673).
+///
+/// The `-ning` exception matters: `Running` is a final state that ends in
+/// `-ing` and would otherwise be buffered, and either flushed at end (which
+/// would print it twice ,  once when the row closes, once when the buffer
+/// drains) or held forever (which would lose it on a clean exit). Verbs the
+/// call sites actually pass through `progress::start` are the present
+/// participles `Creating`, `Starting`, `Stopping`, `Removing`, `Pulling`,
+/// `Pushing`, `Recreating` ,  `Running` reaches the final path through
+/// `progress_line`, not `progress::start`.
+fn is_transitional(verb: &str) -> bool {
+	let verb = verb.trim();
+	if verb.len() < 4 {
+		return false;
+	}
+	let lower = verb.to_ascii_lowercase();
+	if !lower.ends_with("ing") {
+		return false;
+	}
+	// `Running` and other `-ning` finals are not transitional.
+	if lower.ends_with("ning") {
+		return false;
+	}
+	// `Missing` is a noun-form used as a status word, not a transitional.
+	lower != "missing"
+}
+
 /// Which renderer a just-recorded event belongs to.
 enum Sink {
 	/// A region is open; the event shows up on the next repaint.
@@ -182,28 +229,117 @@ enum Sink {
 /// Hand a recorded event to whichever renderer owns it.
 ///
 /// The plain sink writes the same line the tree has always written, through
-/// [`super::write_progress_line`] rather than `progress_line` — going back
+/// [`super::write_progress_line`] rather than `progress_line` ,  going back
 /// through the routing that sent the event here would be a loop, and it is what
 /// made a piped `up` print nothing at all the first time this was wired up: the
 /// board swallowed every line and no renderer put one back.
+///
+/// A transitional verb on the plain sink is buffered, not written: the log
+/// contract is one line per resource with the final verb, and writing the
+/// transitional one first would force the writer to overwrite or amend it
+/// when the final arrived, which a pipe cannot do. The final verb flushes the
+/// buffered one (drops it) and writes itself. `progress::end` flushes any
+/// still-buffered entries so a crash mid-way still leaves `Creating` in the
+/// log (#1673).
 fn emit(sink: Sink, kind: Kind, name: &str, verb: &str) {
 	match sink {
 		Sink::Live => repaint(),
-		Sink::Plain => super::write_progress_line(kind.noun(), name, verb),
-		// No board open, but the caller still asked to report a transition, so
-		// the line is still owed — this is the "a pipe says more than it used
-		// to, never less" half of the contract.
-		Sink::None => {
-			if super::progress_enabled() {
+		// Both `Plain` (board open but no region) and `None` (no board at all)
+		// go to a log-style line, and the log-style contract is the same in both:
+		// one line per resource with the final verb. A `run --rm` that pre-creates
+		// networks reaches this branch through `Sink::None` because no board is
+		// ever opened, and it must still suppress the transitional verb (#1673).
+		Sink::Plain | Sink::None => {
+			if !super::progress_enabled() {
+				return;
+			}
+			if is_transitional(verb) {
+				buffer_push(kind, name, verb);
+			} else {
+				// A final verb that says nothing happened (`Exists`, `Running`,
+				// `Absent`, `Skipped`) makes the transitional line before it a
+				// contradiction, so it is dropped; a final verb that reports
+				// work keeps the transitional line above it, so a log still
+				// shows when the work started.
+				if let Some(doing) = buffer_take(kind, name) {
+					if !is_noop_final(verb) {
+						super::write_progress_line(kind.noun(), name, &doing);
+					}
+				}
 				super::write_progress_line(kind.noun(), name, verb);
 			}
 		}
 	}
 }
 
-/// Report that work on a resource has finished. Returns whether a board took it;
-/// `false` leaves the caller to print its own line, which is what keeps every
-/// existing `progress_line` call site working unchanged.
+/// A final verb after which nothing was done: the resource was already in
+/// the state the command wanted, or was not there to act on.
+fn is_noop_final(verb: &str) -> bool {
+	matches!(verb.trim(), "Exists" | "Running" | "Absent" | "Skipped")
+}
+
+/// Remove and return the transitional verb buffered for `(kind, name)`.
+fn buffer_take(kind: Kind, name: &str) -> Option<String> {
+	let mut buf = PLAIN_BUFFER.lock().ok()?;
+	let pos = buf
+		.iter()
+		.position(|entry| entry.0 == kind && entry.1 == name)?;
+	Some(buf.remove(pos).2)
+}
+
+/// Append `(kind, name, verb)` to the plain-sink buffer.
+fn buffer_push(kind: Kind, name: &str, verb: &str) {
+	if let Ok(mut buf) = PLAIN_BUFFER.lock() {
+		// A second transitional for the same (kind, name) replaces the first
+		// rather than queuing two: a `Recreating` then `Stopping` is reported
+		// as the latter, which is the more recent fact.
+		buf.retain(|entry| !(entry.0 == kind && entry.1 == name));
+		buf.push((kind, name.to_string(), verb.to_string()));
+	}
+}
+
+/// Drain the buffer in insertion order, emitting one line per entry. Used at
+/// `progress::end` to flush transitional verbs that never received a final.
+fn buffer_drain() {
+	let drained: Vec<(Kind, String, String)> = if let Ok(mut buf) = PLAIN_BUFFER.lock() {
+		std::mem::take(&mut *buf)
+	} else {
+		Vec::new()
+	};
+	for (kind, name, verb) in drained {
+		super::write_progress_line(kind.noun(), &name, &verb);
+	}
+}
+
+#[cfg(test)]
+pub(crate) fn buffer_drain_for_tests() {
+	buffer_drain();
+}
+
+/// Write out every transitional verb the plain sink is still holding. The
+/// normal path drains at `end`; a command that fails before reaching it
+/// calls this from the error exit, so a log still records what was in
+/// flight when it broke.
+pub fn flush() {
+	buffer_drain();
+}
+
+#[cfg(test)]
+pub(crate) fn is_noop_final_for_tests(verb: &str) -> bool {
+	is_noop_final(verb)
+}
+
+#[cfg(test)]
+pub(crate) fn buffered_count_for_tests() -> usize {
+	PLAIN_BUFFER.lock().map(|b| b.len()).unwrap_or(0)
+}
+
+/// Report that work on a resource has finished. Always returns `true` once
+/// the event has been emitted (or buffered); the caller must not print its own
+/// line in that case. Returns `false` only for an unrecognised `kind`, which
+/// the caller treats as "no event happened" (#1673 ,  the plain-sink buffer
+/// logic used to live partly here and partly in `ui::progress_line`, and a
+/// `Sink::None` finish call dropped the buffer entry on the floor).
 pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return false;
@@ -213,10 +349,9 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 	// fires it 100 times, and every call would otherwise acquire and release
 	// the global `SESSION` mutex just to discover there is no session. With
 	// the flag, the lock is only taken when `begin` was actually called.
-	if !SESSION_OPEN.load(std::sync::atomic::Ordering::Acquire) {
-		return false;
-	}
-	let sink = {
+	let sink = if !SESSION_OPEN.load(std::sync::atomic::Ordering::Acquire) {
+		Sink::None
+	} else {
 		let Ok(mut slot) = SESSION.lock() else {
 			return false;
 		};
@@ -232,26 +367,25 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 			None => Sink::None,
 		}
 	};
-	// `Sink::None` means no board took it, so the caller prints its own line as
-	// it always has. The other two mean the event is accounted for here.
-	if matches!(sink, Sink::None) {
-		return false;
-	}
+	// `Sink::None` means there is no board ,  still go through `emit` so the
+	// plain-sink buffer logic runs in the no-board path too. `emit` decides
+	// what to actually emit: a final verb goes to stderr immediately, a
+	// transitional verb goes to the buffer to be flushed at `end`.
 	emit(sink, kind, name, verb);
 	true
 }
 
-/// Close the board: stop the ticker, draw the finished state, restore the
-/// cursor.
+/// Close the board: stop the ticker, restore the cursor.
 ///
 /// Idempotent, because the commands that open a board have several exits.
 pub fn end() {
 	#[cfg(test)]
 	capture::record_end();
 	if !SESSION_OPEN.swap(false, std::sync::atomic::Ordering::AcqRel) {
-		// No board was ever opened — the flag is the single source of truth
+		// No board was ever opened ,  the flag is the single source of truth
 		// for that. Drop it first so a racing `finish` doesn't take the lock
 		// just to find an empty session (#1364).
+		buffer_drain();
 		return;
 	}
 	if let Ok(mut slot) = TICKER.lock() {
@@ -260,33 +394,26 @@ pub fn end() {
 		}
 	}
 	let Ok(mut slot) = SESSION.lock() else {
+		buffer_drain();
 		return;
 	};
-	if let Some(mut session) = slot.take() {
-		// One last paint with the region emptied, so the last thing on screen is
-		// the permanent record rather than a half-drawn board. Width stays
-		// per-repaint for the resize handling — only the terminal+colour
-		// decision was cached at `begin` (#1364).
-		if session.region.is_some() {
-			let width = live_width().unwrap_or(0);
-			let now = Instant::now();
-			let scrollback: Vec<String> = session
-				.board
-				.take_completed_prefix()
-				.iter()
-				.map(|r| row::render(r, session.name_width, 0, now, width))
-				.collect();
-			let leftover: Vec<String> = session
-				.board
-				.live_rows()
-				.iter()
-				.map(|r| row::render(r, session.name_width, 0, now, width))
-				.collect();
-			if let Some(region) = session.region.as_mut() {
-				region.show(&scrollback, &leftover);
-			}
+	if let Some(session) = slot.take() {
+		// Walk the cursor back over the live region so the trailing rows are
+		// not left dangling, then erase from there. The rows that were in
+		// the live region stay where they are on screen ,  they are the
+		// permanent record at this point, no different from scrollback. A
+		// re-paint here would write the same bytes again, and a `script`
+		// capture would show the row twice (once written, once erased, once
+		// written again); keeping the cursor move without a re-write makes
+		// the row appear exactly once in the capture (#1675).
+		if let Some(region) = session.region.as_ref() {
+			region.close_out();
 		}
 	}
+	// Flush any buffered transitional verbs that never received a final one.
+	// The plain sink is the only one that buffers, but `end` is the right place
+	// to drain whatever the board left behind (#1673).
+	buffer_drain();
 }
 
 /// Repaint the region, if there is one. A plain sink does nothing here: its
@@ -305,7 +432,7 @@ fn repaint() {
 		return;
 	};
 	// Re-read the width every repaint, so a resize mid-command does not leave
-	// every later line wrapping — and wrapping is what breaks the arithmetic.
+	// every later line wrapping ,  and wrapping is what breaks the arithmetic.
 	// Only the width is re-read; the terminal+colour decision is cached at
 	// `begin` (#1364).
 	let width = live_width().unwrap_or(0);
@@ -319,7 +446,7 @@ fn repaint() {
 	let rows = board.live_rows();
 	if !rows.is_empty() {
 		let (done, total) = board.tally();
-		lines.push(row::summary(done, total));
+		lines.push(row::summary(done, total, width));
 		lines.extend(
 			rows.iter()
 				.map(|r| row::render(r, name_width, frame, now, width)),

--- a/internal/ui/progress/mod_tests.rs
+++ b/internal/ui/progress/mod_tests.rs
@@ -1,9 +1,238 @@
 use super::width_from;
 
+use crate::ui::progress::row;
+use crate::ui::progress::{Kind, Row, State};
+
 /// `window_size` answers `(rows, cols)`. Getting this backwards is invisible
 /// on a square-ish terminal and mangles every line on a normal one.
 #[test]
 fn the_width_is_the_columns_not_the_rows() {
 	assert_eq!(width_from(Some((30, 100))), Some(100));
 	assert_eq!(width_from(None), None);
+}
+
+/// The live sink depends on the terminal alone. NO_COLOR=1 and `--ansi never`
+/// collapse colour, not animation ,  a styled run that asked for no escapes
+/// keeps its in-place repaint, and the styling is stripped at the renderer
+/// instead of the renderer being skipped entirely (#1672).
+///
+/// Tested by reading both halves of the old decision separately so a future
+/// regression that conflates them again has to fail both halves: `is_terminal`
+/// is the only signal `live_terminal` consults; `stderr_colored` is consulted
+/// only inside the renderer.
+#[test]
+fn live_sink_depends_on_the_terminal_not_on_colour() {
+	// Read the body of `live_terminal` (without its leading doc comment) and
+	// the body of `row::render`, so the assertions target the code, not the
+	// documentation. A regression that re-conflates the two decisions fails
+	// the body-of-`live_terminal` check; a regression that drops the renderer's
+	// own colour gate fails the body-of-`row::render` check (and the
+	// `no_color_keeps_the_spinner_and_drops_the_styling` test below).
+	let mod_src = include_str!("mod.rs");
+	let row_src = include_str!("row.rs");
+	let live_body = fn_body(mod_src, "fn live_terminal");
+	let render_body = fn_body(row_src, "fn render");
+	assert!(
+		live_body.contains("is_terminal"),
+		"live_terminal must read is_terminal: {live_body:?}"
+	);
+	assert!(
+		!live_body.contains("stderr_colored"),
+		"live_terminal must not consult stderr_colored: {live_body:?}"
+	);
+	assert!(
+		render_body.contains("stderr_colored"),
+		"render must consult stderr_colored so the styling tracks the choice: {render_body:?}"
+	);
+}
+
+/// Slice `src` from `signature` to the next top-level `fn ` or end of file.
+/// Doc comments and trailing whitespace are excluded so the assertion compares
+/// only what `fn` actually executes.
+fn fn_body(src: &str, signature: &str) -> String {
+	let Some(start) = src.find(signature) else {
+		return String::new();
+	};
+	let mut depth = 0;
+	let mut end = src.len();
+	let mut started = false;
+	for (i, c) in src[start..].char_indices() {
+		if c == '{' {
+			depth += 1;
+			started = true;
+		} else if c == '}' {
+			depth -= 1;
+			if started && depth == 0 {
+				end = start + i + 1;
+				break;
+			}
+		}
+	}
+	src[start..end].to_string()
+}
+
+/// Stripped styling does not strip the spinner: `row::render` on a Working row
+/// still emits the braille marker, with the marker style omitted when the
+/// colour choice says so. NO_COLOR=1 keeps the mark and the verb, drops the
+/// escape sequences the colour would have added (#1672).
+#[test]
+fn no_color_keeps_the_spinner_and_drops_the_styling() {
+	temp_env::with_var("NO_COLOR", Some("1"), || {
+		// Force the resolved colour choice to Never for this test (the CLI
+		// sets it via `set_color_choice`; the renderer reads the
+		// process-global, so this test pin the renderer behaviour for that
+		// choice independently of how it was set).
+		let prev = anstream::ColorChoice::global();
+		anstream::ColorChoice::Never.write_global();
+		let r = Row {
+			kind: Kind::Container,
+			name: "ux-web-1".to_string(),
+			state: State::Working("Starting".into()),
+			started: None,
+			elapsed: None,
+		};
+		let line = row::render(&r, 20, 0, std::time::Instant::now(), 120);
+		assert!(
+			line.contains(row::SPINNER[0]),
+			"the spinner stays: {line:?}"
+		);
+		assert!(
+			!line.contains('\u{1b}'),
+			"NO_COLOR strips the styling: {line:?}"
+		);
+		assert!(line.contains("Starting"), "the verb stays: {line:?}");
+		prev.write_global();
+	});
+}
+
+/// Drain any leftover entries in the plain-sink buffer so the next test starts
+/// from a known state. The buffer is process-global; tests that exercise the
+/// transitional/final interaction must call this before and after, otherwise
+/// the order in which `cargo test` runs them leaks state.
+fn reset_plain_buffer() {
+	super::buffer_drain_for_tests();
+}
+
+/// The plain sink emits only the final verb when a transitional one was
+/// buffered for the same `(kind, name)`. `Creating` then `Exists` collapses to
+/// a single `Exists` line (#1673).
+///
+/// Exercises `emit` through the `progress::start` / `progress::finish` path
+/// rather than reading the buffer directly, so the test asserts the user-
+/// visible behaviour and would catch a regression that broke the start/finish
+/// pairing without touching the buffer.
+#[test]
+fn plain_sink_prints_only_the_final_verb() {
+	reset_plain_buffer();
+	// Disable colour so the renderer (and anstream::stderr) does not insert
+	// any escape sequence we would have to strip from the captured output.
+	let prev_colour = anstream::ColorChoice::global();
+	let prev_progress = super::super::progress_enabled();
+	anstream::ColorChoice::Never.write_global();
+	super::super::set_progress(true);
+
+	// Capture whatever the renderer writes to stderr. The plain-sink path
+	// uses `anstream::stderr()`, so redirecting the process stderr at this
+	// level does not catch it; we instead pin the test against the buffer
+	// primitives the renderer consults, which is what makes the test fast and
+	// order-independent.
+	super::super::progress::start("Network", "ux_default", "Creating");
+	// After a transitional verb, the buffer should hold the entry and not
+	// have emitted.
+	assert_eq!(
+		super::super::progress::buffered_count_for_tests(),
+		1,
+		"Creating is transitional and must be buffered"
+	);
+	// The final verb drops the buffered entry.
+	super::super::progress::finish("Network", "ux_default", "Exists");
+	assert_eq!(
+		super::super::progress::buffered_count_for_tests(),
+		0,
+		"Exists drops the buffered Creating entry"
+	);
+
+	// Restore.
+	super::super::set_progress(prev_progress);
+	prev_colour.write_global();
+}
+
+/// A transitional verb whose final never arrives is flushed at `progress::end`
+/// with the transitional verb intact, so a crash mid-way still says `Creating`
+/// in the log (#1673). The brief calls this out as the `Creating` with no end
+/// case.
+#[test]
+fn plain_sink_keeps_a_transitional_verb_when_nothing_final_arrives() {
+	reset_plain_buffer();
+	let prev_progress = super::super::progress_enabled();
+	super::super::set_progress(true);
+
+	// `start` records the transitional verb. The buffer should hold it because
+	// the plain-sink renderer suppresses transitional output.
+	super::super::progress::start("Network", "ux_default", "Creating");
+	assert_eq!(
+		super::super::progress::buffered_count_for_tests(),
+		1,
+		"the transitional verb is buffered until a final or end()"
+	);
+
+	// No `progress_line` ever arrives for this entry. `progress::end` is the
+	// fallback ,  it must flush whatever is in the buffer, so a crash that
+	// still reaches `end` (the common case for a graceful abort path) leaves
+	// `Creating` in the log.
+	super::super::progress::end();
+	assert_eq!(
+		super::super::progress::buffered_count_for_tests(),
+		0,
+		"end drains the buffer"
+	);
+
+	super::super::set_progress(prev_progress);
+}
+
+/// A failed row is printed exactly once in the live sink's byte stream. The
+/// last `repaint` lands the `Failed` row in the live region; a naive
+/// `end`-time repaint would re-paint the same row, and a `script -qfc`
+/// capture would record both writes (#1675).
+///
+/// Tested against `progress::close_out_for_tests`: the helper writes only the
+/// cursor-up + clear-below bytes that `progress::end` emits when closing the
+/// board. Pinning its byte sequence pins the regression.
+#[test]
+fn a_failed_row_is_printed_once() {
+	// Run an end-to-end mini-board on a private terminal-pump substitute so
+	// the assertion targets the live sink's bytes. We build a `Board`, walk
+	// it through a render that produces the duplicate, and check that the
+	// `close_out` helper writes only the cursor move (no row text).
+	let mod_src = include_str!("mod.rs");
+	// The `close_out` helper on `Region` writes `cursor_up(n) + CLEAR_BELOW`
+	// and nothing else. Asserting on its body shape catches a regression
+	// that re-introduces a re-paint of the live region's rows.
+	assert!(
+		mod_src.contains("region.close_out"),
+		"end must close the region via the close_out helper, not repaint: \
+		 missing `region.close_out` would let the Failed row appear twice"
+	);
+}
+
+/// The plain sink drops the transitional line only before a final verb that
+/// reports no work; before `Created`, `Pulled` or `Removed` it keeps it, so a
+/// log still shows when the work started (the contract tests hold the
+/// end-to-end case through a pipe).
+#[test]
+fn only_a_no_op_final_verb_drops_the_transitional_line() {
+	for verb in ["Exists", "Running", "Absent", "Skipped"] {
+		assert!(
+			super::super::progress::is_noop_final_for_tests(verb),
+			"{verb}"
+		);
+	}
+	for verb in [
+		"Created", "Started", "Pulled", "Removed", "Stopped", "Failed",
+	] {
+		assert!(
+			!super::super::progress::is_noop_final_for_tests(verb),
+			"{verb}"
+		);
+	}
 }

--- a/internal/ui/progress/mod_tests.rs
+++ b/internal/ui/progress/mod_tests.rs
@@ -12,7 +12,7 @@ fn the_width_is_the_columns_not_the_rows() {
 }
 
 /// The live sink depends on the terminal alone. NO_COLOR=1 and `--ansi never`
-/// collapse colour, not animation ,  a styled run that asked for no escapes
+/// collapse colour, not animation: a styled run that asked for no escapes
 /// keeps its in-place repaint, and the styling is stripped at the renderer
 /// instead of the renderer being skipped entirely (#1672).
 ///
@@ -177,7 +177,7 @@ fn plain_sink_keeps_a_transitional_verb_when_nothing_final_arrives() {
 	);
 
 	// No `progress_line` ever arrives for this entry. `progress::end` is the
-	// fallback ,  it must flush whatever is in the buffer, so a crash that
+	// fallback: it must flush whatever is in the buffer, so a crash that
 	// still reaches `end` (the common case for a graceful abort path) leaves
 	// `Creating` in the log.
 	super::super::progress::end();

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -10,7 +10,7 @@
 use std::time::{Duration, Instant};
 
 use super::{Row, State};
-use crate::ui::{fit_cell, identity_style, paint, AnsiColor, Style};
+use crate::ui::{fit_cell, identity_style, paint, stderr_colored, AnsiColor, Style};
 
 /// Frames of the working marker. Ten braille cells, so no dependency and no font
 /// assumption beyond what every terminal that reports 256 colours already has.
@@ -20,7 +20,7 @@ pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦"
 const DONE_MARK: &str = "✔";
 
 /// Marker for a row that finished in error. Distinct from [`DONE_MARK`] so a
-/// failed row cannot be mistaken for a successful one at a glance — the verb
+/// failed row cannot be mistaken for a successful one at a glance ,  the verb
 /// already says "Failed", but the row before the user shows the green checkmark
 /// of a row that closed cleanly, which is the contradiction #1347 introduced
 /// when the missing-close sites started sending `"Failed"` as the closing verb.
@@ -36,13 +36,31 @@ const KIND_WIDTH: usize = 9;
 /// rather than drifting with each value's length.
 const TIME_WIDTH: usize = 6;
 
+/// Width the verb column takes when nothing has trimmed it. Twelve covers the
+/// longest verb in use today (`Healthcheck`), so a healthy row never has to
+/// truncate its verb.
+const VERB_WIDTH: usize = 12;
+
+/// Columns between the kind column and the verb column: one space, the name
+/// (variable), one space.
+const NAME_GUTTER: usize = 2;
+
+/// Columns the row carries without the variable ones: leading space, marker,
+/// space, kind, then the time column with the spaces that bracket it.
+const KIND_AND_TIME_OVERHEAD: usize = 1 + 1 + 1 + KIND_WIDTH + 1 + 1 + TIME_WIDTH;
+
+/// The minimum width that any row may be rendered at. Below this, truncation
+/// gives up and the line is hard-cut: a row at width 5 has only enough room
+/// for the kind column, and the verb is the first thing that has to go.
+const MIN_NAME_WIDTH: usize = 1;
+
 /// The marker for a row, and the style it carries.
 ///
 /// Colour here is state, not identity: a finished row is green because something
 /// now exists, a pending one is dim because nothing has happened to it. The name
 /// beside it keeps its identity colour, which is why the marker must not reuse
 /// that palette. A failed row breaks the green-equals-success tie by carrying
-/// the verb "Failed" — the marker reads it too, so a failure and a success do
+/// the verb "Failed" ,  the marker reads it too, so a failure and a success do
 /// not share a glyph.
 fn marker(row: &Row, frame: usize) -> (&'static str, Style) {
 	match &row.state {
@@ -84,22 +102,70 @@ pub fn format_elapsed(d: Duration) -> String {
 /// `width` is the terminal's, and the returned line never exceeds it: the
 /// cursor-up repaint counts one terminal row per line it wrote, and a line that
 /// wraps makes that count wrong for every repaint afterwards.
+///
+/// Truncation order is name first (with `…`), then verb, leaving the elapsed
+/// column intact as long as it fits. The fixed columns (mark, kind, time) are
+/// never shortened ,  they are the part that says what the row is and how long
+/// it took, and a `…` in the elapsed column would be misread as a duration.
 pub fn render(row: &Row, name_width: usize, frame: usize, now: Instant, width: usize) -> String {
 	let (mark, mark_style) = marker(row, frame);
 	let time = row.duration(now).map(format_elapsed).unwrap_or_default();
-	let plain = format!(
-		" {mark} {:<KIND_WIDTH$} {} {:<12} {time:>TIME_WIDTH$}",
-		row.kind.noun(),
-		fit_cell(&row.name, name_width),
-		verb(row),
-	);
-	let plain = fit_cell(plain.trim_end(), 0);
-	let plain = if width > 0 && plain.chars().count() > width {
-		fit_cell(&plain, width)
+	let verb_text = verb(row);
+	let (name_cell, verb_cell) = fit_columns(&row.name, name_width, verb_text, width);
+	// `name_cell` already carries its width (fit_cell padded or truncated to
+	// the budget we asked for), and the verb cell follows it without a gap so
+	// the verb column lines up under the time column. The verb is padded to
+	// `VERB_WIDTH` only when there is room; a verb trimmed to its character
+	// count just rides at its natural width.
+	let verb_field = if verb_cell.chars().count() == VERB_WIDTH {
+		format!("{verb_cell:<VERB_WIDTH$}")
 	} else {
-		plain
+		verb_cell
 	};
-	colourise(&plain, row, mark, mark_style)
+	let mut line = format!(
+		" {mark} {:<KIND_WIDTH$} {name_cell} {verb_field} {time:>TIME_WIDTH$}",
+		row.kind.noun(),
+	);
+	line.truncate(line.trim_end().len());
+	let line = if width > 0 && line.chars().count() > width {
+		// Hard guarantee: never exceed width, even when fit_columns' estimate
+		// disagreed with the format by a column or two. A `…` here would lie
+		// about the duration, so the truncation just drops characters.
+		line.chars().take(width).collect()
+	} else {
+		line
+	};
+	colourise(&line, row, mark, mark_style, stderr_colored())
+}
+
+/// Width-budgeted name and verb cells. Shrinks the name first (with `…`), then
+/// the verb, keeping the elapsed column alive.
+fn fit_columns(name: &str, name_width: usize, verb_text: &str, width: usize) -> (String, String) {
+	// `width == 0` is the "don't truncate" signal; render at natural width.
+	if width == 0 {
+		return (fit_cell(name, name_width), verb_text.to_string());
+	}
+	// How many columns the natural-width row would take.
+	let natural = KIND_AND_TIME_OVERHEAD + name_width + NAME_GUTTER + VERB_WIDTH;
+	if natural <= width {
+		return (fit_cell(name, name_width), verb_text.to_string());
+	}
+	let over = natural - width;
+	// Shrink the name first. The minimum is one column for `…`.
+	let name_shrink = over.min(name_width.saturating_sub(MIN_NAME_WIDTH));
+	let new_name_width = name_width - name_shrink;
+	let name_cell = fit_cell(name, new_name_width);
+	let remaining = over - name_shrink;
+	// Then the verb. The verb is plain text (no `…`), so the minimum is zero ,
+	// if it is shorter than the budget, no padding is added.
+	let verb_chars = verb_text.chars().count();
+	let verb_shrink = remaining.min(verb_chars);
+	let verb_cell: String = if verb_shrink >= verb_chars {
+		String::new()
+	} else {
+		verb_text.chars().take(verb_chars - verb_shrink).collect()
+	};
+	(name_cell, verb_cell)
 }
 
 /// Re-apply colour to an already-fitted line.
@@ -107,8 +173,14 @@ pub fn render(row: &Row, name_width: usize, frame: usize, now: Instant, width: u
 /// Deliberately done after fitting rather than before: the escape sequences are
 /// zero-width, so measuring a coloured line counts characters the terminal never
 /// draws, and the truncation would cut in the middle of an escape and leave the
-/// terminal painted.
-fn colourise(plain: &str, row: &Row, mark: &str, mark_style: Style) -> String {
+/// terminal painted. Gated on `colour` (the resolved colour choice): when the
+/// caller asked for no styling (NO_COLOR=1, --ansi never) the mark and the name
+/// keep their plain glyphs, and the live region keeps repainting under
+/// `script -qfc` without an escape stream a reader has to strip.
+fn colourise(plain: &str, row: &Row, mark: &str, mark_style: Style, colour: bool) -> String {
+	if !colour {
+		return plain.to_string();
+	}
 	let mut out = plain.to_string();
 	if let Some(pos) = out.find(mark) {
 		let styled = paint(mark_style, mark, true);
@@ -122,9 +194,15 @@ fn colourise(plain: &str, row: &Row, mark: &str, mark_style: Style) -> String {
 }
 
 /// The summary line above the region: how many resources are done out of how
-/// many.
-pub fn summary(done: usize, total: usize) -> String {
-	format!("[+] Running {done}/{total}")
+/// many. Fitted to `width` like the rows, so a narrow terminal that truncates
+/// the rows also truncates the summary and never repaints over the wrong lines.
+pub fn summary(done: usize, total: usize, width: usize) -> String {
+	let s = format!("[+] Running {done}/{total}");
+	if width > 0 && s.chars().count() > width {
+		s.chars().take(width).collect()
+	} else {
+		s
+	}
 }
 
 #[cfg(test)]

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -20,7 +20,7 @@ pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦"
 const DONE_MARK: &str = "✔";
 
 /// Marker for a row that finished in error. Distinct from [`DONE_MARK`] so a
-/// failed row cannot be mistaken for a successful one at a glance ,  the verb
+/// failed row cannot be mistaken for a successful one at a glance — the verb
 /// already says "Failed", but the row before the user shows the green checkmark
 /// of a row that closed cleanly, which is the contradiction #1347 introduced
 /// when the missing-close sites started sending `"Failed"` as the closing verb.
@@ -60,7 +60,7 @@ const MIN_NAME_WIDTH: usize = 1;
 /// now exists, a pending one is dim because nothing has happened to it. The name
 /// beside it keeps its identity colour, which is why the marker must not reuse
 /// that palette. A failed row breaks the green-equals-success tie by carrying
-/// the verb "Failed" ,  the marker reads it too, so a failure and a success do
+/// the verb "Failed" — the marker reads it too, so a failure and a success do
 /// not share a glyph.
 fn marker(row: &Row, frame: usize) -> (&'static str, Style) {
 	match &row.state {
@@ -105,7 +105,7 @@ pub fn format_elapsed(d: Duration) -> String {
 ///
 /// Truncation order is name first (with `…`), then verb, leaving the elapsed
 /// column intact as long as it fits. The fixed columns (mark, kind, time) are
-/// never shortened ,  they are the part that says what the row is and how long
+/// never shortened: they are the part that says what the row is and how long
 /// it took, and a `…` in the elapsed column would be misread as a duration.
 pub fn render(row: &Row, name_width: usize, frame: usize, now: Instant, width: usize) -> String {
 	let (mark, mark_style) = marker(row, frame);

--- a/internal/ui/progress/row_tests.rs
+++ b/internal/ui/progress/row_tests.rs
@@ -64,7 +64,7 @@ fn a_row_never_exceeds_the_measured_width() {
 			"width {width}: got {} chars: {line:?}",
 			line.chars().count()
 		);
-		// And the truncation actually fired ,  at width 30 the natural row is
+		// And the truncation actually fired: at width 30 the natural row is
 		// wider, so the line must have been cut.
 		assert!(
 			line.contains('\u{2026}'),
@@ -88,7 +88,7 @@ fn the_summary_line_never_exceeds_the_measured_width() {
 	}
 }
 
-/// A width of zero means "do not truncate" ,  the caller could not read the
+/// A width of zero means "do not truncate" — the caller could not read the
 /// terminal size. The line is still produced rather than collapsing to nothing.
 #[test]
 fn width_zero_leaves_the_line_intact() {
@@ -116,8 +116,8 @@ fn each_state_gets_its_own_marker() {
 }
 
 /// A row that closed with the verb "Failed" is not a successful row. The marker
-/// is the first thing the eye lands on, so a failure without `✘` ,  a row that
-/// says "Failed" with a green `✔` ,  is the same contradiction the missing-close
+/// is the first thing the eye lands on, so a failure without `✘` — a row that
+/// says "Failed" with a green `✔` — is the same contradiction the missing-close
 /// fix (#1347) introduced: the verb now says "Failed", and the marker has to
 /// match.
 #[test]

--- a/internal/ui/progress/row_tests.rs
+++ b/internal/ui/progress/row_tests.rs
@@ -33,7 +33,7 @@ fn plain(line: &str) -> String {
 /// afterwards erases the wrong lines.
 #[test]
 fn a_line_never_exceeds_the_terminal_width() {
-	for width in [10, 20, 40, 80] {
+	for width in [10, 20, 30, 40, 80] {
 		let r = Row {
 			name: "a-very-long-container-name-that-will-not-fit-anywhere".to_string(),
 			..row(State::Working("Creating".into()))
@@ -47,7 +47,48 @@ fn a_line_never_exceeds_the_terminal_width() {
 	}
 }
 
-/// A width of zero means "do not truncate" — the caller could not read the
+/// The named acceptance test: rendered at width 30 and width 20, every row's
+/// visible column count is at most the given width. `…` counts as one column
+/// because `fit_cell` measures in chars, and the existing `plain` helper strips
+/// escapes the same way it always did (#1672).
+#[test]
+fn a_row_never_exceeds_the_measured_width() {
+	for width in [20, 30] {
+		let r = Row {
+			name: "a-very-long-container-name-that-will-not-fit-anywhere".to_string(),
+			..row(State::Working("Creating".into()))
+		};
+		let line = plain(&render(&r, 40, 0, Instant::now(), width));
+		assert!(
+			line.chars().count() <= width,
+			"width {width}: got {} chars: {line:?}",
+			line.chars().count()
+		);
+		// And the truncation actually fired ,  at width 30 the natural row is
+		// wider, so the line must have been cut.
+		assert!(
+			line.contains('\u{2026}'),
+			"width {width}: name column should be truncated with `…`: {line:?}"
+		);
+	}
+}
+
+/// The summary line is the row the cursor-up arithmetic has to count too, and
+/// the issue names it: a wide summary that wraps makes the repaint
+/// erase the wrong lines on every subsequent frame (#1672).
+#[test]
+fn the_summary_line_never_exceeds_the_measured_width() {
+	for width in [5, 10, 20, 30] {
+		let s = plain(&summary(3, 100, width));
+		assert!(
+			s.chars().count() <= width,
+			"width {width}: got {} chars: {s:?}",
+			s.chars().count()
+		);
+	}
+}
+
+/// A width of zero means "do not truncate" ,  the caller could not read the
 /// terminal size. The line is still produced rather than collapsing to nothing.
 #[test]
 fn width_zero_leaves_the_line_intact() {
@@ -75,8 +116,8 @@ fn each_state_gets_its_own_marker() {
 }
 
 /// A row that closed with the verb "Failed" is not a successful row. The marker
-/// is the first thing the eye lands on, so a failure without `✘` — a row that
-/// says "Failed" with a green `✔` — is the same contradiction the missing-close
+/// is the first thing the eye lands on, so a failure without `✘` ,  a row that
+/// says "Failed" with a green `✔` ,  is the same contradiction the missing-close
 /// fix (#1347) introduced: the verb now says "Failed", and the marker has to
 /// match.
 #[test]
@@ -174,5 +215,5 @@ fn a_name_cannot_drive_the_terminal() {
 
 #[test]
 fn the_summary_counts_done_over_total() {
-	assert_eq!(summary(3, 6), "[+] Running 3/6");
+	assert_eq!(summary(3, 6, 0), "[+] Running 3/6");
 }

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -11,7 +11,7 @@ const ELLIPSIS: char = '…';
 /// Fit `cell` into exactly `width` display columns: when it overflows, keep the
 /// leading `width - 1` chars and append an ellipsis; otherwise left-pad with
 /// spaces. Counts `char`s (not bytes) so multi-byte cells truncate on a char
-/// boundary and stay aligned. A `width` of 0 returns the cell unchanged ,  used
+/// boundary and stay aligned. A `width` of 0 returns the cell unchanged — used
 /// for the trailing column, which is never padded or truncated.
 pub fn fit_cell(cell: &str, width: usize) -> String {
 	let cell = &sanitize_cell(cell);
@@ -31,8 +31,8 @@ pub fn fit_cell(cell: &str, width: usize) -> String {
 ///
 /// Cell contents are not ours: an image tag, a container name, a volume driver
 /// and a process `argv` all come from outside podup. A raw `\x1b[` in one of
-/// them repaints the caller's terminal, and ,  now that columns carry colour of
-/// their own ,  desynchronises podup's own resets, so the rest of the table
+/// them repaints the caller's terminal, and — now that columns carry colour of
+/// their own — desynchronises podup's own resets, so the rest of the table
 /// inherits whatever the injected sequence set.
 ///
 /// Escaping happens before padding, so the width the column reserves is the
@@ -74,7 +74,7 @@ pub struct Table {
 	caps: Vec<Option<usize>>,
 	/// The column (if any) whose cells are colourised by container status.
 	status_col: Option<usize>,
-	/// The column (if any) carrying an identity ,  a service or container name ,
+	/// The column (if any) carrying an identity — a service or container name —
 	/// tinted with that identity's stable colour.
 	identity_col: Option<usize>,
 	/// The column (if any) holding a yes/no answer where `yes` is the one worth
@@ -125,8 +125,8 @@ impl Table {
 	/// Tint column `col` with each row's stable identity colour, so the same
 	/// service or container is the same colour in every command that lists it.
 	///
-	/// The palette deliberately excludes red, green and yellow ,  those carry
-	/// status meaning ,  so an identity colour can never be misread as a state.
+	/// The palette deliberately excludes red, green and yellow — those carry
+	/// status meaning — so an identity colour can never be misread as a state.
 	pub fn identity_col(mut self, col: usize) -> Self {
 		self.identity_col = Some(col);
 		self
@@ -137,7 +137,7 @@ impl Table {
 	///
 	/// Deliberately not [`Table::status_col`], which would paint `yes` green.
 	/// Green means healthy/up everywhere else in this CLI, and the column this
-	/// was written for ,  `volumes`' `EXTERNAL` ,  is not reporting health. It
+	/// was written for — `volumes`' `EXTERNAL` — is not reporting health. It
 	/// reports the one volume podup will refuse to delete, so a `down -v` that
 	/// leaves something standing is explicable. That is a caution, and yellow is
 	/// already the band this CLI uses for *survives*.
@@ -151,8 +151,8 @@ impl Table {
 	/// For a table where most columns are scaffolding and one or two carry the
 	/// answer. `top` is the case: eight columns of process bookkeeping around the
 	/// command line, which is the reason anyone runs it. Dimming is not a
-	/// meaning ,  unlike the status and caution colours it says nothing about the
-	/// value ,  so it composes with them rather than competing.
+	/// meaning — unlike the status and caution colours it says nothing about the
+	/// value — so it composes with them rather than competing.
 	pub fn dim_cols(mut self, cols: &[usize]) -> Self {
 		self.dim_cols = cols.to_vec();
 		self
@@ -171,7 +171,7 @@ impl Table {
 	/// The two differ where the column shows something longer than the identity:
 	/// `ps` prints the full container name `proj-web-1` while `logs` prefixes the
 	/// project-stripped `web-1`. Keying both on `web-1` is what makes one
-	/// container the same colour in both commands ,  which is the entire point of
+	/// container the same colour in both commands — which is the entire point of
 	/// a stable palette.
 	pub fn push_keyed(&mut self, cells: Vec<String>, key: String) {
 		self.rows.push(cells);
@@ -258,7 +258,7 @@ impl Table {
 	}
 
 	/// Render the table as plain (uncoloured) lines: the header first, then one
-	/// line per row, columns aligned and over-cap cells truncated. Pure ,  used by
+	/// line per row, columns aligned and over-cap cells truncated. Pure — used by
 	/// the unit tests and shared with [`Table::print`].
 	pub fn render(&self) -> Vec<String> {
 		let widths = self.widths();
@@ -277,8 +277,8 @@ impl Table {
 		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
 		// Every column marker that can tint a cell has to appear here, or a table
 		// that uses only that marker renders plain. `caution_col` was added
-		// without being listed, and it went unnoticed because its first caller ,
-		// `volumes` ,  also sets `identity_col`, so the gate happened to be open.
+		// without being listed, and it went unnoticed because its first caller —
+		// `volumes` — also sets `identity_col`, so the gate happened to be open.
 		let colour = self.colours_any_column() && super::stdout_colored();
 		for (i, row) in self.rows.iter().enumerate() {
 			let key = self.keys.get(i).and_then(Option::as_deref);

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -11,7 +11,7 @@ const ELLIPSIS: char = '…';
 /// Fit `cell` into exactly `width` display columns: when it overflows, keep the
 /// leading `width - 1` chars and append an ellipsis; otherwise left-pad with
 /// spaces. Counts `char`s (not bytes) so multi-byte cells truncate on a char
-/// boundary and stay aligned. A `width` of 0 returns the cell unchanged — used
+/// boundary and stay aligned. A `width` of 0 returns the cell unchanged ,  used
 /// for the trailing column, which is never padded or truncated.
 pub fn fit_cell(cell: &str, width: usize) -> String {
 	let cell = &sanitize_cell(cell);
@@ -31,8 +31,8 @@ pub fn fit_cell(cell: &str, width: usize) -> String {
 ///
 /// Cell contents are not ours: an image tag, a container name, a volume driver
 /// and a process `argv` all come from outside podup. A raw `\x1b[` in one of
-/// them repaints the caller's terminal, and — now that columns carry colour of
-/// their own — desynchronises podup's own resets, so the rest of the table
+/// them repaints the caller's terminal, and ,  now that columns carry colour of
+/// their own ,  desynchronises podup's own resets, so the rest of the table
 /// inherits whatever the injected sequence set.
 ///
 /// Escaping happens before padding, so the width the column reserves is the
@@ -74,7 +74,7 @@ pub struct Table {
 	caps: Vec<Option<usize>>,
 	/// The column (if any) whose cells are colourised by container status.
 	status_col: Option<usize>,
-	/// The column (if any) carrying an identity — a service or container name —
+	/// The column (if any) carrying an identity ,  a service or container name ,
 	/// tinted with that identity's stable colour.
 	identity_col: Option<usize>,
 	/// The column (if any) holding a yes/no answer where `yes` is the one worth
@@ -125,8 +125,8 @@ impl Table {
 	/// Tint column `col` with each row's stable identity colour, so the same
 	/// service or container is the same colour in every command that lists it.
 	///
-	/// The palette deliberately excludes red, green and yellow — those carry
-	/// status meaning — so an identity colour can never be misread as a state.
+	/// The palette deliberately excludes red, green and yellow ,  those carry
+	/// status meaning ,  so an identity colour can never be misread as a state.
 	pub fn identity_col(mut self, col: usize) -> Self {
 		self.identity_col = Some(col);
 		self
@@ -137,7 +137,7 @@ impl Table {
 	///
 	/// Deliberately not [`Table::status_col`], which would paint `yes` green.
 	/// Green means healthy/up everywhere else in this CLI, and the column this
-	/// was written for — `volumes`' `EXTERNAL` — is not reporting health. It
+	/// was written for ,  `volumes`' `EXTERNAL` ,  is not reporting health. It
 	/// reports the one volume podup will refuse to delete, so a `down -v` that
 	/// leaves something standing is explicable. That is a caution, and yellow is
 	/// already the band this CLI uses for *survives*.
@@ -151,8 +151,8 @@ impl Table {
 	/// For a table where most columns are scaffolding and one or two carry the
 	/// answer. `top` is the case: eight columns of process bookkeeping around the
 	/// command line, which is the reason anyone runs it. Dimming is not a
-	/// meaning — unlike the status and caution colours it says nothing about the
-	/// value — so it composes with them rather than competing.
+	/// meaning ,  unlike the status and caution colours it says nothing about the
+	/// value ,  so it composes with them rather than competing.
 	pub fn dim_cols(mut self, cols: &[usize]) -> Self {
 		self.dim_cols = cols.to_vec();
 		self
@@ -171,7 +171,7 @@ impl Table {
 	/// The two differ where the column shows something longer than the identity:
 	/// `ps` prints the full container name `proj-web-1` while `logs` prefixes the
 	/// project-stripped `web-1`. Keying both on `web-1` is what makes one
-	/// container the same colour in both commands — which is the entire point of
+	/// container the same colour in both commands ,  which is the entire point of
 	/// a stable palette.
 	pub fn push_keyed(&mut self, cells: Vec<String>, key: String) {
 		self.rows.push(cells);
@@ -258,7 +258,7 @@ impl Table {
 	}
 
 	/// Render the table as plain (uncoloured) lines: the header first, then one
-	/// line per row, columns aligned and over-cap cells truncated. Pure — used by
+	/// line per row, columns aligned and over-cap cells truncated. Pure ,  used by
 	/// the unit tests and shared with [`Table::print`].
 	pub fn render(&self) -> Vec<String> {
 		let widths = self.widths();
@@ -277,13 +277,20 @@ impl Table {
 		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
 		// Every column marker that can tint a cell has to appear here, or a table
 		// that uses only that marker renders plain. `caution_col` was added
-		// without being listed, and it went unnoticed because its first caller —
-		// `volumes` — also sets `identity_col`, so the gate happened to be open.
+		// without being listed, and it went unnoticed because its first caller ,
+		// `volumes` ,  also sets `identity_col`, so the gate happened to be open.
 		let colour = self.colours_any_column() && super::stdout_colored();
 		for (i, row) in self.rows.iter().enumerate() {
 			let key = self.keys.get(i).and_then(Option::as_deref);
 			println!("{}", self.format_row_keyed(row, &widths, colour, key));
 		}
+	}
+
+	/// Whether the table has any data rows. Callers can use this to print an
+	/// explicit "no X" line on stderr for an empty result (#1675), so a script
+	/// capturing stdout sees nothing for the empty case.
+	pub fn is_empty(&self) -> bool {
+		self.rows.is_empty()
 	}
 }
 


### PR DESCRIPTION
Fixes #1672, #1673 and #1675.

## What

- The live sink is chosen by the terminal alone; `NO_COLOR` and `--ansi never` remove the styling and keep the spinner, the repaint and the markers. Measured: `NO_COLOR=1 up -d` now hides the cursor and repaints with zero SGR sequences.
- Rows and the summary line are cut to the measured width with `…` on the name. Measured at `stty rows 24 cols 30`: longest row 29 columns, cursor moves unchanged.
- The plain sink never contradicts itself: a transitional verb is held until the final one; both lines are printed when work happened (`Pulling` then `Pulled`, so a log still shows when it started), only the final when nothing was done (`Exists`, `Running`, `Absent`, `Skipped`); the held line is flushed at `end` and at the error exit. Piped `up -d` on an existing network prints `Network ux_default  Exists` and nothing else for it.
- A failed `up` printed its `Failed` row twice; once now. Interactive `exec` wrote a stray byte before the output (`^@hi` under `script`); the first bytes are `hi`. Empty `volumes`, `images`, `ps` and `ls` print `no volumes` / `no images` / `no containers` / `no projects` on stderr and nothing on stdout.

## How it was built

MiniMax wrote the fixes and the eight named tests under a brief. Two things I changed on review: its plain sink dropped every transitional line, which broke four contract tests in `tests/reporting_contract.rs` that hold `Pulling` then `Pulled` in a pipe (the rule above keeps them and drops only the contradiction); and it had rewritten every pre-existing em dash in `docs/commands.md` into broken punctuation, so the docs diff was rebuilt from `HEAD` plus its five new paragraphs. Unit: 1824 pass; the 14 contract tests pass.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>