### PR TITLE
chore(release): bump to 5.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.8.0"
+version = "5.9.0"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+podup (5.9.0) unstable; urgency=medium
+
+  * Every command that acts on resources draws the live board: `up`, `down`,
+    `start`, `stop`, `restart`, `kill`, `pause`, `unpause`, `rm`, `create`,
+    `scale`, `pull`, `push` and `build`, with a working verb while a row is in
+    flight and a final verb with the elapsed time. The board survives
+    `NO_COLOR` and a narrow terminal, and in a pipe the plain lines never
+    contradict each other.
+  * `pull` counts the layers as they copy; `build` draws one row per image
+    with `Building n/m` from the builder's STEP lines, folds the builder
+    stream under the row on a terminal, replays it above the error when a
+    build fails, and in a pipe prefixes every line with the image tag and
+    prints the image id on stdout.
+  * The release reads the hardening off every binary before signing: static
+    PIE, RELRO, NX and no symbol table on Linux; ASLR, high-entropy VA, DEP and
+    Control Flow Guard on Windows, with CFG newly enabled for both MSVC
+    targets; PIE and a stripped symbol table on macOS. The windows-arm64 asset
+    is built and run on an arm64 runner.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 04 Sep 2026 10:05:09 -0500
+
 podup (5.8.0) unstable; urgency=medium
 
   * `x-podman-pod: true` at the top level puts every service of a project


### PR DESCRIPTION
Bump for the minor release carrying the live board on every verb command,
the build and pull rows, and the hardening gates for the Windows and macOS
binaries with Control Flow Guard newly enabled. Nothing existing changes
what it does; the output is what changed.

## Verified

The three version comparisons of release.yml run locally: crate=5.9.0
lock=5.9.0 deb=5.9.0, GATE OK; cargo metadata --locked accepts the
lockfile.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>