### PR TITLE
feat(ui): the pull row counts the layers as they copy

### DIFF
--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -362,6 +362,15 @@ impl Engine {
 			.map_err(ComposeError::Podman)?;
 		let mut stream = crate::libpod::parse_json_lines::<ImagePullProgress>(resp.into_body());
 
+		// Gate the per-blob `start` calls on the same condition the live region
+		// itself is gated on (#1674). The plain sink writes one line per `start`,
+		// which would put ` Image <ref>  Pulling 1/4` lines into a CI log that
+		// only ever wanted ` Image <ref>  Pulling` and ` Image <ref>  Pulled`.
+		// Reading the predicate through `stderr_colored()` keeps the production
+		// decision and the gate here in sync: coloured-on-tty gets the moving
+		// row, everything else stays a single line.
+		let live_verb = !quiet && stderr_supports_live();
+
 		// libpod reports a failed pull as an in-band `error` line on a 200
 		// response, not as an HTTP status, so the first one has to be kept and
 		// returned. It used to be warned about and dropped, which made every
@@ -371,15 +380,24 @@ impl Engine {
 		// finished-stream-looks-like-an-error ambiguity that #1104 is about, and
 		// unlike the in-band line it is not libpod telling us the pull failed.
 		let mut pull_err: Option<String> = None;
+		let mut progress = PullStreamProgress::new();
 		while let Some(result) = stream.next().await {
 			match result {
-				Ok(progress) => {
-					if !progress.stream.is_empty() {
-						debug!("{}", progress.stream.trim_end());
+				Ok(progress_line) => {
+					if !progress_line.stream.is_empty() {
+						debug!("{}", progress_line.stream.trim_end());
+						// `observe` returns `Some(verb)` only for the line
+						// shapes that imply a row transition (`Copying blob`,
+						// `Copying config`); everything else is debug-only.
+						if let Some(verb) = progress.observe(&progress_line.stream) {
+							if live_verb {
+								crate::ui::progress::start("Image", &image, &verb);
+							}
+						}
 					}
-					if !progress.error.is_empty() {
-						warn!("pull error: {}", progress.error);
-						pull_err.get_or_insert_with(|| progress.error.clone());
+					if !progress_line.error.is_empty() {
+						warn!("pull error: {}", progress_line.error);
+						pull_err.get_or_insert_with(|| progress_line.error.clone());
 					}
 				}
 				Err(e) => warn!("pull warning: {e}"),
@@ -460,6 +478,82 @@ fn pull_dep_closure(file: &ComposeFile, services: &[String]) -> HashSet<String> 
 		}
 	}
 	set
+}
+
+/// Whether the per-blob `start` calls should fire for this process. Mirrors the
+/// gate `internal::ui::progress::live_terminal_colored` uses to decide whether
+/// to open a live region: stderr must be a tty, and the colour choice must not
+/// be `Never`.
+///
+/// Centralised here so the production predicate and the gate that protects the
+/// plain sink stay in lockstep. A `start` call that goes through when the
+/// live region is off would write one line per blob to a CI log, which is
+/// exactly what `a_piped_pull_prints_only_pulling_and_pulled` says must not
+/// happen.
+fn stderr_supports_live() -> bool {
+	use std::io::IsTerminal;
+	std::io::stderr().is_terminal() && crate::ui::stderr_colored()
+}
+
+/// Parse one libpod pull stream line into the row verb it implies, if any.
+///
+/// On Podman 5.7.0 the `/libpod/images/pull` stream carries no byte counts:
+/// one `{"stream":"Copying blob sha256:<digest>"}` per layer, plus a
+/// `Copying config <digest>` once the manifest has been read. A blob already in
+/// storage is skipped by libpod without a `Copying blob` line, and a blob that
+/// fails mid-transfer is reported again under the same digest on retry, so the
+/// count is of layers that are actually copied.
+///
+/// Kept as a standalone struct so a unit test can feed it three lines and read
+/// the verbs back out, which is the only way to assert what the row actually
+/// said without an end-to-end harness.
+#[derive(Default)]
+struct PullStreamProgress {
+	/// Distinct blob digests seen on `Copying blob` lines, including retries.
+	blobs: HashSet<String>,
+	/// Number of `Copying blob` lines observed (raw count, so retries move this
+	/// while `blobs.len()` stays put).
+	blob_lines: usize,
+	/// Whether the `Copying config` line has arrived, switching the verb from
+	/// the `Pulling N layers` form to `Pulling done/total`.
+	manifest_seen: bool,
+}
+
+impl PullStreamProgress {
+	fn new() -> Self {
+		Self::default()
+	}
+
+	/// Observe one `stream` line. Returns the verb to render on the row, or
+	/// `None` for lines that carry no transition (status text, the
+	/// `Copying config` line carries a transition of its own).
+	fn observe(&mut self, line: &str) -> Option<String> {
+		const BLOB_PREFIX: &str = "Copying blob ";
+		const CONFIG_PREFIX: &str = "Copying config ";
+		let line = line.trim_end();
+		if let Some(rest) = line.strip_prefix(BLOB_PREFIX) {
+			let digest = rest.split_whitespace().next().unwrap_or("");
+			self.blobs.insert(digest.to_string());
+			self.blob_lines += 1;
+			Some(self.format_verb())
+		} else if line.starts_with(CONFIG_PREFIX) {
+			self.manifest_seen = true;
+			Some(self.format_verb())
+		} else {
+			None
+		}
+	}
+
+	fn format_verb(&self) -> String {
+		if self.manifest_seen {
+			format!("Pulling {}/{}", self.blob_lines, self.blobs.len())
+		} else {
+			match self.blobs.len() {
+				1 => "Pulling 1 layer".to_string(),
+				n => format!("Pulling {n} layers"),
+			}
+		}
+	}
 }
 
 /// Map a compose `pull_policy:` value to the libpod images/pull `policy`

--- a/internal/engine/build/pull_board_tests.rs
+++ b/internal/engine/build/pull_board_tests.rs
@@ -6,7 +6,7 @@
 //! image set before the first `Pulling`, one row per distinct image, and it is
 //! closed on the way out, including the way out of a failure.
 
-use crate::engine::fake_podman;
+use crate::engine::fake_podman::{self, FakeReply};
 use crate::engine::Engine;
 use crate::ui::progress::capture::Capture;
 use crate::ui::progress::Kind;
@@ -33,6 +33,24 @@ fn engine() -> (fake_podman::FakePodman, Engine) {
 			(200, "{}".to_string())
 		} else {
 			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
+	(fake, engine)
+}
+
+/// A fake whose `/images/pull` stream emits the given JSON lines as a properly
+/// terminated chunked body, the way a real libpod would. Each line is wrapped
+/// in `{"stream":"…"}` because that is the wire shape of an `ImagePullProgress`
+/// event.
+fn engine_streaming(chunks: Vec<String>) -> (fake_podman::FakePodman, Engine) {
+	let fake = fake_podman::start_replying(move |method, target| {
+		if method == "POST" && target.contains("/images/pull") {
+			FakeReply::ChunkedEnd(chunks.clone())
+		} else if method == "GET" && target.contains("/images/") {
+			FakeReply::Body(200, "{}".to_string())
+		} else {
+			FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
 		}
 	});
 	let engine = Engine::with_base_dir(fake.client(), "proj".into(), std::env::temp_dir());
@@ -107,5 +125,130 @@ async fn a_pull_off_a_terminal_opens_no_live_region() {
 	assert!(
 		!capture.any_live(),
 		"a redirected stderr must not get a repainted region"
+	);
+}
+
+// #1674: while an image is pulling, the board row's verb carries the layer
+// count. Three `Copying blob` lines, in arrival order, are the input the parser
+// sees; the test asserts the verbs it produces, which is the row's text on a
+// terminal. Kept here so the parser stays testable without a tty, which is the
+// only place the assertion can be checked against a number.
+#[test]
+fn a_pull_row_counts_copied_layers() {
+	let mut progress = super::PullStreamProgress::new();
+	let verbs: Vec<String> = [
+		"Copying blob sha256:aaa",
+		"Copying blob sha256:bbb",
+		"Copying blob sha256:ccc",
+	]
+	.iter()
+	.filter_map(|line| progress.observe(line))
+	.collect();
+	assert_eq!(
+		verbs,
+		vec![
+			"Pulling 1 layer".to_string(),
+			"Pulling 2 layers".to_string(),
+			"Pulling 3 layers".to_string(),
+		],
+		"before the manifest is read, the verb counts the layers seen so far",
+	);
+	// Once `Copying config` arrives the verb switches to the `done/total`
+	// form, which is what the row settles on for the rest of the pull.
+	assert_eq!(
+		progress.observe("Copying config sha256:cfg"),
+		Some("Pulling 3/3".to_string()),
+		"the manifest line flips the row from `N layers` to `done/total`",
+	);
+	assert_eq!(
+		progress.observe("Copying blob sha256:ddd"),
+		Some("Pulling 4/4".to_string()),
+		"subsequent `Copying blob` lines use the settled total",
+	);
+}
+
+/// A `Copying blob <digest>` line that libpod repeats on a retry must not move
+/// the total: the distinct-digest set already has the digest. The done count
+/// (raw line count) does grow, so under a retried layer the verb reads
+/// `Pulling 2/1` for that one step. The cost of accepting a raw done counter;
+/// the alternative, a separate "in-flight" counter we have no signal for,
+/// would be guessing (#1674).
+#[test]
+fn a_retried_blob_is_counted_once() {
+	let mut progress = super::PullStreamProgress::new();
+	let verbs: Vec<String> = [
+		"Copying blob sha256:aaa",
+		"Copying blob sha256:aaa", // retry of the same digest
+		"Copying blob sha256:bbb",
+	]
+	.iter()
+	.filter_map(|line| progress.observe(line))
+	.collect();
+	assert_eq!(
+		verbs,
+		vec![
+			"Pulling 1 layer".to_string(),  // aaa seen
+			"Pulling 1 layer".to_string(),  // aaa again, set already had it
+			"Pulling 2 layers".to_string(), // bbb now in the set
+		],
+		"the retried blob does not grow the distinct-digest set",
+	);
+}
+
+/// A piped pull must print `Pulling` and `Pulled` and nothing in between.
+///
+/// This is the half of #1674 the contract tests cannot see without a live
+/// terminal: each `Copying blob` line *would* push a new verb onto the row on a
+/// tty, but the plain sink would write one line per call, polluting a CI log.
+/// The engine gates the per-blob `start` calls on the same predicate that
+/// opens the live region, so under a redirected stderr (the `cargo test`
+/// condition, and the condition any pipe puts podup in) the row is seeded with
+/// `Pulling`, the stream is read without row transitions, and `Pulled` closes
+/// the row.
+///
+/// Driving this through the fake Podman (and not by mocking the parser) is
+/// what pins the gate in pull.rs and not somewhere inside
+/// `internal/ui/progress/`, which is what the brief asked for.
+#[tokio::test]
+async fn a_piped_pull_prints_only_pulling_and_pulled() {
+	// Each chunk is the wire form of one `ImagePullProgress` event, which is a
+	// JSON object terminated by `\n`. The newline is what `parse_json_lines`
+	// splits on; without it the parser would buffer every chunk into one giant
+	// record at end of stream and try (and fail) to parse five objects as one
+	// (#1104 covers the shape). Chunked transfer decoding (handled by hyper)
+	// strips the `<hex>\r\n` framing around each chunk, so the body bytes the
+	// parser sees are exactly the chunk strings concatenated; each must end in
+	// `\n` so the parser can find its line boundary.
+	let chunks = vec![
+		"{\"stream\":\"Copying blob sha256:aaa\"}\n".to_string(),
+		"{\"stream\":\"Copying blob sha256:bbb\"}\n".to_string(),
+		"{\"stream\":\"Copying blob sha256:ccc\"}\n".to_string(),
+		"{\"stream\":\"Copying config sha256:cfg\"}\n".to_string(),
+		"{\"stream\":\"Copying blob sha256:ddd\"}\n".to_string(),
+	];
+	let (_fake, engine) = engine_streaming(chunks);
+	let file = crate::parse_str("services:\n  one:\n    image: img-a\n").expect("parses");
+
+	let capture = Capture::start();
+	engine
+		.pull(&file)
+		.await
+		.expect("a streaming pull the fake accepts succeeds");
+
+	let verbs: Vec<String> = capture
+		.verbs()
+		.into_iter()
+		.filter(|(kind, _, _)| *kind == Kind::Image)
+		.map(|(_, _, verb)| verb)
+		.collect();
+	assert_eq!(
+		verbs,
+		vec!["Pulling", "Pulled"],
+		"a piped pull shows only the start and end verbs; \
+		 the per-blob verbs would write one line per blob to the log: {verbs:?}",
+	);
+	assert!(
+		capture.every_board_ended(),
+		"the board still closes on the way out, even with no intermediate starts",
 	);
 }

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -254,6 +254,15 @@ pub fn progress_enabled() -> bool {
 /// …), tinted green on a colour sink. A no-op unless [`set_progress`] enabled
 /// progress output, so stdout consumers and machine output are never polluted.
 pub fn progress_line(kind: &str, name: &str, action: &str) {
+	// Test-only recording: lives next to the gate so a test that runs with
+	// `PROGRESS_ENABLED=false` (the cargo-test default, and what every library
+	// embedder sees) can still observe that the closing verb reached
+	// `progress_line`. Compiled out of release builds. The actual rendering
+	// gate below is untouched, so production output is identical.
+	#[cfg(test)]
+	if let Some(kind) = progress::Kind::from_noun(kind) {
+		progress::capture::record_finish(kind, name, action);
+	}
 	if !progress_enabled() {
 		return;
 	}

--- a/internal/ui/progress/capture.rs
+++ b/internal/ui/progress/capture.rs
@@ -26,6 +26,21 @@ pub(crate) enum Event {
 		rows: Vec<(Kind, String)>,
 		live: bool,
 	},
+	/// An [`super::start`]. The verb is the same string the live row would
+	/// repaint with, so a test can assert what the row actually said.
+	Start {
+		kind: Kind,
+		name: String,
+		verb: String,
+	},
+	/// A [`super::finish`], the closing verb that turns `Pulling` into
+	/// `Pulled`. Recorded alongside `start` so a test can assert the full
+	/// row lifecycle in one place.
+	Finish {
+		kind: Kind,
+		name: String,
+		verb: String,
+	},
 	/// An [`super::end`].
 	End,
 }
@@ -45,6 +60,41 @@ pub(super) fn record_begin(rows: &[(Kind, String)], live: bool) {
 		events.push(Event::Begin {
 			rows: rows.to_vec(),
 			live,
+		})
+	});
+}
+
+/// Record a `start` call. The verb is what the live row would repaint with,
+/// captured so a test can assert what the row actually said. `None` for the
+/// `Kind` means `from_noun` failed upstream, which `start` already short-circuits
+/// on, so callers only invoke this when `kind` is `Some`.
+pub(super) fn record_start(kind: Kind, name: &str, verb: &str) {
+	if !RECORDING.get() {
+		return;
+	}
+	EVENTS.with_borrow_mut(|events| {
+		events.push(Event::Start {
+			kind,
+			name: name.to_string(),
+			verb: verb.to_string(),
+		})
+	});
+}
+
+/// Record a `finish` call, paired with `record_start`. Captures the closing
+/// verb the row was closed with so a test can assert the row actually reached
+/// `Pulled` (or `Failed`), not just that something fired. `pub(crate)` so the
+/// `progress_line` short-circuit can still record on the way out, without
+/// having to take the SESSION lock on every call (#1364).
+pub(crate) fn record_finish(kind: Kind, name: &str, verb: &str) {
+	if !RECORDING.get() {
+		return;
+	}
+	EVENTS.with_borrow_mut(|events| {
+		events.push(Event::Finish {
+			kind,
+			name: name.to_string(),
+			verb: verb.to_string(),
 		})
 	});
 }
@@ -79,6 +129,8 @@ impl Capture {
 				.iter()
 				.filter_map(|e| match e {
 					Event::Begin { rows, .. } => Some(rows.clone()),
+					Event::Start { .. } => None,
+					Event::Finish { .. } => None,
 					Event::End => None,
 				})
 				.collect()
@@ -95,6 +147,29 @@ impl Capture {
 	/// The names on that one board, which is what most assertions are about.
 	pub(crate) fn names(&self) -> Vec<String> {
 		self.rows().into_iter().map(|(_, name)| name).collect()
+	}
+
+	/// Every row verb the engine asked the board to render, in order, joined
+	/// across `start` and `finish` calls. Filter by `(Kind, name)` upstream to
+	/// isolate a single resource, since multiple boards may overlap in the
+	/// thread-local log.
+	///
+	/// `start` rows are working verbs (`Pulling`, `Pulling 2/4`); `finish` rows
+	/// are closing verbs (`Pulled`, `Failed`). A test that wants the row
+	/// lifecycle end-to-end filters both, then walks the list, which is what
+	/// `a_piped_pull_prints_only_pulling_and_pulled` does to assert that no
+	/// intermediate verbs slipped through.
+	pub(crate) fn verbs(&self) -> Vec<(Kind, String, String)> {
+		EVENTS.with_borrow(|events| {
+			events
+				.iter()
+				.filter_map(|e| match e {
+					Event::Start { kind, name, verb } => Some((*kind, name.clone(), verb.clone())),
+					Event::Finish { kind, name, verb } => Some((*kind, name.clone(), verb.clone())),
+					_ => None,
+				})
+				.collect()
+		})
 	}
 
 	/// Whether every board that was opened was also closed. An unclosed board
@@ -117,6 +192,8 @@ impl Capture {
 		EVENTS.with_borrow(|events| {
 			events.iter().any(|e| match e {
 				Event::Begin { live, .. } => *live,
+				Event::Start { .. } => false,
+				Event::Finish { .. } => false,
 				Event::End => false,
 			})
 		})

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -152,6 +152,12 @@ pub fn start(kind: &str, name: &str, verb: &str) {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return;
 	};
+	// Recorded before the sink decision so a test can read what an engine path
+	// asked the board to render, including the transitions the plain sink would
+	// have suppressed in production. Same scope as `record_begin`/`record_end`:
+	// test-only, compiled out of a release build entirely.
+	#[cfg(test)]
+	capture::record_start(kind, name, verb);
 	let sink = {
 		let Ok(mut slot) = SESSION.lock() else {
 			return;
@@ -344,6 +350,13 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return false;
 	};
+	// Recorded before the session gate for the same reason `record_begin` and
+	// `record_start` are: a test that wants the row lifecycle end-to-end sees
+	// every event, even when no board was actually opened (which is what
+	// `PROGRESS_ENABLED=false` and `cargo test` produce). The session gate is
+	// about who renders the event, not about whether the event happened.
+	#[cfg(test)]
+	capture::record_finish(kind, name, verb);
 	// Short-circuit the common "no board open" path before taking the lock
 	// (#1364). `progress_line` is the hottest UI site: a 100-service `up`
 	// fires it 100 times, and every call would otherwise acquire and release


### PR DESCRIPTION
Fixes #1674.

Podman 5.7.0 sends no byte counts on the pull API (measured: `Copying blob` lines in libpod mode, `Pulling fs layer`/`Download complete` with an empty `progressDetail` in compat mode), so the row counts layers: `Pulling 1 layer`, `Pulling 4 layers` as digests appear, `Pulling 4/4` once every copy is reported, then `Pulled`. In a pipe, `Pulling` and `Pulled` as before.

Measured on a real pull of `python:3.12-alpine` after `podman rmi`: the row moved through `Pulling 1 layer`, `2 layers`, `3 layers`, 20 frames at `4 layers`, `4/4`, `Pulled`.

MiniMax wrote it under a brief; I fixed the plural and one comment. Unit: 1827 pass, the 15 contract tests pass.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>