### PR TITLE
feat(ui): build draws a row per image on the board, with the stream folded under it

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -186,6 +186,21 @@ Build or rebuild service images (optionally only the named services).
 | `--push` | Push each built image to its registry after a successful build. | off |
 | `-q, --quiet` | Suppress the build output. | off |
 
+On a terminal `build` draws a board of its own, one row per image, `Building`, then `Building n/m` as each
+`STEP n/m` line arrives, then `Built` (or `Failed`). The buildah stream
+itself is folded: while a row builds, its last four lines sit dimmed under
+the row and vanish when it finishes; on failure the whole stream is
+printed once, above the error, so the reason is on screen.
+`up --build` runs that build board first and the `up` board after it; an
+`up` that finds a service's image missing builds it on the `up` board,
+with the image row just above the service's container row.
+
+In a pipe every stream line goes to stderr prefixed with `<image-tag> | `,
+the way `logs` prefixes container output. The image id of the freshly built
+image goes to stdout only when stdout is not a terminal, so a script
+piping `podup build | awk '{print $1}'` can pluck it; on a terminal the
+row says `Built` and the id is dropped so the row is the record.
+
 ## Inspection
 
 ### `ps`

--- a/internal/engine/build/build_board_tests.rs
+++ b/internal/engine/build/build_board_tests.rs
@@ -1,0 +1,240 @@
+//! The board `build` opens, and the row verbs that arrive as buildah streams
+//! the build.
+//!
+//! Each test wires a fake libpod that answers `/libpod/build` with a canned
+//! stream and (where it matters) `/libpod/images/{tag}/tag` for the
+//! `build.tags` aliases. The board and the row verbs are observed through the
+//! `progress::capture` harness, which is what makes the assertions
+//! deterministic without a real Podman.
+
+#[cfg(unix)]
+mod tests {
+	use crate::engine::fake_podman::{self, FakeReply};
+	use crate::engine::Engine;
+	use crate::ui::progress::capture::Capture;
+	use crate::ui::progress::Kind;
+
+	/// A small project whose only service has a `build:` and an `image:` so
+	/// the libpod tag call (`POST /libpod/images/.../tag`) has somewhere to
+	/// land when the fake answers it.
+	const FILE: &str = "\
+services:
+  app:
+    image: localhost/ux-talker:1
+    build:
+      context: .
+";
+
+	/// A context directory with a real Dockerfile so `build_service`'s
+	/// `fs::metadata(context_path)` check passes. Returns the directory and
+	/// its path; the directory lives as long as the returned `TempDir` does.
+	fn context() -> (tempfile::TempDir, std::path::PathBuf) {
+		let dir = tempfile::tempdir().expect("tempdir");
+		let path = dir.path().to_path_buf();
+		std::fs::write(
+			path.join("Dockerfile"),
+			b"FROM docker.io/library/alpine:3.20\nRUN echo hi\nCMD [\"echo\",\"hi\"]\n",
+		)
+		.expect("write Dockerfile");
+		(dir, path)
+	}
+
+	/// A fake Podman that walks `/build`,` writes `chunks` as one well-formed
+	/// chunked body (each chunk's payload is the JSON line libpod would have
+	/// sent at that point; the parser splits on `\n`), and answers the
+	/// `POST /libpod/images/{tag}/tag` call that `apply_extra_tags` issues
+	/// for an `image:` on a build-section service. Every other request gets
+	/// a 404.
+	fn engine_streaming(
+		chunks: Vec<String>,
+		context: std::path::PathBuf,
+	) -> (fake_podman::FakePodman, Engine) {
+		let fake = fake_podman::start_replying(move |method, target| {
+			if method == "POST" && target.contains("/build?") {
+				FakeReply::ChunkedEnd(chunks.clone())
+			} else if method == "POST" && target.contains("/images/") && target.contains("/tag") {
+				FakeReply::Body(200, String::new())
+			} else {
+				FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let engine = Engine::with_base_dir(fake.client(), "proj".into(), context);
+		(fake, engine)
+	}
+
+	/// As [`engine_streaming`], but `/build` answers with a non-2xx body so
+	/// the stream reader surfaces the error rather than treating the line as
+	/// normal output. Used by the failure-path tests.
+	fn engine_with_body(
+		status: u16,
+		body: String,
+		context: std::path::PathBuf,
+	) -> (fake_podman::FakePodman, Engine) {
+		let fake = fake_podman::start_replying(move |method, target| {
+			if method == "POST" && target.contains("/build?") {
+				FakeReply::Body(status, body.clone())
+			} else {
+				FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+			}
+		});
+		let engine = Engine::with_base_dir(fake.client(), "proj".into(), context);
+		(fake, engine)
+	}
+
+	#[tokio::test]
+	async fn build_draws_a_row_per_image_and_counts_steps() {
+		// A three-step Dockerfile's worth of stream: each STEP line is the
+		// row transition the test asserts on. The trailing `-->` line is
+		// what `parse_image_id_line` matches to recover the id on stdout;
+		// the test does not assert on stdout here (that path is covered
+		// end-to-end by the contract suite against a real Podman).
+		let chunks = vec![
+			"{\"stream\":\"STEP 1/3: FROM docker.io/library/alpine:3.20\\n\"}\n".to_string(),
+			"{\"stream\":\"--> 3f3c8b769775\\n\"}\n".to_string(),
+			"{\"stream\":\"STEP 2/3: RUN echo hi\\n\"}\n".to_string(),
+			"{\"stream\":\"--> Using cache\\n\"}\n".to_string(),
+			"{\"stream\":\"STEP 3/3: CMD [\\\"echo\\\",\\\"hi\\\"]\\n\"}\n".to_string(),
+			"{\"stream\":\"--> 9f3c8b769775\\n\"}\n".to_string(),
+			"{\"stream\":\"COMMIT localhost/ux-talker:1\\n\"}\n".to_string(),
+			"{\"stream\":\"--> sha256:1111111111111111111111111111111111111111111111111111111111111111\\n\"}\n".to_string(),
+			"{\"stream\":\"Successfully tagged localhost/ux-talker:1\\n\"}\n".to_string(),
+		];
+		let (_dir, ctx_path) = context();
+		let (_fake, engine) = engine_streaming(chunks, ctx_path);
+		let file = crate::parse_str(FILE).expect("the fixture parses");
+
+		let capture = Capture::start();
+		engine
+			.build_all_with_options(&file, &[], &crate::engine::BuildOptions::default())
+			.await
+			.expect("a streaming build the fake accepts succeeds");
+
+		let names = capture.names();
+		assert_eq!(
+			names,
+			vec!["localhost/ux-talker:1"],
+			"one row per image the pass builds: {names:?}"
+		);
+		assert!(
+			capture.rows().iter().all(|(kind, _)| *kind == Kind::Image),
+			"the build row is an image row, not a container: {:?}",
+			capture.rows()
+		);
+
+		let verbs: Vec<String> = capture
+			.verbs()
+			.into_iter()
+			.filter(|(_, name, _)| name == "localhost/ux-talker:1")
+			.map(|(_, _, verb)| verb)
+			.collect();
+		assert_eq!(
+			verbs,
+			vec![
+				"Building".to_string(),
+				"Building 1/3".to_string(),
+				"Building 2/3".to_string(),
+				"Building 3/3".to_string(),
+				"Built".to_string(),
+			],
+			"each STEP n/m advances the verb and the success verb closes the row: {verbs:?}"
+		);
+		assert!(
+			capture.every_board_ended(),
+			"the board closes on the way out, even on success"
+		);
+	}
+
+	#[tokio::test]
+	async fn a_failed_build_prints_its_stream_once_before_the_error() {
+		// An in-band error on a 200 response is how libpod reports a build
+		// that compiled nothing: the build itself returned 200 with one
+		// `error` JSON line. The test asserts the error reaches the caller.
+		// The failure replay path itself runs through the same plumbing
+		// (the replay on a terminal, #1681); the per-line stderr mirror in
+		// a pipe is the contract test's job.
+		let body = "{\"stream\":\"STEP 1/3: FROM docker.io/library/alpine:3.20\\n\"}\n\
+		             {\"stream\":\"--> 3f3c8b769775\\n\"}\n\
+		             {\"stream\":\"STEP 2/3: RUN false\\n\"}\n\
+		             {\"stream\":\"--> running step\\n\"}\n\
+		             {\"error\":\"The command '/bin/sh -c false' returned a non-zero code: 1\\n\"}\n"
+			.to_string();
+		let (_dir, ctx_path) = context();
+		let (_fake, engine) = engine_with_body(200, body, ctx_path);
+		let file = crate::parse_str(FILE).expect("the fixture parses");
+
+		let err = engine
+			.build_all_with_options(&file, &[], &crate::engine::BuildOptions::default())
+			.await
+			.expect_err("a build whose last line is an `error` field must fail the pass");
+		let msg = err.to_string();
+		assert!(
+			msg.contains("returned a non-zero code"),
+			"the in-band error reaches the caller unchanged: {msg}"
+		);
+	}
+
+	#[test]
+	fn build_stream_progress_parses_a_three_step_dockerfile() {
+		// Unit test on the parser: three STEP lines plus their `-->` markers,
+		// in arrival order. Mirrors what `build_draws_a_row_per_image_and_counts_steps`
+		// asserts at the row level, kept here so the parser is testable
+		// without an end-to-end harness: the only way to assert what the
+		// row actually said.
+		let mut progress = super::super::BuildStreamProgress::new();
+		let verbs: Vec<String> = [
+			"STEP 1/3: FROM docker.io/library/alpine:3.20",
+			"--> 3f3c8b769775",
+			"STEP 2/3: RUN echo hi",
+			"--> Using cache",
+			"STEP 3/3: CMD [\"echo\", \"hi\"]",
+		]
+		.iter()
+		.filter_map(|line| progress.observe(line))
+		.collect();
+		assert_eq!(
+			verbs,
+			vec![
+				"Building 1/3".to_string(),
+				"Building 2/3".to_string(),
+				"Building 3/3".to_string(),
+			],
+			"each STEP advances the row verb by one: {verbs:?}"
+		);
+	}
+
+	#[test]
+	fn parse_image_id_line_only_matches_the_bare_full_id() {
+		// Buildah's stream, measured on Podman 5.7: the full id is a line of
+		// 64 hex digits on its own, after `Successfully tagged`. The layer
+		// markers (`--> 3f3c8b769775`), cache hits (`--> Using cache <digest>`)
+		// and the closing `Successfully built <short-id>` must NOT match: a
+		// script reading stdout would take them for the image id.
+		let id = "d1a7420d91864dc804e255408877a5234dfcfc9302e2526209d1f60ffd17f90b";
+		assert_eq!(
+			super::super::parse_image_id_line(id).as_deref(),
+			Some(id),
+			"the bare 64-hex line is the image id"
+		);
+		assert_eq!(
+			super::super::parse_image_id_line(&format!("{id}\n")).as_deref(),
+			Some(id),
+			"with the stream's trailing newline still attached"
+		);
+		for other in [
+			"--> d1a7420d9186",
+			&format!("--> Using cache {id}"),
+			"Successfully built d1a7420d9186",
+			&format!("--> sha256:{id}"),
+			&id[..63],
+			"g1a7420d91864dc804e255408877a5234dfcfc9302e2526209d1f60ffd17f90b",
+		] {
+			assert!(
+				super::super::parse_image_id_line(other).is_none(),
+				"{other:?} is not the image id line"
+			);
+		}
+	}
+}
+
+#[cfg(not(unix))]
+mod tests {}

--- a/internal/engine/build/build_board_tests.rs
+++ b/internal/engine/build/build_board_tests.rs
@@ -180,7 +180,7 @@ services:
 		// asserts at the row level, kept here so the parser is testable
 		// without an end-to-end harness: the only way to assert what the
 		// row actually said.
-		let mut progress = super::super::BuildStreamProgress::new();
+		let mut progress = super::super::steps::BuildStreamProgress::new();
 		let verbs: Vec<String> = [
 			"STEP 1/3: FROM docker.io/library/alpine:3.20",
 			"--> 3f3c8b769775",
@@ -211,12 +211,12 @@ services:
 		// script reading stdout would take them for the image id.
 		let id = "d1a7420d91864dc804e255408877a5234dfcfc9302e2526209d1f60ffd17f90b";
 		assert_eq!(
-			super::super::parse_image_id_line(id).as_deref(),
+			super::super::steps::parse_image_id_line(id).as_deref(),
 			Some(id),
 			"the bare 64-hex line is the image id"
 		);
 		assert_eq!(
-			super::super::parse_image_id_line(&format!("{id}\n")).as_deref(),
+			super::super::steps::parse_image_id_line(&format!("{id}\n")).as_deref(),
 			Some(id),
 			"with the stream's trailing newline still attached"
 		);
@@ -229,7 +229,7 @@ services:
 			"g1a7420d91864dc804e255408877a5234dfcfc9302e2526209d1f60ffd17f90b",
 		] {
 			assert!(
-				super::super::parse_image_id_line(other).is_none(),
+				super::super::steps::parse_image_id_line(other).is_none(),
 				"{other:?} is not the image id line"
 			);
 		}

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -24,6 +24,8 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use tracing::{info, warn};
 
+use std::io::IsTerminal;
+
 use crate::compose::types::{BuildConfig, Service};
 use crate::engine::container_config::resources::is_known_ulimit;
 use crate::error::{ComposeError, Result};
@@ -185,13 +187,53 @@ impl Engine {
 			target_services.to_vec()
 		};
 
+		// Seed the board with the image set this pass will build, one row
+		// per image, before the first `Building` line. A service with no
+		// `build:` block is skipped, the same way `build_service` does; its
+		// row would never move and would read as something hung (#1681).
+		// Two services on the same image share one row, since the row is
+		// the image.
+		let mut images: Vec<String> = Vec::new();
 		for name in &names {
-			let service = &file.services[name];
-			if service.build.is_some() {
-				self.build_service(name, service, file, opts).await?;
+			let Some(service) = file.services.get(name) else {
+				continue;
+			};
+			if service.build.is_none() {
+				continue;
+			}
+			let tag = primary_build_tag(
+				&self.project,
+				name,
+				service.image.as_deref(),
+				service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
+			);
+			if !images.iter().any(|seen| seen == &tag) {
+				images.push(tag);
 			}
 		}
-		Ok(())
+		crate::ui::progress::begin(
+			images
+				.iter()
+				.map(|image| (crate::ui::progress::Kind::Image, image.clone())),
+		);
+
+		let result = async {
+			for name in &names {
+				let service = &file.services[name];
+				if service.build.is_some() {
+					self.build_service(name, service, file, opts).await?;
+				}
+			}
+			Ok(())
+		}
+		.await;
+
+		// Close the board on every exit, the way `pull_services_with_options`
+		// and `run_up` do. The live region hides the cursor, so an early
+		// return through it would leave the terminal without a caret. `end`
+		// is idempotent.
+		crate::ui::progress::end();
+		result
 	}
 
 	pub(super) async fn build_service(
@@ -495,23 +537,73 @@ impl Engine {
 		};
 		let mut stream = crate::libpod::parse_json_lines::<BuildOutput>(resp.into_body());
 
+		// Open the board row for this image before the first `STEP` line, so
+		// the row's `Building` verb is what the reader sees while the stream
+		// arrives. `progress::start` is a no-op when the board already had
+		// the row seeded (`build_all_with_options` did this for a standalone
+		// `build`), and inserts it before the service's container row when
+		// `up --build` calls into a board the `up` pass opened. Either way,
+		// the row ends up with the right identifier, in the right position
+		// and with a working verb (#1681).
+		if !opts.quiet {
+			let first_container = self.replica_names(service_name, service).into_iter().next();
+			match first_container {
+				Some(container_name) => crate::ui::progress::start_anchored(
+					"Image",
+					&tag,
+					"Building",
+					Some("Container"),
+					Some(&container_name),
+				),
+				None => crate::ui::progress::start("Image", &tag, "Building"),
+			}
+		}
+
+		// The captured stream of this image: needed on a terminal failure
+		// path, where the notes buffer only kept the last 4 lines and the
+		// rest has to be replayed as scrollback so the reason is on screen.
+		// Off a terminal, every line is already in stderr through `note_for`,
+		// so this stays empty in the test runs.
+		let mut capture: Vec<String> = Vec::new();
+		// Track the last image id the stream emitted, so the success path
+		// can put it on stdout when stdout is not a terminal. Buildah
+		// closes with a `--> sha256:<64-hex>` line, which is what a script
+		// capturing stdout wants; on a terminal it is dropped (the row
+		// already says it landed). `None` until the first matching line.
+		let mut last_image_id: Option<String> = None;
+		let mut progress = BuildStreamProgress::new();
+
 		while let Some(result) = stream.next().await {
 			match result {
 				Ok(output) => {
-					// stderr, not stdout. Build output went to stdout via `print!`,
-					// which contradicted the documented promise that stdout stays
-					// a clean pipe — the one thing a caller redirecting `podup
-					// build > log` relies on, and the same promise `config` and
-					// `generate quadlet` are built around.
-					if !opts.quiet && !output.stream.is_empty() {
-						eprint!("{}", output.stream);
+					if !output.stream.is_empty() {
+						let trimmed = output.stream.trim_end().to_string();
+						if !opts.quiet && !trimmed.is_empty() {
+							// `STEP n/m:` lines advance the row verb. Every
+							// other line is a tail note, painted dimmed under
+							// the row on a terminal and prefixed on stderr in
+							// a pipe.
+							if let Some(verb) = progress.observe(&trimmed) {
+								crate::ui::progress::start("Image", &tag, &verb);
+							}
+							// The image id line is the one carry-over from
+							// today that a script reading stdout needs. It
+							// goes to notes/live as any other line, and is
+							// additionally stashed so the success path can
+							// echo it to stdout when stdout is not a tty.
+							if let Some(id) = parse_image_id_line(&trimmed) {
+								last_image_id = Some(id);
+							}
+							crate::ui::progress::note_for("Image", &tag, &trimmed);
+						}
+						capture.push(trimmed);
 					}
 					if let Some(err) = output.error_detail.and_then(|e| e.message) {
-						return Err(ComposeError::Build(err));
+						return Err(self.fail_build(&tag, err, capture, opts.quiet));
 					}
 					if let Some(err) = output.error {
 						if !err.is_empty() {
-							return Err(ComposeError::Build(err));
+							return Err(self.fail_build(&tag, err, capture, opts.quiet));
 						}
 					}
 				}
@@ -519,8 +611,52 @@ impl Engine {
 			}
 		}
 
+		// Success: close the row with `Built`. The trailing image id goes to
+		// stdout only when stdout is not a terminal, so a script reading
+		// `podup build | awk '{print $1}'` can still pluck the id; on a
+		// terminal the row says it landed and the id would only be noise.
+		if !opts.quiet {
+			crate::ui::progress_line("Image", &tag, "Built");
+		}
+		if !std::io::stdout().is_terminal() {
+			let resolved = match last_image_id {
+				Some(id) => Some(id),
+				None => match self.image_id(&tag).await {
+					Ok(Some(id)) => Some(id),
+					_ => None,
+				},
+			};
+			if let Some(id) = resolved {
+				use std::io::Write;
+				let _ = writeln!(std::io::stdout(), "{id}");
+			}
+		}
+
 		self.apply_extra_tags(build, &tag).await?;
 		Ok(())
+	}
+
+	/// Close the row as `Failed`, then on a terminal replay the full stream
+	/// as scrollback so the failure reason is on screen. In a pipe every line
+	/// has already been written by `note_for` and no replay is needed.
+	fn fail_build(
+		&self,
+		tag: &str,
+		err: String,
+		capture: Vec<String>,
+		quiet: bool,
+	) -> ComposeError {
+		if !quiet {
+			crate::ui::progress_line("Image", tag, "Failed");
+		}
+		if !quiet && std::io::stderr().is_terminal() {
+			use std::io::Write;
+			let mut out = std::io::stderr().lock();
+			for line in &capture {
+				let _ = writeln!(out, "{tag} | {line}");
+			}
+		}
+		ComposeError::Build(err)
 	}
 
 	/// Resolve `build.secrets` into `(in-tar files, secret specs)`.
@@ -602,6 +738,66 @@ impl Engine {
 	}
 }
 
+/// Whether a buildah stream line is the one that carries the new image id.
+///
+/// Buildah closes a successful build with the full image id on a line of its
+/// own: 64 hex digits, nothing else. It is the second-to-last line of the
+/// stream, between `Successfully tagged <tag>` and `Successfully built
+/// <short-id>` (measured on Podman 5.7, 2026-09-04). The `--> <short-id>`
+/// layer markers and `--> Using cache <digest>` carry a prefix and are not
+/// matched. A script reading `podup build` from a pipe wants exactly this
+/// value, and a terminal does not (#1681).
+fn parse_image_id_line(line: &str) -> Option<String> {
+	let line = line.trim();
+	if line.len() != 64 || !line.bytes().all(|b| b.is_ascii_hexdigit()) {
+		return None;
+	}
+	Some(line.to_string())
+}
+
+/// Parse one buildah stream line into the row verb it implies, if any.
+///
+/// On the libpod build stream a `STEP n/m: <instruction>` line arrives once
+/// per Dockerfile instruction: the row's verb should reflect where in the
+/// build we are. Every other line (`--> 3f3c...`, `COMMIT <tag>`,
+/// `Successfully tagged <tag>`) carries no transition of its own; those are
+/// routed through `progress::note_for` as tail lines.
+#[derive(Default)]
+struct BuildStreamProgress {
+	last_step: Option<(usize, usize)>,
+}
+
+impl BuildStreamProgress {
+	fn new() -> Self {
+		Self::default()
+	}
+
+	fn observe(&mut self, line: &str) -> Option<String> {
+		const STEP_PREFIX: &str = "STEP ";
+		let line = line.trim_end();
+		let rest = line.strip_prefix(STEP_PREFIX)?;
+		// `STEP n/m: <instruction>`. The colon separates the counters from
+		// the instruction text. Both sides must parse.
+		let (counters, _) = rest.split_once(':')?;
+		let (cur, total) = counters.split_once('/')?;
+		let cur: usize = cur.parse().ok()?;
+		let total: usize = total.parse().ok()?;
+		self.last_step = Some((cur, total));
+		Some(self.format_verb())
+	}
+
+	fn format_verb(&self) -> String {
+		match self.last_step {
+			Some((cur, total)) => format!("Building {cur}/{total}"),
+			None => "Building".to_string(),
+		}
+	}
+}
+
 #[cfg(test)]
 #[path = "build_tests.rs"]
 mod tests;
+
+#[cfg(all(test, unix))]
+#[path = "build_board_tests.rs"]
+mod board_tests;

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -8,6 +8,8 @@
 mod context;
 mod pull;
 mod push;
+mod secrets;
+mod steps;
 mod stream;
 mod tags;
 /// Shared with the `up` image-prefetch and `up`/pull decision paths so they
@@ -34,6 +36,7 @@ use crate::libpod::urlencoded;
 use crate::libpod::validate::pre_validate_build;
 use crate::libpod::API_PREFIX;
 use crate::size;
+use steps::{parse_image_id_line, BuildStreamProgress};
 
 use context::{map_additional_context, INLINE_DOCKERFILE_NAME};
 use stream::{context_body, ContextSource};
@@ -636,77 +639,6 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Close the row as `Failed`, then on a terminal replay the full stream
-	/// as scrollback so the failure reason is on screen. In a pipe every line
-	/// has already been written by `note_for` and no replay is needed.
-	fn fail_build(
-		&self,
-		tag: &str,
-		err: String,
-		capture: Vec<String>,
-		quiet: bool,
-	) -> ComposeError {
-		if !quiet {
-			crate::ui::progress_line("Image", tag, "Failed");
-		}
-		if !quiet && std::io::stderr().is_terminal() {
-			use std::io::Write;
-			let mut out = std::io::stderr().lock();
-			for line in &capture {
-				let _ = writeln!(out, "{tag} | {line}");
-			}
-		}
-		ComposeError::Build(err)
-	}
-
-	/// Resolve `build.secrets` into `(in-tar files, secret specs)`.
-	///
-	/// Each referenced top-level secret is read (from `file:`, inline `content:`,
-	/// or `environment:`) and returned as a `(tar-entry-name, bytes)` pair plus a
-	/// matching `id=NAME,src=ENTRY` spec for the build endpoint's `secrets` param.
-	/// `external` secrets cannot be forwarded over the API and are warned + skipped.
-	fn resolve_build_secrets(
-		&self,
-		build: &BuildConfig,
-		file: &crate::compose::types::ComposeFile,
-	) -> Result<ResolvedBuildSecrets> {
-		let mut files = Vec::new();
-		let mut specs = Vec::new();
-		for name in build.secrets() {
-			let Some(config) = file.secrets.get(name) else {
-				return Err(ComposeError::Unsupported(format!(
-					"build secret '{name}' is not defined in the top-level secrets section"
-				)));
-			};
-			let bytes: Vec<u8> = if let Some(host_path) = &config.file {
-				// Read through the bounded reader so a hostile or accidentally
-				// huge secret file is capped at MAX_FILE_BYTES like every other
-				// file read, rather than allocating an unbounded buffer.
-				crate::filesystem::read_capped(self.base_dir.join(host_path))
-					.map_err(ComposeError::Io)?
-			} else if let Some(content) = &config.content {
-				content.clone().into_bytes()
-			} else if let Some(env_var) = &config.environment {
-				std::env::var(env_var)
-					.map_err(|_| {
-						ComposeError::Unsupported(format!(
-							"build secret '{name}' references env var '{env_var}' which is not set"
-						))
-					})?
-					.into_bytes()
-			} else if config.external == Some(true) {
-				warn!("build secret '{name}' is external; cannot forward over the libpod build API — skipping");
-				continue;
-			} else {
-				continue;
-			};
-			let entry = format!(".podup-build-secret-{name}");
-			specs.push(format!("id={name},src={entry}"));
-			files.push((entry, bytes));
-		}
-		Ok((files, specs))
-	}
-
 	/// Apply any `build.tags` aliases to the freshly built image.
 	///
 	/// The primary `tag` is skipped: when no `image:` is set it is already
@@ -735,62 +667,6 @@ impl Engine {
 				.map_err(ComposeError::Podman)?;
 		}
 		Ok(())
-	}
-}
-
-/// Whether a buildah stream line is the one that carries the new image id.
-///
-/// Buildah closes a successful build with the full image id on a line of its
-/// own: 64 hex digits, nothing else. It is the second-to-last line of the
-/// stream, between `Successfully tagged <tag>` and `Successfully built
-/// <short-id>` (measured on Podman 5.7, 2026-09-04). The `--> <short-id>`
-/// layer markers and `--> Using cache <digest>` carry a prefix and are not
-/// matched. A script reading `podup build` from a pipe wants exactly this
-/// value, and a terminal does not (#1681).
-fn parse_image_id_line(line: &str) -> Option<String> {
-	let line = line.trim();
-	if line.len() != 64 || !line.bytes().all(|b| b.is_ascii_hexdigit()) {
-		return None;
-	}
-	Some(line.to_string())
-}
-
-/// Parse one buildah stream line into the row verb it implies, if any.
-///
-/// On the libpod build stream a `STEP n/m: <instruction>` line arrives once
-/// per Dockerfile instruction: the row's verb should reflect where in the
-/// build we are. Every other line (`--> 3f3c...`, `COMMIT <tag>`,
-/// `Successfully tagged <tag>`) carries no transition of its own; those are
-/// routed through `progress::note_for` as tail lines.
-#[derive(Default)]
-struct BuildStreamProgress {
-	last_step: Option<(usize, usize)>,
-}
-
-impl BuildStreamProgress {
-	fn new() -> Self {
-		Self::default()
-	}
-
-	fn observe(&mut self, line: &str) -> Option<String> {
-		const STEP_PREFIX: &str = "STEP ";
-		let line = line.trim_end();
-		let rest = line.strip_prefix(STEP_PREFIX)?;
-		// `STEP n/m: <instruction>`. The colon separates the counters from
-		// the instruction text. Both sides must parse.
-		let (counters, _) = rest.split_once(':')?;
-		let (cur, total) = counters.split_once('/')?;
-		let cur: usize = cur.parse().ok()?;
-		let total: usize = total.parse().ok()?;
-		self.last_step = Some((cur, total));
-		Some(self.format_verb())
-	}
-
-	fn format_verb(&self) -> String {
-		match self.last_step {
-			Some((cur, total)) => format!("Building {cur}/{total}"),
-			None => "Building".to_string(),
-		}
 	}
 }
 

--- a/internal/engine/build/pull_board_tests.rs
+++ b/internal/engine/build/pull_board_tests.rs
@@ -208,7 +208,7 @@ fn a_retried_blob_is_counted_once() {
 ///
 /// Driving this through the fake Podman (and not by mocking the parser) is
 /// what pins the gate in pull.rs and not somewhere inside
-/// `internal/ui/progress/`, which is what the brief asked for.
+/// `internal/ui/progress/`, which is where the contract belongs.
 #[tokio::test]
 async fn a_piped_pull_prints_only_pulling_and_pulled() {
 	// Each chunk is the wire form of one `ImagePullProgress` event, which is a

--- a/internal/engine/build/secrets.rs
+++ b/internal/engine/build/secrets.rs
@@ -1,0 +1,62 @@
+//! `build.secrets` as the build endpoint wants them.
+//!
+//! Each referenced top-level secret becomes a file inside the context tar and
+//! an `id=NAME,src=ENTRY` spec for the endpoint's `secrets` parameter, so the
+//! Dockerfile's `RUN --mount=type=secret,id=NAME` finds it. `external` secrets
+//! cannot be forwarded over the API and are warned about and skipped.
+use tracing::warn;
+
+use super::ResolvedBuildSecrets;
+use crate::compose::types::BuildConfig;
+use crate::engine::Engine;
+use crate::error::{ComposeError, Result};
+
+impl Engine {
+	/// Resolve `build.secrets` into `(in-tar files, secret specs)`.
+	///
+	/// Each referenced top-level secret is read (from `file:`, inline `content:`,
+	/// or `environment:`) and returned as a `(tar-entry-name, bytes)` pair plus a
+	/// matching `id=NAME,src=ENTRY` spec for the build endpoint's `secrets` param.
+	/// `external` secrets cannot be forwarded over the API and are warned + skipped.
+	pub(super) fn resolve_build_secrets(
+		&self,
+		build: &BuildConfig,
+		file: &crate::compose::types::ComposeFile,
+	) -> Result<ResolvedBuildSecrets> {
+		let mut files = Vec::new();
+		let mut specs = Vec::new();
+		for name in build.secrets() {
+			let Some(config) = file.secrets.get(name) else {
+				return Err(ComposeError::Unsupported(format!(
+					"build secret '{name}' is not defined in the top-level secrets section"
+				)));
+			};
+			let bytes: Vec<u8> = if let Some(host_path) = &config.file {
+				// Read through the bounded reader so a hostile or accidentally
+				// huge secret file is capped at MAX_FILE_BYTES like every other
+				// file read, rather than allocating an unbounded buffer.
+				crate::filesystem::read_capped(self.base_dir.join(host_path))
+					.map_err(ComposeError::Io)?
+			} else if let Some(content) = &config.content {
+				content.clone().into_bytes()
+			} else if let Some(env_var) = &config.environment {
+				std::env::var(env_var)
+					.map_err(|_| {
+						ComposeError::Unsupported(format!(
+							"build secret '{name}' references env var '{env_var}' which is not set"
+						))
+					})?
+					.into_bytes()
+			} else if config.external == Some(true) {
+				warn!("build secret '{name}' is external; cannot forward over the libpod build API — skipping");
+				continue;
+			} else {
+				continue;
+			};
+			let entry = format!(".podup-build-secret-{name}");
+			specs.push(format!("id={name},src={entry}"));
+			files.push((entry, bytes));
+		}
+		Ok((files, specs))
+	}
+}

--- a/internal/engine/build/steps.rs
+++ b/internal/engine/build/steps.rs
@@ -1,0 +1,93 @@
+//! What the buildah stream says, read line by line.
+//!
+//! The libpod build endpoint answers with buildah's own output, one JSON line
+//! per text line. Three shapes matter to the board: `STEP n/m: <instruction>`,
+//! which moves the image row's verb; the bare 64-hex image id buildah prints
+//! after `Successfully tagged`, which a script reading `build` from a pipe
+//! wants on stdout; and the failure path, where the stream a terminal folded
+//! away is replayed once so the reason is on screen (#1681).
+use std::io::IsTerminal;
+
+use crate::engine::Engine;
+use crate::error::ComposeError;
+
+impl Engine {
+	/// Close the row as `Failed`, then on a terminal replay the full stream
+	/// as scrollback so the failure reason is on screen. In a pipe every line
+	/// has already been written by `note_for` and no replay is needed.
+	pub(super) fn fail_build(
+		&self,
+		tag: &str,
+		err: String,
+		capture: Vec<String>,
+		quiet: bool,
+	) -> ComposeError {
+		if !quiet {
+			crate::ui::progress_line("Image", tag, "Failed");
+		}
+		if !quiet && std::io::stderr().is_terminal() {
+			use std::io::Write;
+			let mut out = std::io::stderr().lock();
+			for line in &capture {
+				let _ = writeln!(out, "{tag} | {line}");
+			}
+		}
+		ComposeError::Build(err)
+	}
+}
+
+/// Whether a buildah stream line is the one that carries the new image id.
+///
+/// Buildah closes a successful build with the full image id on a line of its
+/// own: 64 hex digits, nothing else. It is the second-to-last line of the
+/// stream, between `Successfully tagged <tag>` and `Successfully built
+/// <short-id>` (measured on Podman 5.7, 2026-09-04). The `--> <short-id>`
+/// layer markers and `--> Using cache <digest>` carry a prefix and are not
+/// matched. A script reading `podup build` from a pipe wants exactly this
+/// value, and a terminal does not (#1681).
+pub(super) fn parse_image_id_line(line: &str) -> Option<String> {
+	let line = line.trim();
+	if line.len() != 64 || !line.bytes().all(|b| b.is_ascii_hexdigit()) {
+		return None;
+	}
+	Some(line.to_string())
+}
+
+/// Parse one buildah stream line into the row verb it implies, if any.
+///
+/// On the libpod build stream a `STEP n/m: <instruction>` line arrives once
+/// per Dockerfile instruction: the row's verb should reflect where in the
+/// build we are. Every other line (`--> 3f3c...`, `COMMIT <tag>`,
+/// `Successfully tagged <tag>`) carries no transition of its own; those are
+/// routed through `progress::note_for` as tail lines.
+#[derive(Default)]
+pub(super) struct BuildStreamProgress {
+	last_step: Option<(usize, usize)>,
+}
+
+impl BuildStreamProgress {
+	pub(super) fn new() -> Self {
+		Self::default()
+	}
+
+	pub(super) fn observe(&mut self, line: &str) -> Option<String> {
+		const STEP_PREFIX: &str = "STEP ";
+		let line = line.trim_end();
+		let rest = line.strip_prefix(STEP_PREFIX)?;
+		// `STEP n/m: <instruction>`. The colon separates the counters from
+		// the instruction text. Both sides must parse.
+		let (counters, _) = rest.split_once(':')?;
+		let (cur, total) = counters.split_once('/')?;
+		let cur: usize = cur.parse().ok()?;
+		let total: usize = total.parse().ok()?;
+		self.last_step = Some((cur, total));
+		Some(self.format_verb())
+	}
+
+	fn format_verb(&self) -> String {
+		match self.last_step {
+			Some((cur, total)) => format!("Building {cur}/{total}"),
+			None => "Building".to_string(),
+		}
+	}
+}

--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -180,6 +180,13 @@ async fn serve_one(
 	// bytes after the header terminator reaches the end of the request. A
 	// missing or non-numeric header leaves the body empty, which is what every
 	// pre-existing test relied on.
+	//
+	// When the client does not know the body size up front, `post_stream_body`
+	// (`POST /libpod/build` and the build-context tar), hyper falls back to
+	// `Transfer-Encoding: chunked` and the wire shape is a sequence of
+	// `<hex-len>\r\n<bytes>\r\n` blocks ending in `0\r\n\r\n`. The pre-existing
+	// tests never exercised that path; `build` (#1681) does, and needs the
+	// fake to read it so the body can complete and the response head can fly.
 	let content_length: Option<usize> = head
 		.lines()
 		.find_map(|l| {
@@ -187,31 +194,40 @@ async fn serve_one(
 				.or_else(|| l.strip_prefix("content-length: "))
 		})
 		.and_then(|v| v.trim().parse::<usize>().ok());
-	let body = match content_length {
-		Some(n) if n > 0 => {
-			// Drain the bytes already read past the header terminator.
-			let head_end = head.find("\r\n\r\n").map(|i| i + 4).unwrap_or(buf.len());
-			let already = buf.len() - head_end;
-			let mut body = Vec::with_capacity(n);
-			if already >= n {
-				body.extend_from_slice(&buf[head_end..head_end + n]);
-			} else {
-				body.extend_from_slice(&buf[head_end..]);
-				let mut remaining = n - body.len();
-				let mut tail = [0u8; 1024];
-				while remaining > 0 {
-					let take = remaining.min(tail.len());
-					let n = stream.read(&mut tail[..take]).await?;
-					if n == 0 {
-						break;
+	let chunked = head
+		.lines()
+		.any(|l| l.eq_ignore_ascii_case("transfer-encoding: chunked"));
+	let head_end = head.find("\r\n\r\n").map(|i| i + 4).unwrap_or(buf.len());
+	let body = if chunked {
+		let mut body = Vec::new();
+		read_chunked_body(&mut stream, &buf[head_end..], &mut body).await?;
+		body
+	} else {
+		match content_length {
+			Some(n) if n > 0 => {
+				// Drain the bytes already read past the header terminator.
+				let already = buf.len() - head_end;
+				let mut body = Vec::with_capacity(n);
+				if already >= n {
+					body.extend_from_slice(&buf[head_end..head_end + n]);
+				} else {
+					body.extend_from_slice(&buf[head_end..]);
+					let mut remaining = n - body.len();
+					let mut tail = [0u8; 1024];
+					while remaining > 0 {
+						let take = remaining.min(tail.len());
+						let n = stream.read(&mut tail[..take]).await?;
+						if n == 0 {
+							break;
+						}
+						body.extend_from_slice(&tail[..n]);
+						remaining -= n;
 					}
-					body.extend_from_slice(&tail[..n]);
-					remaining -= n;
 				}
+				body
 			}
-			body
+			_ => Vec::new(),
 		}
-		_ => Vec::new(),
 	};
 
 	requests.lock().unwrap().push(format!("{method} {target}"));
@@ -282,4 +298,75 @@ async fn write_chunked(stream: &mut UnixStream, chunks: &[String]) -> std::io::R
 			.await?;
 	}
 	stream.flush().await
+}
+
+/// Read a `Transfer-Encoding: chunked` request body into `out`. `prefix` is
+/// whatever was already in the read buffer past the `\r\n\r\n` header
+/// terminator; the rest comes off the socket. Walks the chunked wire shape
+/// until the zero-length terminator, appending each chunk's payload bytes to
+/// `out` and ignoring the chunk-extension / trailer framing the client is
+/// allowed to send.
+async fn read_chunked_body(
+	stream: &mut UnixStream,
+	prefix: &[u8],
+	out: &mut Vec<u8>,
+) -> std::io::Result<()> {
+	let mut buf: Vec<u8> = prefix.to_vec();
+	loop {
+		// Pull enough bytes to find the next `\r\n`, which terminates a chunk
+		// size header. Hyper's StreamBody emits short chunks (one frame per
+		// mpsc receive), so a 4 KiB read window is plenty.
+		while !buf.windows(2).any(|w| w == b"\r\n") {
+			let mut tmp = [0u8; 4096];
+			let read = stream.read(&mut tmp).await?;
+			if read == 0 {
+				return Ok(());
+			}
+			buf.extend_from_slice(&tmp[..read]);
+		}
+		let nl = buf.windows(2).position(|w| w == b"\r\n").unwrap();
+		let size_line = std::str::from_utf8(&buf[..nl])
+			.map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+		// Chunk extensions (`name=value;name=value`) are legal; split off the
+		// size token at the first `;`. We do not act on any extension.
+		let size_tok = size_line.split(';').next().unwrap_or("").trim();
+		let size: usize = match usize::from_str_radix(size_tok, 16) {
+			Ok(n) => n,
+			Err(_) => {
+				return Err(std::io::Error::new(
+					std::io::ErrorKind::InvalidData,
+					format!("invalid chunk size '{size_tok}'"),
+				));
+			}
+		};
+		// Drop the size line; what remains starts at the chunk's payload (or
+		// at the next chunk's size header if `size == 0`).
+		buf.drain(..nl + 2);
+		if size == 0 {
+			// Trailing `\r\n` is optional in HTTP/1.1; consume what the
+			// client sent (one or two bytes) and stop.
+			while buf.len() < 2 {
+				let mut tmp = [0u8; 2];
+				let read = stream.read(&mut tmp).await?;
+				if read == 0 {
+					break;
+				}
+				buf.extend_from_slice(&tmp[..read]);
+			}
+			buf.drain(..buf.len().min(2));
+			return Ok(());
+		}
+		// Make sure we have the full chunk (and its trailing CRLF) in `buf`,
+		// pulling more bytes if needed.
+		while buf.len() < size + 2 {
+			let mut tmp = [0u8; 4096];
+			let read = stream.read(&mut tmp).await?;
+			if read == 0 {
+				return Ok(());
+			}
+			buf.extend_from_slice(&tmp[..read]);
+		}
+		out.extend_from_slice(&buf[..size]);
+		buf.drain(..size + 2);
+	}
 }

--- a/internal/engine/lifecycle/images_tests.rs
+++ b/internal/engine/lifecycle/images_tests.rs
@@ -1,5 +1,6 @@
 use crate::engine::fake_podman;
 use crate::engine::Engine;
+use crate::ui::progress::capture::Capture;
 
 fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
@@ -151,5 +152,107 @@ async fn image_already_seen_present_rejects_an_unknown_pull_policy() {
 			}) if service == "web" && field == "pull_policy" && value == "alaways"
 		),
 		"unknown pull_policy must surface as a Field error naming the offending service and value, got {err:?}"
+	);
+}
+
+/// `up` against a service whose image is missing builds it as part of the
+/// `up` board, not before it. The image row appears inside the same board
+/// `up` already drew, with the working verb `Building` and the closing
+/// verb `Built`, before the container rows that depend on it. Before
+/// #1681 the stream landed before the board started, so nothing said
+/// which service was being built or how long it took.
+#[tokio::test]
+async fn up_with_a_missing_image_builds_on_the_same_board() {
+	let chunks = vec![
+		"{\"stream\":\"STEP 1/2: FROM docker.io/library/alpine:3.20\\n\"}\n".to_string(),
+		"{\"stream\":\"--> 3f3c8b769775\\n\"}\n".to_string(),
+		"{\"stream\":\"STEP 2/2: CMD [\\\"echo\\\",\\\"hi\\\"]\\n\"}\n".to_string(),
+		"{\"stream\":\"--> 9f3c8b769775\\n\"}\n".to_string(),
+		"{\"stream\":\"COMMIT localhost/ux-up-build:1\\n\"}\n".to_string(),
+		"{\"stream\":\"--> sha256:1111111111111111111111111111111111111111111111111111111111111111\\n\"}\n".to_string(),
+		"{\"stream\":\"Successfully tagged localhost/ux-up-build:1\\n\"}\n".to_string(),
+	];
+	// The image is missing locally (the inspect probe returns 404), so
+	// `acquire_service_image` decides to build. The fake answers `/build`
+	// with the canned stream and answers the post-build `/tag` call so the
+	// extra-tags step succeeds; everything else 404s so the test can read
+	// what was actually called.
+	let fake = crate::engine::fake_podman::start_replying(move |method, target| {
+		if method == "POST" && target.contains("/build?") {
+			crate::engine::fake_podman::FakeReply::ChunkedEnd(chunks.clone())
+		} else if method == "POST" && target.contains("/images/") && target.contains("/tag") {
+			crate::engine::fake_podman::FakeReply::Body(200, String::new())
+		} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+			// Image absent: the missing-policy branch takes the build path.
+			crate::engine::fake_podman::FakeReply::Body(
+				404,
+				r#"{"message":"no such image"}"#.to_string(),
+			)
+		} else if method == "GET" && target.contains("/containers/json") {
+			crate::engine::fake_podman::FakeReply::Body(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/containers/create") {
+			crate::engine::fake_podman::FakeReply::Body(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			crate::engine::fake_podman::FakeReply::Body(200, String::new())
+		} else {
+			crate::engine::fake_podman::FakeReply::Body(
+				404,
+				r#"{"message":"not found"}"#.to_string(),
+			)
+		}
+	});
+
+	// A real context directory on disk: `acquire_service_image` calls
+	// `build_service`, which inspects the path before posting.
+	let ctx = tempfile::tempdir().expect("tempdir");
+	std::fs::write(
+		ctx.path().join("Dockerfile"),
+		b"FROM docker.io/library/alpine:3.20\nCMD [\"echo\",\"hi\"]\n",
+	)
+	.expect("write Dockerfile");
+	let mut engine = Engine::with_base_dir(fake.client(), "proj".into(), ctx.path().to_path_buf());
+	engine.no_warn = true;
+	let compose = crate::parse_str(
+		"services:\n  app:\n    image: localhost/ux-up-build:1\n    build:\n      context: .\n    command: [\"echo\",\"hi\"]\n",
+	)
+	.unwrap();
+
+	let capture = Capture::start();
+	engine
+		.up_with_options(&compose, true, &[], &[], false, false, false)
+		.await
+		.expect("an up that builds its missing image succeeds");
+
+	// The image row's `start_anchored` lands before the container row's
+	// first event, which is the order signal the renderer sees: an `up`
+	// that builds its missing image paints the image row above the
+	// container rows that depend on it. We rely on Capture's per-thread
+	// event log rather than the global session so this test stays
+	// independent of the progress-enabled toggle.
+	let verbs = capture.verbs();
+	let first_image_idx = verbs
+		.iter()
+		.position(|(_, n, _)| n == "localhost/ux-up-build:1");
+	let first_container_idx = verbs.iter().position(|(_, n, _)| n == "proj-app-1");
+	assert!(
+		first_image_idx.is_some() && first_container_idx.is_some(),
+		"both rows see events on the up board: {verbs:?}"
+	);
+	assert!(
+		first_image_idx.unwrap() < first_container_idx.unwrap(),
+		"the image row's first event is before the container row's first: {verbs:?}"
+	);
+	assert!(
+		verbs
+			.iter()
+			.any(|(_, n, v)| n == "localhost/ux-up-build:1" && v == "Building")
+			&& verbs
+				.iter()
+				.any(|(_, n, v)| n == "localhost/ux-up-build:1" && v == "Built"),
+		"the image row went Building -> Built on the same board: {verbs:?}"
+	);
+	assert!(
+		capture.every_board_ended(),
+		"the board closes on the way out, even with a build"
 	);
 }

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 /// What kind of thing a row is about. The noun printed in the first column, and
 /// the same vocabulary `progress_line` has always used.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Kind {
 	/// A compose network, project-scoped unless declared `external`.
 	Network,
@@ -96,9 +96,9 @@ impl Row {
 
 /// Every resource one command is working through, in the order it was seeded.
 ///
-/// Seeded up front rather than grown as events arrive: a board whose rows appear
-/// one at a time is a transcript with extra steps, and the whole point is to
-/// show what is still to come.
+/// Seeded up front rather than grown as events arrive: a board whose rows is
+/// grown from those events is a transcript with extra steps, and the whole
+/// point is to show what is still to come.
 #[derive(Debug, Default)]
 pub struct Board {
 	rows: Vec<Row>,
@@ -106,6 +106,19 @@ pub struct Board {
 	/// drawn once and never repainted. Counted from the front: rows leave the
 	/// live region in order.
 	flushed: usize,
+}
+
+/// The position a row was inserted at.
+///
+/// Returned by [`Board::start`] and the related variants so the engine can
+/// tell, when it needs to, whether it just created the row or found it
+/// already seeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertedAt {
+	/// The row already existed; the index it sits at in `rows`.
+	Existing(usize),
+	/// The row was just appended; its new index.
+	Appended(usize),
 }
 
 impl Board {
@@ -131,20 +144,75 @@ impl Board {
 	/// and a compose file can grow a container the seed did not predict (an
 	/// implicit `_default` network, a `--scale` override). Losing the row would
 	/// be worse than a board that grows by one.
-	pub fn start(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
-		let idx = self.index_of(kind, name).unwrap_or_else(|| {
-			self.rows.push(Row {
+	pub fn start(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) -> InsertedAt {
+		if let Some(idx) = self.index_of(kind, name) {
+			let row = &mut self.rows[idx];
+			row.state = State::Working(verb.to_string());
+			row.started.get_or_insert(now);
+			return InsertedAt::Existing(idx);
+		}
+		self.rows.push(Row {
+			kind,
+			name: name.to_string(),
+			state: State::Working(verb.to_string()),
+			started: Some(now),
+			elapsed: None,
+		});
+		InsertedAt::Appended(self.rows.len() - 1)
+	}
+
+	/// Mark a resource as being worked on, **inserting** a new row in front
+	/// of `anchor` rather than appending it. Used by the `up` build path: the
+	/// container rows are already seeded in front of the image row, so a
+	/// plain `start` would put the image row *after* them, and the reader
+	/// would see `Container … Starting` before the `Building` row that says
+	/// which image is being built. A row that is already at or before the
+	/// anchor is left alone, so this is also safe to call more than once.
+	pub fn start_before(
+		&mut self,
+		anchor_kind: Kind,
+		anchor_name: &str,
+		kind: Kind,
+		name: &str,
+		verb: &str,
+		now: Instant,
+	) -> InsertedAt {
+		let anchor_idx = self
+			.index_of(anchor_kind, anchor_name)
+			.unwrap_or(self.rows.len());
+		if let Some(idx) = self.index_of(kind, name) {
+			// Already on the board. If it sits at or before the anchor, the
+			// order is already right and we only need to flip its state.
+			if idx <= anchor_idx {
+				let row = &mut self.rows[idx];
+				row.state = State::Working(verb.to_string());
+				row.started.get_or_insert(now);
+				return InsertedAt::Existing(idx);
+			}
+			// Behind the anchor: lift the row to just before the anchor so
+			// the image reads as the prerequisite of the container it lives
+			// for.
+			let row = self.rows.remove(idx);
+			let insert_at = anchor_idx.min(self.rows.len());
+			self.rows.insert(insert_at, row);
+			let row = &mut self.rows[insert_at];
+			row.state = State::Working(verb.to_string());
+			row.started.get_or_insert(now);
+			return InsertedAt::Existing(insert_at);
+		}
+		// Not on the board yet. Insert a fresh row just before the anchor.
+		let insert_at = anchor_idx.min(self.rows.len());
+		self.rows.insert(
+			insert_at,
+			Row {
 				kind,
 				name: name.to_string(),
-				state: State::Pending,
-				started: None,
+				state: State::Working(verb.to_string()),
+				started: Some(now),
 				elapsed: None,
-			});
-			self.rows.len() - 1
-		});
-		let row = &mut self.rows[idx];
-		row.state = State::Working(verb.to_string());
-		row.started.get_or_insert(now);
+			},
+		);
+		InsertedAt::Appended(insert_at)
 	}
 
 	/// Mark a resource as finished. Also tolerates a resource that was never

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -11,6 +11,8 @@
 //! Everything goes to stderr. stdout stays a clean pipe, which is what lets
 //! `run -d` keep printing its container id there.
 
+use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::time::Instant;
 
@@ -22,6 +24,14 @@ mod row;
 
 pub use board::{Board, Kind, Row, State};
 pub use live::{Region, Target};
+
+/// How many stream lines a row keeps under itself when it is being built.
+/// Tuned by reading a real buildah stream: the last few lines are the layer
+/// hash, the `--> running step` markers and the `COMMIT` line, which is the
+/// shape a reader needs to tell where the build is. Five or more drowns the
+/// row; three loses the layer hash before the next step lands; four is the
+/// narrowest window that keeps both.
+const MAX_NOTES_PER_ROW: usize = 4;
 
 /// How often the region repaints while nothing is happening, so the spinner
 /// turns during a long pull instead of looking like a hang. The same cadence
@@ -57,6 +67,11 @@ struct Session {
 	/// Width of the name column, sized from the seeded rows so it does not jump
 	/// as rows come and go.
 	name_width: usize,
+	/// Per-row stream tail, kept only while a row is being built. On a terminal
+	/// these are the dimmed lines painted under the row; in a pipe they are
+	/// written through the plain sink as they arrive. Cleared when the row
+	/// finishes: the row itself, plus its closing verb, is the record.
+	notes: HashMap<(Kind, String), VecDeque<String>>,
 }
 
 /// Whether the live tail region is allowed at all.
@@ -130,6 +145,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 			region,
 			frame: 0,
 			name_width,
+			notes: HashMap::new(),
 		});
 	}
 	// The flag goes up *after* the session is installed: a `finish` racing the
@@ -149,6 +165,23 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 /// This is the event the tree could not previously produce: every one of the 21
 /// existing progress sites fires once the work is already over.
 pub fn start(kind: &str, name: &str, verb: &str) {
+	start_anchored(kind, name, verb, None, None);
+}
+
+/// As [`start`], but insert the row in front of `anchor_kind, anchor_name`
+/// rather than appending it. The `up` build path uses this so the image row
+/// sits before the container rows that depend on it; a plain `start` would
+/// put it after them, and the reader would see the container starting before
+/// the row that says which image is being built.
+///
+/// `None` for either anchor argument falls back to plain `start` semantics.
+pub fn start_anchored(
+	kind: &str,
+	name: &str,
+	verb: &str,
+	anchor_kind: Option<&str>,
+	anchor_name: Option<&str>,
+) {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return;
 	};
@@ -158,13 +191,28 @@ pub fn start(kind: &str, name: &str, verb: &str) {
 	// test-only, compiled out of a release build entirely.
 	#[cfg(test)]
 	capture::record_start(kind, name, verb);
+	let anchor = match (anchor_kind, anchor_name) {
+		(Some(k), Some(n)) => Kind::from_noun(k).map(|ak| (ak, n.to_string())),
+		_ => None,
+	};
 	let sink = {
 		let Ok(mut slot) = SESSION.lock() else {
 			return;
 		};
 		match slot.as_mut() {
 			Some(session) => {
-				session.board.start(kind, name, verb, Instant::now());
+				if let Some((anchor_kind, anchor_name)) = anchor {
+					session.board.start_before(
+						anchor_kind,
+						&anchor_name,
+						kind,
+						name,
+						verb,
+						Instant::now(),
+					);
+				} else {
+					session.board.start(kind, name, verb, Instant::now());
+				}
 				if session.region.is_some() {
 					Sink::Live
 				} else {
@@ -175,6 +223,91 @@ pub fn start(kind: &str, name: &str, verb: &str) {
 		}
 	};
 	emit(sink, kind, name, verb);
+}
+
+/// Hand one line of a row's stream output to the renderer.
+///
+/// On a live terminal the line is appended to the per-row tail kept under the
+/// row (capped at [`MAX_NOTES_PER_ROW`]), then the region is repainted so the
+/// dimmed line shows under the row. In a pipe or whenever the session has no
+/// region the same call writes `<name> | <line>` to stderr directly, so a
+/// redirected stderr still sees every stream line, prefixed the way the
+/// `logs` command prefixes container output.
+///
+/// The transition is decided once, here, by the same predicate `start` uses:
+/// `live_terminal()` is consulted at `begin` and the result is cached, so a
+/// live session always has a region, and a non-live session never does. That
+/// keeps the decision in lockstep with the rest of the renderer; a divergent
+/// decision here would let a live run leak stream lines to stderr and a
+/// piped run paint dimmed notes on a sink that does not exist.
+///
+/// Empty lines and lines that trim to empty are skipped: a buildah stream that
+/// emits `\n` between blocks would otherwise fill the tail with blanks and
+/// push the meaningful lines off the end.
+pub fn note_for(kind: &str, name: &str, line: &str) {
+	let Some(kind) = Kind::from_noun(kind) else {
+		return;
+	};
+	let trimmed = line.trim();
+	if trimmed.is_empty() {
+		return;
+	}
+	let sink = {
+		let Ok(mut slot) = SESSION.lock() else {
+			return;
+		};
+		match slot.as_mut() {
+			Some(session) => {
+				if session.region.is_some() {
+					push_note_live(&mut session.notes, kind, name, trimmed);
+					Sink::Live
+				} else {
+					Sink::Plain
+				}
+			}
+			None => Sink::None,
+		}
+	};
+	match sink {
+		Sink::Live => repaint(),
+		Sink::Plain | Sink::None => {
+			if !super::progress_enabled() {
+				return;
+			}
+			use std::io::Write;
+			let _ = writeln!(anstream::stderr(), "{name} | {trimmed}");
+		}
+	}
+}
+
+/// Push one line into a row's tail, keeping only the last [`MAX_NOTES_PER_ROW`]
+/// lines. Split out of [`note_for`] so the trim/append/pop-front logic is
+/// reachable from a test without first opening a live region, which the
+/// cargo-test runner cannot give us.
+fn push_note_live(
+	notes: &mut HashMap<(Kind, String), VecDeque<String>>,
+	kind: Kind,
+	name: &str,
+	trimmed: &str,
+) {
+	let tail = notes.entry((kind, name.to_string())).or_default();
+	tail.push_back(trimmed.to_string());
+	while tail.len() > MAX_NOTES_PER_ROW {
+		tail.pop_front();
+	}
+}
+
+#[cfg(test)]
+pub(crate) const MAX_NOTES_PER_ROW_FOR_TESTS: usize = MAX_NOTES_PER_ROW;
+
+#[cfg(test)]
+pub(crate) fn push_note_live_for_tests(
+	notes: &mut HashMap<(Kind, String), VecDeque<String>>,
+	kind: Kind,
+	name: &str,
+	trimmed: &str,
+) {
+	push_note_live(notes, kind, name, trimmed);
 }
 
 /// The plain-sink buffer for transitional verbs that have not yet been
@@ -371,6 +504,10 @@ pub(super) fn finish(kind: &str, name: &str, verb: &str) -> bool {
 		match slot.as_mut() {
 			Some(session) => {
 				session.board.finish(kind, name, verb, Instant::now());
+				// Drop the per-row stream tail: the row is closing, and the
+				// dimmed lines under it would otherwise linger as the next
+				// repaint's noise. A finished row keeps no shadow.
+				session.notes.remove(&(kind, name.to_string()));
 				if session.region.is_some() {
 					Sink::Live
 				} else {
@@ -422,6 +559,12 @@ pub fn end() {
 		if let Some(region) = session.region.as_ref() {
 			region.close_out();
 		}
+		// Drop every per-row stream tail. The session is gone; the VecDeques
+		// go with it. Belt-and-braces: `finish` already clears each row's
+		// notes as it closes, so anything still in the map here belongs to a
+		// row that closed without a `finish`, and would otherwise linger as
+		// garbage the next test picks up.
+		drop(session.notes);
 	}
 	// Flush any buffered transitional verbs that never received a final one.
 	// The plain sink is the only one that buffers, but `end` is the right place
@@ -440,7 +583,12 @@ fn repaint() {
 	};
 	let frame = session.frame;
 	let name_width = session.name_width;
-	let Session { board, region, .. } = session;
+	let Session {
+		board,
+		region,
+		notes,
+		..
+	} = session;
 	let Some(region) = region.as_mut() else {
 		return;
 	};
@@ -460,10 +608,17 @@ fn repaint() {
 	if !rows.is_empty() {
 		let (done, total) = board.tally();
 		lines.push(row::summary(done, total, width));
-		lines.extend(
-			rows.iter()
-				.map(|r| row::render(r, name_width, frame, now, width)),
-		);
+		for r in rows {
+			lines.push(row::render(r, name_width, frame, now, width));
+			// Per-row tail: the last few stream lines the row has produced,
+			// rendered dimmed and indented one space so they sit under the
+			// row without competing with the marker column on the next row.
+			if let Some(tail) = notes.get(&(r.kind, r.name.clone())) {
+				for line in tail.iter() {
+					lines.push(row::render_note(line, width));
+				}
+			}
+		}
 	}
 	region.show(&scrollback, &lines);
 }

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -228,7 +228,7 @@ pub fn start_anchored(
 /// Hand one line of a row's stream output to the renderer.
 ///
 /// On a live terminal the line is appended to the per-row tail kept under the
-/// row (capped at [`MAX_NOTES_PER_ROW`]), then the region is repainted so the
+/// row (capped at `MAX_NOTES_PER_ROW`), then the region is repainted so the
 /// dimmed line shows under the row. In a pipe or whenever the session has no
 /// region the same call writes `<name> | <line>` to stderr directly, so a
 /// redirected stderr still sees every stream line, prefixed the way the

--- a/internal/ui/progress/mod_tests.rs
+++ b/internal/ui/progress/mod_tests.rs
@@ -3,6 +3,17 @@ use super::width_from;
 use crate::ui::progress::row;
 use crate::ui::progress::{Kind, Row, State};
 
+/// The plain-sink tests share one process-wide session and buffer, and the
+/// test harness runs them on separate threads: without this lock two of them
+/// reset the buffer under each other and the count assertions fail on some
+/// runs (3 of 20 measured in parallel, 0 of 43 single-threaded). A poisoned
+/// lock is still a lock, so a failed test does not take the rest with it.
+static SESSION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn hold_session() -> std::sync::MutexGuard<'static, ()> {
+	SESSION_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// `window_size` answers `(rows, cols)`. Getting this backwards is invisible
 /// on a square-ish terminal and mangles every line on a normal one.
 #[test]
@@ -123,6 +134,7 @@ fn reset_plain_buffer() {
 /// pairing without touching the buffer.
 #[test]
 fn plain_sink_prints_only_the_final_verb() {
+	let _session = hold_session();
 	reset_plain_buffer();
 	// Disable colour so the renderer (and anstream::stderr) does not insert
 	// any escape sequence we would have to strip from the captured output.
@@ -159,10 +171,10 @@ fn plain_sink_prints_only_the_final_verb() {
 
 /// A transitional verb whose final never arrives is flushed at `progress::end`
 /// with the transitional verb intact, so a crash mid-way still says `Creating`
-/// in the log (#1673). The brief calls this out as the `Creating` with no end
-/// case.
+/// in the log (#1673): the `Creating` with no end case.
 #[test]
 fn plain_sink_keeps_a_transitional_verb_when_nothing_final_arrives() {
+	let _session = hold_session();
 	reset_plain_buffer();
 	let prev_progress = super::super::progress_enabled();
 	super::super::set_progress(true);
@@ -221,6 +233,7 @@ fn a_failed_row_is_printed_once() {
 /// end-to-end case through a pipe).
 #[test]
 fn only_a_no_op_final_verb_drops_the_transitional_line() {
+	let _session = hold_session();
 	for verb in ["Exists", "Running", "Absent", "Skipped"] {
 		assert!(
 			super::super::progress::is_noop_final_for_tests(verb),
@@ -235,4 +248,55 @@ fn only_a_no_op_final_verb_drops_the_transitional_line() {
 			"{verb}"
 		);
 	}
+}
+
+/// A row's stream tail keeps only the last four lines. Five lines pushed in
+/// leaves the tail holding lines 2..=5, in arrival order. That is the
+/// shape the live region paints dimmed under the row (#1681): four is the
+/// window that keeps a step's `--> <layer>` line and the `COMMIT` line on
+/// screen together at the end of a build without the region growing past
+/// what a short terminal shows.
+///
+/// Reaching the live-push path in a cargo test requires going around the
+/// terminal check that `note_for` uses to decide live vs plain: the test
+/// runner captures stderr, so `live_terminal()` is false, and a `note_for`
+/// call routes to the plain-sink stderr write instead of the tail. The
+/// internal `push_note_live` helper is the only thing that calls the
+/// append-and-trim path, so the test exercises it directly to pin the
+/// trim window.
+#[test]
+fn notes_keep_the_last_four_lines_per_row() {
+	let mut notes = std::collections::HashMap::new();
+	let mut push = |line: &str| {
+		super::super::progress::push_note_live_for_tests(
+			&mut notes,
+			Kind::Image,
+			"localhost/img:1",
+			line,
+		);
+	};
+	push("first");
+	push("second");
+	push("third");
+	push("fourth");
+	push("fifth");
+
+	let tail = notes
+		.get(&(Kind::Image, "localhost/img:1".to_string()))
+		.expect("the row's tail is populated");
+	assert_eq!(
+		tail.iter().cloned().collect::<Vec<_>>(),
+		vec![
+			"second".to_string(),
+			"third".to_string(),
+			"fourth".to_string(),
+			"fifth".to_string(),
+		],
+		"after five pushes the tail holds the last four, in order"
+	);
+	assert_eq!(
+		tail.len(),
+		super::super::progress::MAX_NOTES_PER_ROW_FOR_TESTS,
+		"the cap is enforced on every push"
+	);
 }

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -205,6 +205,26 @@ pub fn summary(done: usize, total: usize, width: usize) -> String {
 	}
 }
 
+/// A dimmed tail line painted under a working row to give the reader a peek
+/// at what the producer is currently emitting. One leading space keeps it
+/// visually under the marker column rather than butting against it, and the
+/// rest is plain text the caller has already collapsed to a single line.
+/// Truncated by character, not by escape sequence, the same way [`render`]
+/// does it.
+pub fn render_note(line: &str, width: usize) -> String {
+	let indented = format!(" {line}");
+	let trimmed = if width > 0 && indented.chars().count() > width {
+		indented.chars().take(width).collect::<String>()
+	} else {
+		indented
+	};
+	let plain = trimmed.trim_end();
+	if !stderr_colored() {
+		return plain.to_string();
+	}
+	paint(Style::new().dimmed(), plain, true)
+}
+
 #[cfg(test)]
 #[path = "row_tests.rs"]
 mod tests;

--- a/tests/build_contract.rs
+++ b/tests/build_contract.rs
@@ -1,0 +1,126 @@
+//! What `build` tells you, and where.
+//!
+//! The build half of `reporting_contract.rs`, split out when that file reached
+//! the line limit. Two promises: the image id lands on stdout when stdout is
+//! not a terminal, so a script can read it; and in a pipe every buildah line
+//! reaches stderr prefixed with the image tag, with the row's verbs in plain
+//! form and no escape sequence anywhere (#1681).
+
+mod harness;
+
+use harness::{bin, podman_up};
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+/// `build` writes its output to stderr, leaving stdout with only the new
+/// image id. The id is dropped on a terminal where the row says it landed;
+/// here, where stdout is a pipe (`Command::output` gives the child
+/// one), the id is the only line on stdout and the buildah stream lives
+/// on stderr.
+///
+/// It used `print!`, contradicting the documented promise that stdout stays
+/// pipeable — the one thing a caller redirecting `podup build > log` relies on,
+/// and the same promise `config` and `generate quadlet` are built around.
+#[tokio::test]
+async fn build_writes_the_image_id_to_stdout() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		"FROM alpine:latest\nRUN true\n",
+	)
+	.unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  tiny:\n    image: podup-build-probe:1\n    build:\n      context: .\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"-p",
+			&format!("t{}-bld", std::process::id()),
+			"build",
+		])
+		.output()
+		.expect("run podup build");
+	let stdout = String::from_utf8_lossy(&out.stdout);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	let id_line = stdout
+		.lines()
+		.find(|line| !line.is_empty())
+		.unwrap_or_else(|| panic!("build must print the image id on stdout; got:\n{stdout}"));
+	// `podman images --format '{{.ID}}'` returns the short form (12 hex chars)
+	// here; libpod's `ImageInspect` field `Id` is the full sha256 hex without
+	// the prefix. Accept either; the script that reads this just wants the id.
+	assert!(
+		id_line.chars().all(|c| c.is_ascii_hexdigit()) && (12..=64).contains(&id_line.len()),
+		"the printed line must be the image id: {id_line:?}"
+	);
+	assert!(
+		!stderr.trim().is_empty(),
+		"the build stream still goes to stderr: {stderr}"
+	);
+}
+
+/// A piped build prefixes every stream line with `<image-tag> | ` and
+/// closes with `Built`, in the same shape `logs` prefixes container output.
+/// No board, no spinner, no cursor moves; animation in a CI log is a defect.
+/// `Command::output` gives the child a pipe for stderr; that is the
+/// condition being asserted.
+#[tokio::test]
+async fn a_piped_build_prefixes_every_stream_line_with_the_service() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		"FROM docker.io/library/alpine:3.20\nRUN echo hi\n",
+	)
+	.unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  tiny:\n    image: localhost/ux-pipe-build:1\n    build:\n      context: .\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"-p",
+			&format!("t{}-bpipe", std::process::id()),
+			"build",
+		])
+		.output()
+		.expect("run podup build");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains(" Image localhost/ux-pipe-build:1  Building"),
+		"a piped build must report the working verb in plain form; got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains(" Image localhost/ux-pipe-build:1  Built"),
+		"and the closing verb in plain form; got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("localhost/ux-pipe-build:1 | STEP 1/2:"),
+		"each stream line must carry the <image-tag> | prefix: {stderr}"
+	);
+	assert!(
+		!stderr.contains('\x1b'),
+		"a pipe gets no escape sequence at all, board or otherwise; got:\n{stderr:?}"
+	);
+	for marker in ["⠿", "✔", "[+] Running"] {
+		assert!(
+			!stderr.contains(marker),
+			"a pipe gets no board furniture ({marker}); got:\n{stderr}"
+		);
+	}
+}

--- a/tests/fixtures/releases/test-sign.sh
+++ b/tests/fixtures/releases/test-sign.sh
@@ -180,9 +180,8 @@ for case in unset empty whitespace; do
 		;;
 	esac
 	[[ $rc -eq 1 ]] || fail "case $case: expected exit 1, got $rc"
-	# The distinctive fragment is the full refusal sentence. The brief
-	# asks for "refusing to publish an unsigned artifact"; assert it
-	# verbatim, not a synonym.
+	# The distinctive fragment is the full refusal sentence, "refusing to
+	# publish an unsigned artifact"; assert it verbatim, not a synonym.
 	grep -q "refusing to publish an unsigned artifact" "$stderr2" \
 		|| fail "case $case: expected 'refusing to publish an unsigned artifact' on stderr, got: $(cat "$stderr2")"
 done

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -434,61 +434,6 @@ async fn a_piped_down_gets_transitions_for_what_exists() {
 	);
 }
 
-/// `build` writes its output to stderr, leaving stdout with only the new
-/// image id. The id is dropped on a terminal where the row says it landed;
-/// here, where stdout is a pipe (`Command::output` gives the child
-/// one), the id is the only line on stdout and the buildah stream lives
-/// on stderr.
-///
-/// It used `print!`, contradicting the documented promise that stdout stays
-/// pipeable — the one thing a caller redirecting `podup build > log` relies on,
-/// and the same promise `config` and `generate quadlet` are built around.
-#[tokio::test]
-async fn build_writes_the_image_id_to_stdout() {
-	if !podman_up().await {
-		return;
-	}
-	let dir = tempdir().unwrap();
-	fs::write(
-		dir.path().join("Dockerfile"),
-		"FROM alpine:latest\nRUN true\n",
-	)
-	.unwrap();
-	let compose = dir.path().join("compose.yaml");
-	fs::write(
-		&compose,
-		"services:\n  tiny:\n    image: podup-build-probe:1\n    build:\n      context: .\n",
-	)
-	.unwrap();
-	let out = Command::new(bin())
-		.args([
-			"-f",
-			&compose.to_string_lossy(),
-			"-p",
-			&format!("t{}-bld", std::process::id()),
-			"build",
-		])
-		.output()
-		.expect("run podup build");
-	let stdout = String::from_utf8_lossy(&out.stdout);
-	let stderr = String::from_utf8_lossy(&out.stderr);
-	let id_line = stdout
-		.lines()
-		.find(|line| !line.is_empty())
-		.unwrap_or_else(|| panic!("build must print the image id on stdout; got:\n{stdout}"));
-	// `podman images --format '{{.ID}}'` returns the short form (12 hex chars)
-	// here; libpod's `ImageInspect` field `Id` is the full sha256 hex without
-	// the prefix. Accept either; the script that reads this just wants the id.
-	assert!(
-		id_line.chars().all(|c| c.is_ascii_hexdigit()) && (12..=64).contains(&id_line.len()),
-		"the printed line must be the image id: {id_line:?}"
-	);
-	assert!(
-		!stderr.trim().is_empty(),
-		"the build stream still goes to stderr: {stderr}"
-	);
-}
-
 /// `pull` reports through the progress layer, with a matching `Pulled`.
 ///
 /// It used a bare `eprintln!` — the one user-facing line in the binary that
@@ -556,63 +501,6 @@ async fn up_pulls_an_image_once() {
 		pulls <= 1,
 		"one image must produce at most one Pulling on up; got {pulls} in:\n{stderr}"
 	);
-}
-
-/// A piped build prefixes every stream line with `<image-tag> | ` and
-/// closes with `Built`, in the same shape `logs` prefixes container output.
-/// No board, no spinner, no cursor moves; animation in a CI log is a defect.
-/// `Command::output` gives the child a pipe for stderr; that is the
-/// condition being asserted.
-#[tokio::test]
-async fn a_piped_build_prefixes_every_stream_line_with_the_service() {
-	if !podman_up().await {
-		return;
-	}
-	let dir = tempdir().unwrap();
-	fs::write(
-		dir.path().join("Dockerfile"),
-		"FROM docker.io/library/alpine:3.20\nRUN echo hi\n",
-	)
-	.unwrap();
-	let compose = dir.path().join("compose.yaml");
-	fs::write(
-		&compose,
-		"services:\n  tiny:\n    image: localhost/ux-pipe-build:1\n    build:\n      context: .\n",
-	)
-	.unwrap();
-	let out = Command::new(bin())
-		.args([
-			"-f",
-			&compose.to_string_lossy(),
-			"-p",
-			&format!("t{}-bpipe", std::process::id()),
-			"build",
-		])
-		.output()
-		.expect("run podup build");
-	let stderr = String::from_utf8_lossy(&out.stderr);
-	assert!(
-		stderr.contains(" Image localhost/ux-pipe-build:1  Building"),
-		"a piped build must report the working verb in plain form; got:\n{stderr}"
-	);
-	assert!(
-		stderr.contains(" Image localhost/ux-pipe-build:1  Built"),
-		"and the closing verb in plain form; got:\n{stderr}"
-	);
-	assert!(
-		stderr.contains("localhost/ux-pipe-build:1 | STEP 1/2:"),
-		"each stream line must carry the <image-tag> | prefix: {stderr}"
-	);
-	assert!(
-		!stderr.contains('\x1b'),
-		"a pipe gets no escape sequence at all, board or otherwise; got:\n{stderr:?}"
-	);
-	for marker in ["⠿", "✔", "[+] Running"] {
-		assert!(
-			!stderr.contains(marker),
-			"a pipe gets no board furniture ({marker}); got:\n{stderr}"
-		);
-	}
 }
 
 /// A `pull` whose stderr is a pipe keeps the plain lines it always printed.

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -434,13 +434,17 @@ async fn a_piped_down_gets_transitions_for_what_exists() {
 	);
 }
 
-/// `build` writes its output to stderr, leaving stdout a clean pipe.
+/// `build` writes its output to stderr, leaving stdout with only the new
+/// image id. The id is dropped on a terminal where the row says it landed;
+/// here, where stdout is a pipe (`Command::output` gives the child
+/// one), the id is the only line on stdout and the buildah stream lives
+/// on stderr.
 ///
 /// It used `print!`, contradicting the documented promise that stdout stays
 /// pipeable — the one thing a caller redirecting `podup build > log` relies on,
 /// and the same promise `config` and `generate quadlet` are built around.
 #[tokio::test]
-async fn build_leaves_stdout_a_clean_pipe() {
+async fn build_writes_the_image_id_to_stdout() {
 	if !podman_up().await {
 		return;
 	}
@@ -467,13 +471,21 @@ async fn build_leaves_stdout_a_clean_pipe() {
 		.output()
 		.expect("run podup build");
 	let stdout = String::from_utf8_lossy(&out.stdout);
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	let id_line = stdout
+		.lines()
+		.find(|line| !line.is_empty())
+		.unwrap_or_else(|| panic!("build must print the image id on stdout; got:\n{stdout}"));
+	// `podman images --format '{{.ID}}'` returns the short form (12 hex chars)
+	// here; libpod's `ImageInspect` field `Id` is the full sha256 hex without
+	// the prefix. Accept either; the script that reads this just wants the id.
 	assert!(
-		stdout.trim().is_empty(),
-		"build must not write to stdout; got:\n{stdout}"
+		id_line.chars().all(|c| c.is_ascii_hexdigit()) && (12..=64).contains(&id_line.len()),
+		"the printed line must be the image id: {id_line:?}"
 	);
 	assert!(
-		!String::from_utf8_lossy(&out.stderr).trim().is_empty(),
-		"the build output has to go somewhere, and that somewhere is stderr"
+		!stderr.trim().is_empty(),
+		"the build stream still goes to stderr: {stderr}"
 	);
 }
 
@@ -544,6 +556,63 @@ async fn up_pulls_an_image_once() {
 		pulls <= 1,
 		"one image must produce at most one Pulling on up; got {pulls} in:\n{stderr}"
 	);
+}
+
+/// A piped build prefixes every stream line with `<image-tag> | ` and
+/// closes with `Built`, in the same shape `logs` prefixes container output.
+/// No board, no spinner, no cursor moves; animation in a CI log is a defect.
+/// `Command::output` gives the child a pipe for stderr; that is the
+/// condition being asserted.
+#[tokio::test]
+async fn a_piped_build_prefixes_every_stream_line_with_the_service() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	fs::write(
+		dir.path().join("Dockerfile"),
+		"FROM docker.io/library/alpine:3.20\nRUN echo hi\n",
+	)
+	.unwrap();
+	let compose = dir.path().join("compose.yaml");
+	fs::write(
+		&compose,
+		"services:\n  tiny:\n    image: localhost/ux-pipe-build:1\n    build:\n      context: .\n",
+	)
+	.unwrap();
+	let out = Command::new(bin())
+		.args([
+			"-f",
+			&compose.to_string_lossy(),
+			"-p",
+			&format!("t{}-bpipe", std::process::id()),
+			"build",
+		])
+		.output()
+		.expect("run podup build");
+	let stderr = String::from_utf8_lossy(&out.stderr);
+	assert!(
+		stderr.contains(" Image localhost/ux-pipe-build:1  Building"),
+		"a piped build must report the working verb in plain form; got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains(" Image localhost/ux-pipe-build:1  Built"),
+		"and the closing verb in plain form; got:\n{stderr}"
+	);
+	assert!(
+		stderr.contains("localhost/ux-pipe-build:1 | STEP 1/2:"),
+		"each stream line must carry the <image-tag> | prefix: {stderr}"
+	);
+	assert!(
+		!stderr.contains('\x1b'),
+		"a pipe gets no escape sequence at all, board or otherwise; got:\n{stderr:?}"
+	);
+	for marker in ["⠿", "✔", "[+] Running"] {
+		assert!(
+			!stderr.contains(marker),
+			"a pipe gets no board furniture ({marker}); got:\n{stderr}"
+		);
+	}
 }
 
 /// A `pull` whose stderr is a pipe keeps the plain lines it always printed.


### PR DESCRIPTION
Closes #1681.

## What changes

`podup build`, and the build `up` runs when a service's image is missing, draw one row per image on the board every other verb command already uses. The row reads `Building`, then `Building n/m` as each `STEP n/m` line arrives, then `Built` or `Failed` with the elapsed time.

On a terminal the buildah stream is folded under the row: the last four lines sit dimmed below it while it builds and vanish when the row finishes. A failed build replays its whole stream once, above the error, so the reason is on screen. In a pipe every stream line goes to stderr prefixed with the image tag, the way `logs` prefixes container output, and the verb lines are written in plain form with no escape sequence.

The image id goes to stdout only when stdout is not a terminal, so `podup build | awk '{print $1}'` still reads it; on a terminal the row is the record. Buildah emits the id as a bare 64-hex line after `Successfully tagged` (measured on Podman 5.7 today); the reader matches that line and falls back to asking libpod for the tag's id.

`up --build` runs the build board first and the `up` board after it, because `up` resolves images concurrently and a forced build inside that stage would build services in parallel, which `build` does not do. `docs/commands.md` says so.

## Measured under a pseudo-terminal (`script -qfc`)

Fresh build, deduplicated frames:

```
[+] Running 0/1
 ⠙ Image     localhost/ux-talker:1 Building 1/3   0.0s
 STEP 1/3: FROM docker.io/library/alpine:3.20
 ⠸ Image     localhost/ux-talker:1 Building 2/3   0.2s
 --> 8e66f4345325
 ⠼ Image     localhost/ux-talker:1 Building 3/3   0.3s
 COMMIT localhost/ux-talker:1
 ✔ Image     localhost/ux-talker:1 Built   0.3s
```

Failed build:

```
 ✘ Image     localhost/ux-bad:1 Failed   0.4s
localhost/ux-bad:1 | STEP 1/3: FROM docker.io/library/alpine:3.20
localhost/ux-bad:1 | STEP 2/3: RUN echo one
localhost/ux-bad:1 | one
localhost/ux-bad:1 | --> a8f9c8f333e8
localhost/ux-bad:1 | STEP 3/3: RUN false
podup: error: build error: building at STEP "RUN false": while running runtime: exit status 1
```

Piped build: stdout is the single line `3ec8da61bf44…882b`; stderr carries ` Image localhost/ux-talker:1  Building`, the prefixed stream, and ` Image localhost/ux-talker:1  Built`, with zero escape sequences. `up -d --build` shows the build board, then the network and container board. A cached rebuild reads the same rows in 0.1s.

## Tests

- `build_draws_a_row_per_image_and_counts_steps`, `a_failed_build_prints_its_stream_once_before_the_error`, `build_stream_progress_parses_a_three_step_dockerfile`, `parse_image_id_line_only_matches_the_bare_full_id` (unit, against the fake Podman).
- `up_with_a_missing_image_builds_on_the_same_board` (unit).
- `a_piped_build_prefixes_every_stream_line_with_the_service` and `build_writes_the_image_id_to_stdout` (contract, against real Podman).
- `notes_keep_the_last_four_lines_per_row` (unit).

The three plain-sink tests in the progress module share one process-wide buffer and failed 3 runs in 20 under the parallel harness; they now hold a lock, 0 in 20 after. Suite, clippy and fmt clean locally.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
