### PR TITLE
feat(cli): port names the missing binding plainly, config resolves every network name, and CREATED reads as a moment

### DIFF
--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -34,6 +34,9 @@ mod lifecycle;
 mod lock;
 mod names;
 mod network;
+/// Re-exported so `startup::config_render` (in the binary crate) can call the
+/// same function `up` uses, instead of duplicating the resolution rule.
+pub use network::resolve_network_name;
 mod pod;
 mod profiles;
 pub use profiles::{retain_active_profiles, retain_active_profiles_with_targets};

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -277,7 +277,13 @@ fn resolve_target_container_name(svc_name: &str, service: &Service, project: &st
 }
 
 /// Resolve the actual network name on the host for a compose network key.
-pub(super) fn resolve_network_name(network: &str, file: &ComposeFile, project: &str) -> String {
+///
+/// `pub` so `startup::config_render` (in the binary crate) can call the same
+/// function `up` uses, rather than duplicating the resolution rule. The rule
+/// is small but every branch (explicit `name:`, `external: true`, the
+/// `<project>_<key>` default) has a footgun if a second copy drifts. The
+/// crate-level docs (`podup::resolve_network_name`) call out the reuse intent.
+pub fn resolve_network_name(network: &str, file: &ComposeFile, project: &str) -> String {
 	match file.networks.get(network).and_then(|c| c.as_ref()) {
 		Some(cfg) => {
 			if let Some(name) = cfg.name.as_deref() {

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -4,9 +4,9 @@ use crate::compose::types::ComposeFile;
 use crate::error::{ComposeError, Result};
 use crate::libpod::types::image::ImageInspect;
 use crate::libpod::{urlencoded, API_PREFIX};
-use crate::units::{format_bytes, format_duration, DurationFormat, SizeFormat};
+use crate::units::{format_bytes, SizeFormat};
 
-use super::inspect_util::split_repo_tag;
+use super::inspect_util::{humanize_age, split_repo_tag};
 use super::Engine;
 
 /// How `images` renders a size: decimal units at three significant digits.
@@ -18,9 +18,6 @@ use super::Engine;
 /// images` rendered `1.01 GB` and `805 kB` on the same host. A fixed decimal
 /// count cannot produce all three.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
-
-/// How `images` renders an age: the shared default, three components.
-const AGE_FORMAT: DurationFormat = DurationFormat::default_parts();
 
 /// One row of the `images` table.
 ///
@@ -214,8 +211,7 @@ fn age_cell(created: &str, now: i64) -> String {
 	let Some(built) = crate::timestamp::parse_rfc3339(created) else {
 		return String::new();
 	};
-	let elapsed = now.saturating_sub(built).max(0);
-	format_duration(std::time::Duration::from_secs(elapsed as u64), &AGE_FORMAT)
+	humanize_age(now.saturating_sub(built).max(0))
 }
 
 #[cfg(test)]

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -196,8 +196,16 @@ impl Engine {
 			// and exiting 0 made `HOST=$(podup port web 80)` yield an empty string
 			// with a success status, so a script cannot tell "not published" from
 			// "published at ''". docker compose exits 1 with a message here.
-			None => Err(ComposeError::Unsupported(format!(
-				"no host binding for {service_name} port {port}/{proto}"
+			//
+			// The variant is `StreamTruncated` rather than `Unsupported` on
+			// purpose: `Unsupported` renders as `unsupported feature: ...`, the
+			// label reserved for compose features podup does not implement.
+			// "this service does not publish that port" is not such a feature,
+			// it is a property of the running service, and labelling it
+			// `unsupported feature:` read as a podup limitation. The variant
+			// renders the sentence verbatim under the CLI's own prefix (#1697).
+			None => Err(ComposeError::PortNotPublished(format!(
+				"{service_name} publishes no host port for {port}/{proto}"
 			))),
 		}
 	}

--- a/internal/engine/query/inspect_tests.rs
+++ b/internal/engine/query/inspect_tests.rs
@@ -1,4 +1,8 @@
 use super::attach_log_query;
+use crate::compose::parse_str;
+use crate::engine::fake_podman;
+use crate::engine::Engine;
+use crate::error::ComposeError;
 
 #[test]
 fn attach_query_suppresses_log_backlog() {
@@ -6,4 +10,55 @@ fn attach_query_suppresses_log_backlog() {
 	let q = attach_log_query();
 	assert!(q.contains("follow=true"), "got: {q}");
 	assert!(q.contains("tail=0"), "got: {q}");
+}
+
+#[cfg(unix)]
+fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+}
+
+/// A service with no host binding for the requested port must surface as
+/// `<service> publishes no host port for <port>/<proto>`, not as an
+/// `unsupported feature:` (which reads as a podup limitation). The variant
+/// must not be `Unsupported` either, and the message must not carry the old
+/// `no host binding for ... port ...` wording.
+#[tokio::test]
+#[cfg(unix)]
+async fn port_without_binding_reports_publishes_no_host_port() {
+	let fake = fake_podman::start(|method, target| {
+		// Container list with one running container for our service.
+		if method == "GET" && target.contains("/containers/json") {
+			(
+				200,
+				r#"[{"Id":"abc123","Names":["/talker-test-talker-1"],"Image":"alpine","State":"running","Labels":{"podup.project":"talker-test","podup.service":"talker"},"Ports":[],"Created":"2026-01-01T00:00:00Z"}]"#.to_string(),
+			)
+		// Container inspect with NO binding for 80/tcp.
+		} else if method == "GET" && target.contains("/containers/talker-test-talker-1/json") {
+			(
+				200,
+				r#"{"State":{"Status":"running"},"NetworkSettings":{"Ports":{}}}"#.to_string(),
+			)
+		} else {
+			(404, r#"{"message":"not used"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "talker-test");
+	let file = parse_str(
+		"services:\n  talker:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let err = e
+		.port_with_index(&file, "talker", "80", "tcp", None)
+		.await
+		.expect_err("a service with no host binding must error");
+	let msg = err.to_string();
+	assert_eq!(
+		msg, "talker publishes no host port for 80/tcp",
+		"the new message names the service and port: {msg}"
+	);
+	assert!(
+		matches!(err, ComposeError::PortNotPublished(_)),
+		"the message has its own variant, not Unsupported: {err:?}"
+	);
 }

--- a/internal/engine/query/inspect_tests.rs
+++ b/internal/engine/query/inspect_tests.rs
@@ -1,7 +1,12 @@
 use super::attach_log_query;
 use crate::compose::parse_str;
+// The fake Podman speaks over a unix socket and exists on unix only, like the
+// test below that drives it.
+#[cfg(unix)]
 use crate::engine::fake_podman;
+#[cfg(unix)]
 use crate::engine::Engine;
+#[cfg(unix)]
 use crate::error::ComposeError;
 
 #[test]

--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -1,8 +1,50 @@
-//! Pure helpers for `inspect`: replica/port selection, image-ref
-//! splitting, and process-table formatting. Kept free of the live Podman
-//! client so each is unit-tested in isolation.
+//! Pure helpers for `inspect` and the read-only query commands: replica/port
+//! selection, image-ref splitting, process-table formatting, and the
+//! shared "N units ago" renderer used by `ps` and `images`. Kept free of the
+//! live Podman client so each is unit-tested in isolation.
 
 use crate::error::{ComposeError, Result};
+
+/// Render an elapsed span as `N units ago`, the same wording `docker compose`
+/// uses for `ps` and `images` CREATED columns.
+///
+/// Largest unit only (so a 90-second row reads `1 minute ago`, not
+/// `1 minute 30 seconds ago`), singular at exactly one (`1 day ago`, not
+/// `1 days ago`), and `Less than a second ago` under one second, since an
+/// elapsed timer like `6s` reads as *how long since*, not *how long ago*,
+/// and the `_ago` wording is what fixes that.
+///
+/// `seconds` is clamped to zero on a negative argument (clock skew between
+/// this process and libpod is not a future age). Pure so the boundaries
+/// (`0 s`, `1 s`, `59 s`, `60 s`, `59 min`, `60 min`, `23 h`, `24 h`) are
+/// pinned without a live socket.
+pub(super) fn humanize_age(seconds: i64) -> String {
+	if seconds < 1 {
+		return "Less than a second ago".to_string();
+	}
+	let s = seconds as u64;
+	if s < 60 {
+		return format_age(s, "second");
+	}
+	if s < 3600 {
+		return format_age(s / 60, "minute");
+	}
+	if s < 86_400 {
+		return format_age(s / 3600, "hour");
+	}
+	format_age(s / 86_400, "day")
+}
+
+/// `1 second ago` at one, `N seconds ago` afterwards (same shape for
+/// minute/hour/day). Kept tiny so the singular/plural rule is a one-line
+/// change instead of a duplicated format string.
+fn format_age(n: u64, unit: &str) -> String {
+	if n == 1 {
+		format!("1 {unit} ago")
+	} else {
+		format!("{n} {unit}s ago")
+	}
+}
 
 /// Pick a service's target replica container from its live container names.
 ///

--- a/internal/engine/query/inspect_util_tests.rs
+++ b/internal/engine/query/inspect_util_tests.rs
@@ -235,3 +235,36 @@ fn running_status_detected_case_insensitively() {
 	assert!(!is_running_status("paused"));
 	assert!(!is_running_status(""));
 }
+
+/// The CREATED column of `ps` and `images` reads as `N units ago`, the same
+/// wording docker compose uses. The boundaries below are exactly the ones the
+/// issue pinned: 0 s, 1 s, 59 s, 60 s, 59 min, 60 min, 23 h, 24 h, plus a
+/// 1-vs-2 check at every unit so the singular/plural rule is also pinned.
+#[test]
+fn humanize_age_covers_the_pinned_boundaries() {
+	assert_eq!(super::humanize_age(0), "Less than a second ago");
+	assert_eq!(super::humanize_age(-3), "Less than a second ago");
+	assert_eq!(super::humanize_age(1), "1 second ago");
+	assert_eq!(super::humanize_age(2), "2 seconds ago");
+	assert_eq!(super::humanize_age(59), "59 seconds ago");
+	assert_eq!(super::humanize_age(60), "1 minute ago");
+	assert_eq!(super::humanize_age(61), "1 minute ago");
+	assert_eq!(super::humanize_age(2 * 60), "2 minutes ago");
+	assert_eq!(super::humanize_age(59 * 60), "59 minutes ago");
+	assert_eq!(super::humanize_age(60 * 60), "1 hour ago");
+	assert_eq!(super::humanize_age(60 * 60 + 1), "1 hour ago");
+	assert_eq!(super::humanize_age(2 * 60 * 60), "2 hours ago");
+	assert_eq!(super::humanize_age(23 * 60 * 60), "23 hours ago");
+	assert_eq!(super::humanize_age(24 * 60 * 60), "1 day ago");
+	assert_eq!(super::humanize_age(24 * 60 * 60 + 1), "1 day ago");
+	assert_eq!(super::humanize_age(2 * 24 * 60 * 60), "2 days ago");
+}
+
+/// The snapshot the issue was filed against: `6s` and `3m 19s` read as elapsed
+/// timers, not as points in the past. The fix uses the same wording for both
+/// columns of both commands.
+#[test]
+fn humanize_age_matches_the_docker_compose_wording() {
+	assert_eq!(super::humanize_age(6), "6 seconds ago");
+	assert_eq!(super::humanize_age(3 * 60 + 19), "3 minutes ago");
+}

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -9,6 +9,8 @@ use crate::libpod::{urlencoded, API_PREFIX};
 use super::Engine;
 use crate::units::{format_bytes, format_duration, DurationFormat, SizeFormat};
 
+use super::inspect_util::humanize_age;
+
 /// Options for [`Engine::ps_with_options`], mirroring `docker compose ps`.
 ///
 /// `#[non_exhaustive]` since 4.0.0, so a new flag can be added in a minor
@@ -281,9 +283,13 @@ fn table_size(c: &ContainerListEntry) -> String {
 /// says podup could not tell; a cell holding a plausible wrong age does not, and
 /// the wrong age is the one a reader acts on.
 fn table_created(c: &ContainerListEntry, now: i64) -> String {
-	crate::timestamp::parse_rfc3339(&c.created)
-		.and_then(|created| span_since(created, now))
-		.unwrap_or_default()
+	let Some(secs) = crate::timestamp::parse_rfc3339(&c.created) else {
+		return String::new();
+	};
+	if secs <= 0 {
+		return String::new();
+	}
+	humanize_age(now.saturating_sub(secs).max(0))
 }
 
 /// Render the span from `then` to `now`, or `None` when there is nothing to

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -348,7 +348,7 @@ fn the_created_cell_reports_the_age_of_the_container() {
 		created: "2026-08-01T00:58:45Z".into(),
 		..entry("", "running")
 	};
-	assert_eq!(table_created(&c, NOW), "2d");
+	assert_eq!(table_created(&c, NOW), "2 days ago");
 }
 
 /// A timestamp podup cannot parse leaves the cell blank rather than showing a

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -73,6 +73,13 @@ pub enum ComposeError {
 	/// (#1104). Carries a short description of which, since the detail (the
 	/// container, the transport error) is already warned as it happens.
 	StreamTruncated(String),
+	/// `port` asked for a container port the service does not publish to
+	/// the host. Carries the rendered sentence, `<service> publishes no host
+	/// port for <port>/<proto>`; the CLI adds its own `error:` prefix. Its own
+	/// variant so the message is not filed under a feature podup lacks
+	/// (`Unsupported`) or a stream that ended early (`StreamTruncated`)
+	/// (#1697).
+	PortNotPublished(String),
 	/// `podup update` (self-update) failed.
 	Update(String),
 	/// An `external: true` secret/config/network/volume is absent.
@@ -271,6 +278,7 @@ impl fmt::Display for ComposeError {
 			Self::RunExited(code) => write!(f, "run container exited with code {code}"),
 			Self::Interrupted => write!(f, "interrupted"),
 			Self::StreamTruncated(what) => write!(f, "{what}"),
+			Self::PortNotPublished(what) => write!(f, "{what}"),
 			Self::Update(s) => write!(f, "update error: {s}"),
 			Self::ExternalNotFound(s) => write!(f, "external resource not found: {s}"),
 			Self::ScalePortConflict {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -57,12 +57,12 @@ pub use compose::{
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, list_projects_filtered, resolve_image_digests,
-	retain_active_profiles, retain_active_profiles_with_targets, surface_host_modes,
-	validate_stop_timeout, AttachOptions, AttachOutcome, AttachSummary, BuildOptions,
-	CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions, ImagesOptions, LogsDisplay,
-	LogsOptions, LsOptions, ProjectLock, PsDisplayOptions, PsFilterOptions, PsOptions, PullOptions,
-	PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesDisplayOptions, VolumesOptions,
-	DEFAULT_LOG_TAIL,
+	resolve_network_name, retain_active_profiles, retain_active_profiles_with_targets,
+	surface_host_modes, validate_stop_timeout, AttachOptions, AttachOutcome, AttachSummary,
+	BuildOptions, CommitOptions, CpOptions, Engine, EventsOptions, ExecOptions, ImagesOptions,
+	LogsDisplay, LogsOptions, LsOptions, ProjectLock, PsDisplayOptions, PsFilterOptions, PsOptions,
+	PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesDisplayOptions,
+	VolumesOptions, DEFAULT_LOG_TAIL,
 };
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 use super::config_normalize::{quote_yaml11_booleans, resolve_bind_sources};
 use crate::cli::ConfigFormat;
+use podup::resolve_network_name;
 
 /// Output selectors for `config`, mirroring the mutually-exclusive `docker
 /// compose config` list modes. The first set selector wins, in the order
@@ -97,6 +98,13 @@ pub(crate) fn render_config(
 	// Surface the resolved project name in the rendered output, like
 	// `docker compose config`, rather than the file's literal `name:` (or none).
 	redacted.name = Some(project.to_string());
+	// Stamp each declared network with the name podup will actually create:
+	// `<project>_<key>` by default, or an explicit `name:` / an `external: true`
+	// network's own key. Without this, `config` left `default:` as `null` while
+	// `up` created `<project>_default`, so a reader of `config` could not tell
+	// what the next `up` would do. The resolution rule is the same `up` uses:
+	// sharing the function keeps the two views from drifting.
+	inject_resolved_network_names(&mut redacted, project);
 	// Don't echo keys the diagnostics pass warned were ignored: the rendered
 	// config should reflect what podup actually applies, and re-feeding it must
 	// not re-trigger the same warning. `x-*` extensions are kept.
@@ -171,6 +179,39 @@ fn render_config_hash(
 		println!("{name} {}", service_config_hash(svc)?);
 	}
 	Ok(())
+}
+
+/// Stamp each declared network with the name podup will create at `up` time,
+/// so `config` shows `<project>_default` (or whatever the resolved name is)
+/// instead of `null`. `file.networks` keeps the same shape (`Some`/`None`),
+/// and a network that already had an explicit `name:` keeps it; this only
+/// fills in the absent case so the two views cannot drift.
+///
+/// The resolution rule is `Engine::resolve_network_name`, called the same way
+/// `up` calls it. Sharing the function is the point: a copy of the rule in this
+/// module would silently disagree the day someone adds a fourth branch.
+fn inject_resolved_network_names(file: &mut podup::compose::types::ComposeFile, project: &str) {
+	// Resolve every name against an immutable borrow of the file first, then
+	// apply under a mutable borrow: `resolve_network_name` reads the file via
+	// shared refs while the loop mutates each network slot.
+	let resolved: Vec<(String, String)> = file
+		.networks
+		.keys()
+		.map(|k| (k.clone(), resolve_network_name(k, file, project)))
+		.collect();
+	for (key, name) in resolved {
+		if let Some(slot) = file.networks.get_mut(&key) {
+			let cfg = slot.get_or_insert_with(Default::default);
+			// `external: true` resolves to the bare key (no project prefix);
+			// an explicit `name:` already pins it. Either way, leave the user's
+			// value alone, since only the implicit-default case writes a name.
+			let user_named = cfg.name.is_some();
+			let external = cfg.external.unwrap_or(false);
+			if !user_named && !external {
+				cfg.name = Some(name);
+			}
+		}
+	}
 }
 
 /// Drop unset keys from a JSON value so `config` output omits them (like

--- a/internal/startup/config_render_tests.rs
+++ b/internal/startup/config_render_tests.rs
@@ -253,3 +253,72 @@ fn a_bare_network_entry_survives_pruning() {
 	);
 	assert!(out.contains("backend"), "{out}");
 }
+
+/// `config` resolves every declared network's name the same way `up` does, so
+/// the rendered output matches what the next `up` will create. A bare network
+/// (`null` body) and the implicit `default` both pick up `<project>_<key>`;
+/// an explicit `name:` is left alone.
+#[test]
+fn inject_resolved_network_names_fills_in_the_implicit_default() {
+	let mut file =
+		podup::parse_str("services:\n  web:\n    image: alpine\nnetworks:\n  default:\n").unwrap();
+	// The implicit `default` network is synthesized by the real pipeline before
+	// `config` runs; declaring it explicitly here is enough to exercise the same
+	// shape the production code sees.
+	inject_resolved_network_names(&mut file, "myproj");
+	let rendered = serde_yaml::to_string(&file.networks).unwrap();
+	assert!(
+		rendered.contains("name: myproj_default"),
+		"the implicit `default` network must resolve to <project>_default: {rendered}"
+	);
+}
+
+/// A network whose body is just `null` is treated the same way: there is no
+/// `name:` to preserve, so `up` would create `<project>_<key>` and `config`
+/// shows the same.
+#[test]
+fn inject_resolved_network_names_fills_a_bare_network() {
+	let mut file =
+		podup::parse_str("services:\n  web:\n    image: alpine\nnetworks:\n  monitoring: null\n")
+			.unwrap();
+	inject_resolved_network_names(&mut file, "myproj");
+	let cfg = file.networks.get("monitoring").unwrap();
+	let name = cfg
+		.as_ref()
+		.and_then(|c| c.name.as_deref())
+		.expect("bare network must pick up the project-prefixed default");
+	assert_eq!(name, "myproj_monitoring");
+}
+
+/// An explicit `name:` is the user's choice; `config` must not overwrite it
+/// just because it would otherwise match the same rule.
+#[test]
+fn inject_resolved_network_names_keeps_an_explicit_name() {
+	let mut file = podup::parse_str(
+		"services:\n  web:\n    image: alpine\nnetworks:\n  backend:\n    name: my-custom-net\n",
+	)
+	.unwrap();
+	inject_resolved_network_names(&mut file, "myproj");
+	let name = file.networks["backend"]
+		.as_ref()
+		.and_then(|c| c.name.as_deref())
+		.expect("explicit name must survive");
+	assert_eq!(name, "my-custom-net");
+}
+
+/// An `external: true` network keeps its bare key as the runtime name, with no
+/// project prefix; `config` reflects that without writing a `name:` it would
+/// then have to also unset.
+#[test]
+fn inject_resolved_network_names_leaves_external_networks_alone() {
+	let mut file = podup::parse_str(
+		"services:\n  web:\n    image: alpine\nnetworks:\n  shared:\n    external: true\n",
+	)
+	.unwrap();
+	inject_resolved_network_names(&mut file, "myproj");
+	let cfg = file.networks["shared"].as_ref().expect("network slot");
+	assert!(
+		cfg.name.is_none(),
+		"external networks must not get a project-prefixed name: {cfg:?}"
+	);
+}

--- a/tests/config_contract.rs
+++ b/tests/config_contract.rs
@@ -1,0 +1,206 @@
+//! Contract tests for `podup config`: the rendered network names must match
+//! what `up` actually creates, so a reader of `config` cannot be misled by a
+//! network the next `up` would silently rename.
+//!
+//! #1698: with a one-service file that declares no networks, `config`
+//! emitted `default: null` while `up` created `<project>_default`. Both views
+//! now agree: `config` prints the resolved name on every declared network,
+//! calling the same `Engine::resolve_network_name` `up` calls rather than
+//! duplicating the rule.
+//!
+//! `config --hash` and `--quiet` are unchanged: a regression that re-introduces
+//! the bug should be caught here, and the existing render-time unit tests
+//! cover the hash and quiet paths.
+
+mod harness;
+
+use harness::{bin, podman_up};
+use std::process::Command;
+use tempfile::tempdir;
+
+/// The network name `config` prints must be a network `podman network ls`
+/// reports under the same project. With no explicit network declared, `config`
+/// resolved to `<project>_default` and `up` created exactly that, so the two
+/// views must agree; otherwise the operator reading `config` would see one
+/// name and the next `up` would silently create another.
+#[tokio::test]
+async fn config_default_network_name_is_what_up_creates() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	std::fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	let proj = format!("t{}-cfgnet", std::process::id());
+
+	let cfg = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "config"])
+		.output()
+		.expect("run podup config");
+	assert!(
+		cfg.status.success(),
+		"config must succeed: {}",
+		String::from_utf8_lossy(&cfg.stderr)
+	);
+	let cfg_text = String::from_utf8_lossy(&cfg.stdout);
+	// The bug was `default: null`; the fix is `default:` followed by the
+	// resolved name.
+	assert!(
+		!cfg_text.contains("default: null"),
+		"`config` must not leave `default: null`; got:\n{cfg_text}"
+	);
+	let expected = format!("name: {proj}_default");
+	assert!(
+		cfg_text.contains(&expected),
+		"`config` must print `{expected}` for the implicit `default` network; \
+		 got:\n{cfg_text}"
+	);
+
+	let up = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "up", "-d"])
+		.output()
+		.expect("run podup up -d");
+	assert!(
+		up.status.success(),
+		"up -d must succeed: {}",
+		String::from_utf8_lossy(&up.stderr)
+	);
+
+	let ls = Command::new("podman")
+		.args(["network", "ls", "--format", "{{.Name}}"])
+		.output()
+		.expect("run podman network ls");
+	assert!(
+		ls.status.success(),
+		"podman network ls must succeed: {}",
+		String::from_utf8_lossy(&ls.stderr)
+	);
+	let ls_text = String::from_utf8_lossy(&ls.stdout);
+	let expected_name = format!("{proj}_default");
+	assert!(
+		ls_text.lines().any(|l| l.trim() == expected_name),
+		"`{expected_name}` must appear in `podman network ls`:\n{ls_text}"
+	);
+
+	let _ = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "down", "-v"])
+		.output();
+}
+
+/// A network declared without a `name:` is also stamped with the project
+/// prefix. The fixture declares one such network alongside an explicit one,
+/// and `config` must show both. The implicit `default` network shows up too,
+/// because the service has no explicit `networks:` block.
+#[tokio::test]
+async fn config_names_both_implicit_and_explicit_networks() {
+	if !podman_up().await {
+		return;
+	}
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	std::fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\nnetworks:\n  backend:\n    name: my-custom-net\n  monitoring:\n",
+	)
+	.unwrap();
+	let proj = format!("t{}-cfgboth", std::process::id());
+	let cfg = Command::new(bin())
+		.args(["-f", compose.to_str().unwrap(), "-p", &proj, "config"])
+		.output()
+		.expect("run podup config");
+	assert!(
+		cfg.status.success(),
+		"`config` must succeed: {}",
+		String::from_utf8_lossy(&cfg.stderr)
+	);
+	let text = String::from_utf8_lossy(&cfg.stdout);
+	assert!(
+		!text.contains(": null\n"),
+		"`config` must not leave any network with `null` body: {text}"
+	);
+	let expected_default = format!("name: {proj}_default");
+	assert!(
+		text.contains(&expected_default),
+		"`config` must print `{expected_default}`: {text}"
+	);
+	assert!(
+		text.contains("name: my-custom-net"),
+		"`config` must keep the explicit `name:`: {text}"
+	);
+	let expected_monitoring = format!("name: {proj}_monitoring");
+	assert!(
+		text.contains(&expected_monitoring),
+		"`config` must print `{expected_monitoring}` for the bare `monitoring` network: {text}"
+	);
+}
+
+/// `--hash` and `--quiet` remain unaffected by the network-name injection.
+/// A regression that mutates the file before hashing or that prints under
+/// `--quiet` would break the existing render-time unit tests; this contract
+/// test pins the binary-level behaviour.
+#[tokio::test]
+async fn config_hash_and_quiet_are_unaffected() {
+	let dir = tempdir().unwrap();
+	let compose = dir.path().join("compose.yaml");
+	std::fs::write(
+		&compose,
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+
+	let hash_out = Command::new(bin())
+		.args([
+			"-f",
+			compose.to_str().unwrap(),
+			"-p",
+			"thashcfg",
+			"config",
+			"--hash",
+			"web",
+		])
+		.output()
+		.expect("run config --hash");
+	assert!(hash_out.status.success(), "--hash must succeed");
+	let hash = String::from_utf8_lossy(&hash_out.stdout);
+	let mut tokens = hash.split_whitespace();
+	let name = tokens.next().unwrap_or_default();
+	let digest = tokens.next().unwrap_or_default();
+	assert_eq!(
+		name, "web",
+		"`config --hash` first token is the service name: {hash:?}"
+	);
+	assert_eq!(
+		digest.len(),
+		64,
+		"`config --hash` second token is a sha-256 hex digest: {hash:?}"
+	);
+	assert!(
+		digest.chars().all(|c| c.is_ascii_hexdigit()),
+		"`config --hash` second token is hex: {hash:?}"
+	);
+
+	let quiet = Command::new(bin())
+		.args([
+			"-f",
+			compose.to_str().unwrap(),
+			"-p",
+			"tquietcfg",
+			"config",
+			"--quiet",
+		])
+		.output()
+		.expect("run config --quiet");
+	assert!(
+		quiet.status.success(),
+		"`config --quiet` must succeed: {}",
+		String::from_utf8_lossy(&quiet.stderr)
+	);
+	assert!(
+		String::from_utf8_lossy(&quiet.stdout).trim().is_empty(),
+		"`config --quiet` prints nothing on stdout"
+	);
+}

--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -126,13 +126,14 @@ async fn cli_ps_subcommand() {
 	// CREATED sits between the image and STATUS. It is only ever filled by
 	// parsing the RFC 3339 string libpod really sends, so a blank here is the
 	// parser failing against the live server — which no unit test can see,
-	// because every fixture it has was written by hand.
+	// because every fixture it has was written by hand. Since #1699 the cell
+	// is a phrase, `3 seconds ago` or `Less than a second ago`, so it spans
+	// several cells: everything between the image and `Up`.
+	let created = cells[2..up].join(" ");
 	assert!(
-		up >= 3
-			&& cells[up - 1]
-				.chars()
-				.next()
-				.is_some_and(|c| c.is_ascii_digit()),
+		created.ends_with(" ago")
+			&& (created.starts_with("Less than")
+				|| created.starts_with(|c: char| c.is_ascii_digit())),
 		"ps printed no CREATED age, so the timestamp did not parse: {row:?}"
 	);
 


### PR DESCRIPTION
Closes #1697, #1698 and #1699. Measured on the branch binary:

```
$ podup port talker 80
podup: error: talker publishes no host port for 80/tcp        (exit 1)

$ podup config | tail -3
networks:
  default:
    name: tpol_default

$ podup ps
NAME          IMAGE                 CREATED       STATUS PORTS
tpol-talker-1 localhost/ux-talker:1 3 seconds ago Up 3s
$ podup images
SERVICE REPOSITORY          TAG IMAGE ID     SIZE   CREATED
talker  localhost/ux-talker 1   51a0cce630f3 8.10MB 10 hours ago
```

- `port`: a new `ComposeError::PortNotPublished` variant (the enum is `non_exhaustive`) carries the sentence; `Unsupported` stays for what podup does not implement. Unit test asserts the text and the variant.
- `config`: `resolve_network_name`, the function `up` calls, is now reachable from the binary crate and `config` stamps `name:` on every declared network without one; four unit tests plus `tests/config_contract.rs` (three cases against Podman, including `--hash`/`--quiet` unaffected).
- CREATED: one `humanize_age` helper for both tables, boundaries pinned at 0 s, 1 s, 59 s, 60 s, 59 min, 60 min, 23 h, 24 h and singular versus plural; the JSON rows keep their raw instants (existing contract test).

Suite, clippy and fmt clean locally.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>