### PR TITLE
feat(ui): up --build draws one board, with the image rows built first at the top

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -191,9 +191,14 @@ On a terminal `build` draws a board of its own, one row per image, `Building`, t
 itself is folded: while a row builds, its last four lines sit dimmed under
 the row and vanish when it finishes; on failure the whole stream is
 printed once, above the error, so the reason is on screen.
-`up --build` runs that build board first and the `up` board after it; an
-`up` that finds a service's image missing builds it on the `up` board,
-with the image row just above the service's container row.
+`up --build` shares the `up` board with the build phase: the image rows
+sit at the top, in `build`'s order, and the network and container rows
+follow on the same board. The build verbs (`Building`/`Building n/m`/
+`Built`) land on the same rows the rest of `up` is drawing on, so a single
+`[+] Running N/M` count covers everything. An `up` that finds a service's
+image missing builds it on the `up` board too, with the image row just
+above the service's container row, in the missing-image case `up` has
+handled since #1681.
 
 In a pipe every stream line goes to stderr prefixed with `<image-tag> | `,
 the way `logs` prefixes container output. The image id of the freshly built

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -60,9 +60,12 @@ pub(crate) async fn dispatch(
 			} else {
 				engine.warn_orphans(file).await?;
 			}
-			if build {
-				engine.build_all(file, &services).await?;
-			}
+			// `--build` runs the build inside the `up` board (#1700): the image
+			// rows are seeded at the top, built sequentially in `build_all`'s
+			// order, then the network and container rows follow on the same
+			// board. No separate `build_all` call, since that would draw its
+			// own `[+] Running 0/N` board and close it before `up` opened its
+			// own.
 			// `--no-start` creates the containers but never starts them, so the
 			// wait/watch/attach steps below do not apply.
 			if no_start {
@@ -87,6 +90,7 @@ pub(crate) async fn dispatch(
 					no_recreate,
 					force_recreate,
 					no_deps,
+					build,
 				)
 				.await?;
 			if wait {

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -9,6 +9,7 @@ mod context;
 mod pull;
 mod push;
 mod secrets;
+mod service;
 mod steps;
 mod stream;
 mod tags;
@@ -22,25 +23,11 @@ pub use push::PushOptions;
 /// image tag the build step produced for a build-only service.
 pub(crate) use tags::primary_build_tag;
 
-use bytes::Bytes;
-use futures_util::StreamExt;
-use tracing::{info, warn};
-
-use std::io::IsTerminal;
-
-use crate::compose::types::{BuildConfig, Service};
+use crate::compose::types::BuildConfig;
 use crate::engine::container_config::resources::is_known_ulimit;
-use crate::error::{ComposeError, Result};
-use crate::libpod::types::image::BuildOutput;
-use crate::libpod::urlencoded;
-use crate::libpod::validate::pre_validate_build;
-use crate::libpod::API_PREFIX;
-use crate::size;
-use steps::{parse_image_id_line, BuildStreamProgress};
+use crate::error::Result;
 
-use context::{map_additional_context, INLINE_DOCKERFILE_NAME};
-use stream::{context_body, ContextSource};
-use tags::{is_remote_context, looks_like_secret};
+use stream::ContextSource;
 
 use super::Engine;
 
@@ -157,6 +144,57 @@ fn render_build_ulimits(build: &BuildConfig) -> Vec<String> {
 		.collect()
 }
 
+/// Resolve the service name list a build pass will iterate over: every service
+/// in the file when `target_services` is empty, otherwise the explicit list
+/// after validating each name is defined. Returning `Vec<String>` keeps the
+/// `build_all_with_options` and `build_images_in_session` paths identical at
+/// the top, which is what lets `up --build` share the build's loop body.
+fn build_target_names(
+	file: &crate::compose::types::ComposeFile,
+	target_services: &[String],
+) -> Result<Vec<String>> {
+	if target_services.is_empty() {
+		return Ok(file.services.keys().cloned().collect());
+	}
+	for name in target_services {
+		if !file.services.contains_key(name) {
+			return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
+		}
+	}
+	Ok(target_services.to_vec())
+}
+
+/// The image tags `build_images_in_session` will build, in order, deduped.
+/// A service without a `build:` block contributes nothing (its row would
+/// never move and would read as something hung); two services sharing one
+/// image share one row. Pulled out so the same row set can be seeded by
+/// `build_all_with_options` and by the `up --build` path in `run_up`.
+pub(crate) fn build_image_tags(
+	engine: &Engine,
+	file: &crate::compose::types::ComposeFile,
+	names: &[String],
+) -> Vec<String> {
+	let mut images: Vec<String> = Vec::new();
+	for name in names {
+		let Some(service) = file.services.get(name) else {
+			continue;
+		};
+		if service.build.is_none() {
+			continue;
+		}
+		let tag = primary_build_tag(
+			&engine.project,
+			name,
+			service.image.as_deref(),
+			service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
+		);
+		if !images.iter().any(|seen| seen == &tag) {
+			images.push(tag);
+		}
+	}
+	images
+}
+
 impl Engine {
 	/// Build (or rebuild) images for services that have a `build:` block.
 	///
@@ -179,58 +217,15 @@ impl Engine {
 		target_services: &[String],
 		opts: &BuildOptions,
 	) -> Result<()> {
-		let names: Vec<String> = if target_services.is_empty() {
-			file.services.keys().cloned().collect()
-		} else {
-			for name in target_services {
-				if !file.services.contains_key(name) {
-					return Err(crate::error::ComposeError::ServiceNotFound(name.clone()));
-				}
-			}
-			target_services.to_vec()
-		};
+		let names = build_target_names(file, target_services)?;
+		let images = build_image_tags(self, file, &names);
 
-		// Seed the board with the image set this pass will build, one row
-		// per image, before the first `Building` line. A service with no
-		// `build:` block is skipped, the same way `build_service` does; its
-		// row would never move and would read as something hung (#1681).
-		// Two services on the same image share one row, since the row is
-		// the image.
-		let mut images: Vec<String> = Vec::new();
-		for name in &names {
-			let Some(service) = file.services.get(name) else {
-				continue;
-			};
-			if service.build.is_none() {
-				continue;
-			}
-			let tag = primary_build_tag(
-				&self.project,
-				name,
-				service.image.as_deref(),
-				service.build.as_ref().map(|b| b.tags()).unwrap_or(&[]),
-			);
-			if !images.iter().any(|seen| seen == &tag) {
-				images.push(tag);
-			}
-		}
 		crate::ui::progress::begin(
 			images
 				.iter()
 				.map(|image| (crate::ui::progress::Kind::Image, image.clone())),
 		);
-
-		let result = async {
-			for name in &names {
-				let service = &file.services[name];
-				if service.build.is_some() {
-					self.build_service(name, service, file, opts).await?;
-				}
-			}
-			Ok(())
-		}
-		.await;
-
+		let result = self.build_images_in_session(file, &names, opts).await;
 		// Close the board on every exit, the way `pull_services_with_options`
 		// and `run_up` do. The live region hides the cursor, so an early
 		// return through it would leave the terminal without a caret. `end`
@@ -239,432 +234,28 @@ impl Engine {
 		result
 	}
 
-	pub(super) async fn build_service(
+	/// Build the images for `target_services` (every service with a `build:`
+	/// block when the list is empty), using an already-open board for the
+	/// row events. Unlike [`Self::build_all_with_options`] this does not
+	/// seed the board or close it on the way out: the caller is running
+	/// inside a board the `up` pass opened, and closing it here would
+	/// tear down the very board the rest of `up` is still drawing on.
+	///
+	/// `image_tags` is the list of image rows the caller already seeded,
+	/// in the order they should be built. Passing the same list back is
+	/// what lets `build_service` find its row in the board and flip it
+	/// from `Pending` to `Working` without re-inserting it.
+	pub(in crate::engine) async fn build_images_in_session(
 		&self,
-		service_name: &str,
-		service: &Service,
 		file: &crate::compose::types::ComposeFile,
+		target_services: &[String],
 		opts: &BuildOptions,
 	) -> Result<()> {
-		let build = match &service.build {
-			Some(b) => b,
-			None => return Ok(()),
-		};
-
-		let context_str = build.context().to_string();
-		let remote_context = is_remote_context(&context_str);
-		let tag = primary_build_tag(
-			&self.project,
-			service_name,
-			service.image.as_deref(),
-			build.tags(),
-		);
-
-		// A Git/URL context is cloned server-side by Podman via the `remote`
-		// query parameter — there is no local directory to tar. Tar-only features
-		// (inline Dockerfile, in-tar build secrets) do not apply.
-		let (body_plan, dockerfile_name, secret_specs) = if remote_context {
-			info!("building {tag} from remote context {context_str}");
-			if build.dockerfile_inline().is_some() {
-				warn!("build.dockerfile_inline is ignored for a remote build context");
+		for name in target_services {
+			let service = &file.services[name];
+			if service.build.is_some() {
+				self.build_service(name, service, file, opts).await?;
 			}
-			if !build.secrets().is_empty() {
-				warn!("build.secrets are ignored for a remote build context");
-			}
-			let df = build.dockerfile().unwrap_or("Dockerfile").to_string();
-			(BodyPlan::Empty, df, Vec::new())
-		} else {
-			let context_path = self.base_dir.join(&context_str);
-			// Fail fast with the service name and the resolved context path if the
-			// directory is missing/unreadable, instead of a bare "io error: No such
-			// file or directory" once the context walk hits it.
-			if let Err(e) = std::fs::metadata(&context_path) {
-				return Err(ComposeError::BuildContext {
-					service: service_name.to_string(),
-					path: context_path.display().to_string(),
-					source: e,
-				});
-			}
-			info!("building {tag} from {}", context_path.display());
-
-			// Resolve `build.secrets` to in-tar files before building the context:
-			// each secret value is shipped inside the build-context tar and
-			// referenced by a relative `src=` path, which is the form the libpod
-			// build endpoint expects (`env=`/host-path forms don't work reliably
-			// over the socket).
-			let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
-
-			// The context tar is streamed to the socket (see the POST below), never
-			// buffered, so a multi-gigabyte context doesn't inflate RSS. Decide the
-			// source and the dockerfile name here; the blocking tar walk happens
-			// while the request body is being sent.
-			let (source, dockerfile_name) = match build.dockerfile_inline() {
-				Some(inline) => (
-					ContextSource::Inline(inline.to_string()),
-					INLINE_DOCKERFILE_NAME.to_string(),
-				),
-				None => {
-					// Honour an explicit dockerfile; otherwise prefer Dockerfile
-					// but fall back to Podman's native Containerfile when only the
-					// latter is present.
-					let df = match build.dockerfile() {
-						Some(name) => name.to_string(),
-						None if !context_path.join("Dockerfile").is_file()
-							&& context_path.join("Containerfile").is_file() =>
-						{
-							"Containerfile".to_string()
-						}
-						None => "Dockerfile".to_string(),
-					};
-					(ContextSource::Dockerfile(df.clone()), df)
-				}
-			};
-			(
-				BodyPlan::Stream {
-					context: context_path,
-					source,
-					secrets: secret_files,
-				},
-				dockerfile_name,
-				secret_specs,
-			)
-		};
-
-		let arg_map = build.args().to_map();
-		let mut build_args: std::collections::HashMap<String, String> =
-			std::collections::HashMap::new();
-		for (k, v) in arg_map {
-			let value = v.unwrap_or_else(|| std::env::var(&k).unwrap_or_default());
-			build_args.insert(k, value);
-		}
-		// CLI `--build-arg KEY=VAL` overrides the compose `build.args`. A bare
-		// `KEY` (no `=`) takes its value from the process environment, matching
-		// docker compose.
-		for entry in &opts.build_args {
-			let (k, v) = match entry.split_once('=') {
-				Some((k, v)) => (k.to_string(), v.to_string()),
-				None => (entry.clone(), std::env::var(entry).unwrap_or_default()),
-			};
-			// A bare `=value` (empty key) is a user typo Podman would silently
-			// ignore; reject it with a clear diagnostic instead.
-			if k.is_empty() {
-				return Err(ComposeError::Build(format!(
-					"invalid --build-arg '{entry}': empty argument name"
-				)));
-			}
-			build_args.insert(k, v);
-		}
-
-		// A secret passed as a build arg is recorded in the image history and, if
-		// promoted via `ENV`, the image config — so it can leak. Warn and point at
-		// `build.secrets` (BuildKit `--mount=type=secret`), which does not persist.
-		let mut secretish: Vec<&str> = build_args
-			.keys()
-			.filter(|k| looks_like_secret(k))
-			.map(String::as_str)
-			.collect();
-		if !secretish.is_empty() {
-			secretish.sort_unstable();
-			warn!(
-				"build-arg(s) [{}] look like secrets; build args are stored in the image history \
-				 and can leak. Use build.secrets for sensitive values.",
-				secretish.join(", ")
-			);
-		}
-
-		let mut labels: std::collections::HashMap<String, String> =
-			std::collections::HashMap::new();
-		if let BuildConfig::Config { labels: l, .. } = build {
-			labels.extend(l.to_map());
-		}
-
-		// Pre-validate the keys libpod's buildkit-fronted parser rejects
-		// (anything outside `[A-Za-z0-9_.-]`), so a bad `build.args` or
-		// `build.labels` key surfaces as a `PodmanError::Field` naming the
-		// compose-side field rather than libpod's `400` body. Runs before
-		// the build URL is assembled so a bad key fails before any POST to
-		// the daemon (#1357).
-		pre_validate_build(&build_args, &labels)?;
-
-		let network = if let BuildConfig::Config {
-			network: Some(n), ..
-		} = build
-		{
-			Some(n.clone())
-		} else {
-			None
-		};
-		let platform = match build {
-			BuildConfig::Config { platforms, .. } => platforms.first().inspect(|first| {
-				let rest_count = platforms.len() - 1;
-				if rest_count > 0 {
-					warn!("build.platforms: libpod builds one platform per request; building {first}, ignoring {rest_count} other(s)");
-				}
-			}).cloned(),
-			_ => None,
-		};
-		// Distinguish "absent" from "present but unparseable": a malformed
-		// `shm_size` must be rejected, not silently dropped to the default.
-		let shmsize = match build.shm_size() {
-			Some(raw) => Some(size::parse_memory(raw).ok_or_else(|| {
-				ComposeError::Build(format!("invalid build.shm_size value '{raw}'"))
-			})? as i32),
-			None => None,
-		};
-		let extrahosts_str = build.extra_hosts().join(",");
-		let extrahosts = if extrahosts_str.is_empty() {
-			None
-		} else {
-			Some(extrahosts_str)
-		};
-		let cachefrom = if build.cache_from().is_empty() {
-			None
-		} else {
-			Some(super::to_query_json(
-				"build.cache_from",
-				&build.cache_from(),
-			)?)
-		};
-		let buildargs_json = if build_args.is_empty() {
-			None
-		} else {
-			Some(super::to_query_json("build.args", &build_args)?)
-		};
-		let labels_json = if labels.is_empty() {
-			None
-		} else {
-			Some(super::to_query_json("build.labels", &labels)?)
-		};
-		let build_ulimits = render_build_ulimits(build);
-		let ulimits_json = if build_ulimits.is_empty() {
-			None
-		} else {
-			Some(super::to_query_json("build.ulimits", &build_ulimits)?)
-		};
-
-		let mut qs = format!(
-			"t={}&rm=true&nocache={}",
-			urlencoded(&tag),
-			build.no_cache() || opts.no_cache
-		);
-		qs.push_str(&format!("&dockerfile={}", urlencoded(&dockerfile_name)));
-		if build.pull() || opts.pull {
-			qs.push_str("&pull=true");
-		}
-		if let Some(p) = &platform {
-			qs.push_str(&format!("&platform={}", urlencoded(p)));
-		}
-		if let Some(n) = &network {
-			qs.push_str(&format!("&networkmode={}", urlencoded(n)));
-		}
-		if let Some(s) = shmsize {
-			qs.push_str(&format!("&shmsize={s}"));
-		}
-		if let Some(h) = &extrahosts {
-			qs.push_str(&format!("&extrahosts={}", urlencoded(h)));
-		}
-		if let Some(c) = &cachefrom {
-			qs.push_str(&format!("&cachefrom={}", urlencoded(c)));
-		}
-		if let Some(a) = &buildargs_json {
-			qs.push_str(&format!("&buildargs={}", urlencoded(a)));
-		}
-		if let Some(l) = &labels_json {
-			qs.push_str(&format!("&labels={}", urlencoded(l)));
-		}
-		if let Some(u) = &ulimits_json {
-			qs.push_str(&format!("&ulimits={}", urlencoded(u)));
-		}
-		if let Some(target) = build.target() {
-			qs.push_str(&format!("&target={}", urlencoded(target)));
-		}
-		if !secret_specs.is_empty() {
-			let json = super::to_query_json("build.secrets", &secret_specs)?;
-			qs.push_str(&format!("&secrets={}", urlencoded(&json)));
-		}
-		if !build.cache_to().is_empty() {
-			let json = super::to_query_json("build.cache_to", &build.cache_to())?;
-			qs.push_str(&format!("&cacheto={}", urlencoded(&json)));
-		}
-		for (name, value) in build.additional_contexts() {
-			let mapped = map_additional_context(&self.base_dir, &value);
-			qs.push_str(&format!(
-				"&additionalbuildcontexts={}",
-				urlencoded(&format!("{name}={mapped}"))
-			));
-		}
-		if !build.ssh().is_empty() {
-			warn!(
-				"build.ssh is not supported over the libpod REST build API; ignoring {:?}",
-				build.ssh()
-			);
-		}
-
-		if remote_context {
-			qs.push_str(&format!("&remote={}", urlencoded(&context_str)));
-		}
-
-		let path = format!("{API_PREFIX}/build?{qs}");
-		let resp = match body_plan {
-			BodyPlan::Empty => self
-				.client
-				.post_bytes_stream(&path, Bytes::new(), "application/x-tar")
-				.await
-				.map_err(ComposeError::Podman)?,
-			BodyPlan::Stream {
-				context,
-				source,
-				secrets,
-			} => {
-				// The tar writer runs on a blocking thread feeding the request
-				// body; drain the body first, then join the writer — joining
-				// before the body is drained would deadlock on the bounded
-				// channel. If the request itself failed, that transport error is
-				// the real cause; otherwise surface any context-assembly error.
-				let (producer, body) = context_body(context, source, secrets);
-				let sent = self
-					.client
-					.post_stream_body(&path, body, "application/x-tar")
-					.await;
-				let produced = producer
-					.await
-					.map_err(|e| ComposeError::Build(e.to_string()))?;
-				match sent {
-					Ok(resp) => {
-						produced?;
-						resp
-					}
-					Err(e) => return Err(ComposeError::Podman(e)),
-				}
-			}
-		};
-		let mut stream = crate::libpod::parse_json_lines::<BuildOutput>(resp.into_body());
-
-		// Open the board row for this image before the first `STEP` line, so
-		// the row's `Building` verb is what the reader sees while the stream
-		// arrives. `progress::start` is a no-op when the board already had
-		// the row seeded (`build_all_with_options` did this for a standalone
-		// `build`), and inserts it before the service's container row when
-		// `up --build` calls into a board the `up` pass opened. Either way,
-		// the row ends up with the right identifier, in the right position
-		// and with a working verb (#1681).
-		if !opts.quiet {
-			let first_container = self.replica_names(service_name, service).into_iter().next();
-			match first_container {
-				Some(container_name) => crate::ui::progress::start_anchored(
-					"Image",
-					&tag,
-					"Building",
-					Some("Container"),
-					Some(&container_name),
-				),
-				None => crate::ui::progress::start("Image", &tag, "Building"),
-			}
-		}
-
-		// The captured stream of this image: needed on a terminal failure
-		// path, where the notes buffer only kept the last 4 lines and the
-		// rest has to be replayed as scrollback so the reason is on screen.
-		// Off a terminal, every line is already in stderr through `note_for`,
-		// so this stays empty in the test runs.
-		let mut capture: Vec<String> = Vec::new();
-		// Track the last image id the stream emitted, so the success path
-		// can put it on stdout when stdout is not a terminal. Buildah
-		// closes with a `--> sha256:<64-hex>` line, which is what a script
-		// capturing stdout wants; on a terminal it is dropped (the row
-		// already says it landed). `None` until the first matching line.
-		let mut last_image_id: Option<String> = None;
-		let mut progress = BuildStreamProgress::new();
-
-		while let Some(result) = stream.next().await {
-			match result {
-				Ok(output) => {
-					if !output.stream.is_empty() {
-						let trimmed = output.stream.trim_end().to_string();
-						if !opts.quiet && !trimmed.is_empty() {
-							// `STEP n/m:` lines advance the row verb. Every
-							// other line is a tail note, painted dimmed under
-							// the row on a terminal and prefixed on stderr in
-							// a pipe.
-							if let Some(verb) = progress.observe(&trimmed) {
-								crate::ui::progress::start("Image", &tag, &verb);
-							}
-							// The image id line is the one carry-over from
-							// today that a script reading stdout needs. It
-							// goes to notes/live as any other line, and is
-							// additionally stashed so the success path can
-							// echo it to stdout when stdout is not a tty.
-							if let Some(id) = parse_image_id_line(&trimmed) {
-								last_image_id = Some(id);
-							}
-							crate::ui::progress::note_for("Image", &tag, &trimmed);
-						}
-						capture.push(trimmed);
-					}
-					if let Some(err) = output.error_detail.and_then(|e| e.message) {
-						return Err(self.fail_build(&tag, err, capture, opts.quiet));
-					}
-					if let Some(err) = output.error {
-						if !err.is_empty() {
-							return Err(self.fail_build(&tag, err, capture, opts.quiet));
-						}
-					}
-				}
-				Err(e) => return Err(ComposeError::Podman(e)),
-			}
-		}
-
-		// Success: close the row with `Built`. The trailing image id goes to
-		// stdout only when stdout is not a terminal, so a script reading
-		// `podup build | awk '{print $1}'` can still pluck the id; on a
-		// terminal the row says it landed and the id would only be noise.
-		if !opts.quiet {
-			crate::ui::progress_line("Image", &tag, "Built");
-		}
-		if !std::io::stdout().is_terminal() {
-			let resolved = match last_image_id {
-				Some(id) => Some(id),
-				None => match self.image_id(&tag).await {
-					Ok(Some(id)) => Some(id),
-					_ => None,
-				},
-			};
-			if let Some(id) = resolved {
-				use std::io::Write;
-				let _ = writeln!(std::io::stdout(), "{id}");
-			}
-		}
-
-		self.apply_extra_tags(build, &tag).await?;
-		Ok(())
-	}
-
-	/// Apply any `build.tags` aliases to the freshly built image.
-	///
-	/// The primary `tag` is skipped: when no `image:` is set it is already
-	/// `tags[0]`, which the build itself produced, so re-tagging it onto itself
-	/// would be a no-op API call.
-	async fn apply_extra_tags(&self, build: &BuildConfig, tag: &str) -> Result<()> {
-		for extra_tag in build.tags() {
-			if extra_tag == tag {
-				continue;
-			}
-			let (repo, tag_str) = extra_tag
-				.rsplit_once(':')
-				.map(|(r, t)| (r.to_string(), t.to_string()))
-				.unwrap_or_else(|| (extra_tag.clone(), "latest".to_string()));
-			let encoded_tag = urlencoded(tag);
-			let tag_path = format!(
-				"{API_PREFIX}/images/{encoded_tag}/tag?repo={}&tag={}",
-				urlencoded(&repo),
-				urlencoded(&tag_str),
-			);
-			// Returning () here meant `build` could not report a failed tag at
-			// all: it exited 0 with the requested tags missing.
-			self.client
-				.post_empty_ok(&tag_path)
-				.await
-				.map_err(ComposeError::Podman)?;
 		}
 		Ok(())
 	}

--- a/internal/engine/build/service.rs
+++ b/internal/engine/build/service.rs
@@ -1,0 +1,469 @@
+//! Per-service build: build one `build:` block end-to-end.
+//!
+//! Split out of `mod.rs` so the dispatching loop in `mod.rs` stays a thin
+//! orchestrator and this file owns the 400-ish lines of URL/stream glue a
+//! single build needs. The split is the one suggested by the engine style:
+//! the entry point (`build_service`) and the small follow-up
+//! (`apply_extra_tags`) sit here, alongside each other, since the row's
+//! final state (`Built` / `Failed` / tagged aliases) is what closes the
+//! build out and `build_service` calls into `apply_extra_tags` directly.
+//!
+//! Visibility is `pub(crate)` everywhere needed across this split: the
+//! stream-helper types in `steps.rs`, the body-stream helpers in
+//! `stream.rs`, and the context helpers in `tags.rs` and `context.rs` are
+//! all called from here.
+
+use std::io::IsTerminal;
+
+use bytes::Bytes;
+use futures_util::StreamExt;
+use tracing::{info, warn};
+
+use crate::compose::types::{BuildConfig, Service};
+use crate::error::{ComposeError, Result};
+use crate::libpod::types::image::BuildOutput;
+use crate::libpod::urlencoded;
+use crate::libpod::validate::pre_validate_build;
+use crate::libpod::API_PREFIX;
+use crate::size;
+
+use super::steps::{parse_image_id_line, BuildStreamProgress};
+use super::stream::{context_body, ContextSource};
+use super::tags::{is_remote_context, looks_like_secret};
+use super::{context::map_additional_context, Engine};
+use super::{context::INLINE_DOCKERFILE_NAME, BodyPlan, BuildOptions};
+
+impl Engine {
+	pub(in crate::engine) async fn build_service(
+		&self,
+		service_name: &str,
+		service: &Service,
+		file: &crate::compose::types::ComposeFile,
+		opts: &BuildOptions,
+	) -> Result<()> {
+		let build = match &service.build {
+			Some(b) => b,
+			None => return Ok(()),
+		};
+
+		let context_str = build.context().to_string();
+		let remote_context = is_remote_context(&context_str);
+		let tag = super::primary_build_tag(
+			&self.project,
+			service_name,
+			service.image.as_deref(),
+			build.tags(),
+		);
+
+		// A Git/URL context is cloned server-side by Podman via the `remote`
+		// query parameter — there is no local directory to tar. Tar-only features
+		// (inline Dockerfile, in-tar build secrets) do not apply.
+		let (body_plan, dockerfile_name, secret_specs) = if remote_context {
+			info!("building {tag} from remote context {context_str}");
+			if build.dockerfile_inline().is_some() {
+				warn!("build.dockerfile_inline is ignored for a remote build context");
+			}
+			if !build.secrets().is_empty() {
+				warn!("build.secrets are ignored for a remote build context");
+			}
+			let df = build.dockerfile().unwrap_or("Dockerfile").to_string();
+			(BodyPlan::Empty, df, Vec::new())
+		} else {
+			let context_path = self.base_dir.join(&context_str);
+			// Fail fast with the service name and the resolved context path if the
+			// directory is missing/unreadable, instead of a bare "io error: No such
+			// file or directory" once the context walk hits it.
+			if let Err(e) = std::fs::metadata(&context_path) {
+				return Err(ComposeError::BuildContext {
+					service: service_name.to_string(),
+					path: context_path.display().to_string(),
+					source: e,
+				});
+			}
+			info!("building {tag} from {}", context_path.display());
+
+			// Resolve `build.secrets` to in-tar files before building the context:
+			// each secret value is shipped inside the build-context tar and
+			// referenced by a relative `src=` path, which is the form the libpod
+			// build endpoint expects (`env=`/host-path forms don't work reliably
+			// over the socket).
+			let (secret_files, secret_specs) = self.resolve_build_secrets(build, file)?;
+
+			// The context tar is streamed to the socket (see the POST below), never
+			// buffered, so a multi-gigabyte context doesn't inflate RSS. Decide the
+			// source and the dockerfile name here; the blocking tar walk happens
+			// while the request body is being sent.
+			let (source, dockerfile_name) = match build.dockerfile_inline() {
+				Some(inline) => (
+					ContextSource::Inline(inline.to_string()),
+					INLINE_DOCKERFILE_NAME.to_string(),
+				),
+				None => {
+					// Honour an explicit dockerfile; otherwise prefer Dockerfile
+					// but fall back to Podman's native Containerfile when only the
+					// latter is present.
+					let df = match build.dockerfile() {
+						Some(name) => name.to_string(),
+						None if !context_path.join("Dockerfile").is_file()
+							&& context_path.join("Containerfile").is_file() =>
+						{
+							"Containerfile".to_string()
+						}
+						None => "Dockerfile".to_string(),
+					};
+					(ContextSource::Dockerfile(df.clone()), df)
+				}
+			};
+			(
+				BodyPlan::Stream {
+					context: context_path,
+					source,
+					secrets: secret_files,
+				},
+				dockerfile_name,
+				secret_specs,
+			)
+		};
+
+		let arg_map = build.args().to_map();
+		let mut build_args: std::collections::HashMap<String, String> =
+			std::collections::HashMap::new();
+		for (k, v) in arg_map {
+			let value = v.unwrap_or_else(|| std::env::var(&k).unwrap_or_default());
+			build_args.insert(k, value);
+		}
+		// CLI `--build-arg KEY=VAL` overrides the compose `build.args`. A bare
+		// `KEY` (no `=`) takes its value from the process environment, matching
+		// docker compose.
+		for entry in &opts.build_args {
+			let (k, v) = match entry.split_once('=') {
+				Some((k, v)) => (k.to_string(), v.to_string()),
+				None => (entry.clone(), std::env::var(entry).unwrap_or_default()),
+			};
+			// A bare `=value` (empty key) is a user typo Podman would silently
+			// ignore; reject it with a clear diagnostic instead.
+			if k.is_empty() {
+				return Err(ComposeError::Build(format!(
+					"invalid --build-arg '{entry}': empty argument name"
+				)));
+			}
+			build_args.insert(k, v);
+		}
+
+		// A secret passed as a build arg is recorded in the image history and, if
+		// promoted via `ENV`, the image config — so it can leak. Warn and point at
+		// `build.secrets` (BuildKit `--mount=type=secret`), which does not persist.
+		let mut secretish: Vec<&str> = build_args
+			.keys()
+			.filter(|k| looks_like_secret(k))
+			.map(String::as_str)
+			.collect();
+		if !secretish.is_empty() {
+			secretish.sort_unstable();
+			warn!(
+				"build-arg(s) [{}] look like secrets; build args are stored in the image history \
+				 and can leak. Use build.secrets for sensitive values.",
+				secretish.join(", ")
+			);
+		}
+
+		let mut labels: std::collections::HashMap<String, String> =
+			std::collections::HashMap::new();
+		if let BuildConfig::Config { labels: l, .. } = build {
+			labels.extend(l.to_map());
+		}
+
+		// Pre-validate the keys libpod's buildkit-fronted parser rejects
+		// (anything outside `[A-Za-z0-9_.-]`), so a bad `build.args` or
+		// `build.labels` key surfaces as a `PodmanError::Field` naming the
+		// compose-side field rather than libpod's `400` body. Runs before
+		// the build URL is assembled so a bad key fails before any POST to
+		// the daemon (#1357).
+		pre_validate_build(&build_args, &labels)?;
+
+		let network = if let BuildConfig::Config {
+			network: Some(n), ..
+		} = build
+		{
+			Some(n.clone())
+		} else {
+			None
+		};
+		let platform = match build {
+			BuildConfig::Config { platforms, .. } => platforms.first().inspect(|first| {
+				let rest_count = platforms.len() - 1;
+				if rest_count > 0 {
+					warn!("build.platforms: libpod builds one platform per request; building {first}, ignoring {rest_count} other(s)");
+				}
+			}).cloned(),
+			_ => None,
+		};
+		// Distinguish "absent" from "present but unparseable": a malformed
+		// `shm_size` must be rejected, not silently dropped to the default.
+		let shmsize = match build.shm_size() {
+			Some(raw) => Some(size::parse_memory(raw).ok_or_else(|| {
+				ComposeError::Build(format!("invalid build.shm_size value '{raw}'"))
+			})? as i32),
+			None => None,
+		};
+		let extrahosts_str = build.extra_hosts().join(",");
+		let extrahosts = if extrahosts_str.is_empty() {
+			None
+		} else {
+			Some(extrahosts_str)
+		};
+		let cachefrom = if build.cache_from().is_empty() {
+			None
+		} else {
+			Some(super::super::to_query_json(
+				"build.cache_from",
+				&build.cache_from(),
+			)?)
+		};
+		let buildargs_json = if build_args.is_empty() {
+			None
+		} else {
+			Some(super::super::to_query_json("build.args", &build_args)?)
+		};
+		let labels_json = if labels.is_empty() {
+			None
+		} else {
+			Some(super::super::to_query_json("build.labels", &labels)?)
+		};
+		let build_ulimits = super::render_build_ulimits(build);
+		let ulimits_json = if build_ulimits.is_empty() {
+			None
+		} else {
+			Some(super::super::to_query_json(
+				"build.ulimits",
+				&build_ulimits,
+			)?)
+		};
+
+		let mut qs = format!(
+			"t={}&rm=true&nocache={}",
+			urlencoded(&tag),
+			build.no_cache() || opts.no_cache
+		);
+		qs.push_str(&format!("&dockerfile={}", urlencoded(&dockerfile_name)));
+		if build.pull() || opts.pull {
+			qs.push_str("&pull=true");
+		}
+		if let Some(p) = &platform {
+			qs.push_str(&format!("&platform={}", urlencoded(p)));
+		}
+		if let Some(n) = &network {
+			qs.push_str(&format!("&networkmode={}", urlencoded(n)));
+		}
+		if let Some(s) = shmsize {
+			qs.push_str(&format!("&shmsize={s}"));
+		}
+		if let Some(h) = &extrahosts {
+			qs.push_str(&format!("&extrahosts={}", urlencoded(h)));
+		}
+		if let Some(c) = &cachefrom {
+			qs.push_str(&format!("&cachefrom={}", urlencoded(c)));
+		}
+		if let Some(a) = &buildargs_json {
+			qs.push_str(&format!("&buildargs={}", urlencoded(a)));
+		}
+		if let Some(l) = &labels_json {
+			qs.push_str(&format!("&labels={}", urlencoded(l)));
+		}
+		if let Some(u) = &ulimits_json {
+			qs.push_str(&format!("&ulimits={}", urlencoded(u)));
+		}
+		if let Some(target) = build.target() {
+			qs.push_str(&format!("&target={}", urlencoded(target)));
+		}
+		if !secret_specs.is_empty() {
+			let json = super::super::to_query_json("build.secrets", &secret_specs)?;
+			qs.push_str(&format!("&secrets={}", urlencoded(&json)));
+		}
+		if !build.cache_to().is_empty() {
+			let json = super::super::to_query_json("build.cache_to", &build.cache_to())?;
+			qs.push_str(&format!("&cacheto={}", urlencoded(&json)));
+		}
+		for (name, value) in build.additional_contexts() {
+			let mapped = map_additional_context(&self.base_dir, &value);
+			qs.push_str(&format!(
+				"&additionalbuildcontexts={}",
+				urlencoded(&format!("{name}={mapped}"))
+			));
+		}
+		if !build.ssh().is_empty() {
+			warn!(
+				"build.ssh is not supported over the libpod REST build API; ignoring {:?}",
+				build.ssh()
+			);
+		}
+
+		if remote_context {
+			qs.push_str(&format!("&remote={}", urlencoded(&context_str)));
+		}
+
+		let path = format!("{API_PREFIX}/build?{qs}");
+		let resp = match body_plan {
+			BodyPlan::Empty => self
+				.client
+				.post_bytes_stream(&path, Bytes::new(), "application/x-tar")
+				.await
+				.map_err(ComposeError::Podman)?,
+			BodyPlan::Stream {
+				context,
+				source,
+				secrets,
+			} => {
+				// The tar writer runs on a blocking thread feeding the request
+				// body; drain the body first, then join the writer — joining
+				// before the body is drained would deadlock on the bounded
+				// channel. If the request itself failed, that transport error is
+				// the real cause; otherwise surface any context-assembly error.
+				let (producer, body) = context_body(context, source, secrets);
+				let sent = self
+					.client
+					.post_stream_body(&path, body, "application/x-tar")
+					.await;
+				let produced = producer
+					.await
+					.map_err(|e| ComposeError::Build(e.to_string()))?;
+				match sent {
+					Ok(resp) => {
+						produced?;
+						resp
+					}
+					Err(e) => return Err(ComposeError::Podman(e)),
+				}
+			}
+		};
+		let mut stream = crate::libpod::parse_json_lines::<BuildOutput>(resp.into_body());
+
+		// Open the board row for this image before the first `STEP` line, so
+		// the row's `Building` verb is what the reader sees while the stream
+		// arrives. `progress::start` is a no-op when the board already had
+		// the row seeded (`build_all_with_options` did this for a standalone
+		// `build`), and inserts it before the service's container row when
+		// `up --build` calls into a board the `up` pass opened. Either way,
+		// the row ends up with the right identifier, in the right position
+		// and with a working verb (#1681).
+		if !opts.quiet {
+			let first_container = self.replica_names(service_name, service).into_iter().next();
+			match first_container {
+				Some(container_name) => crate::ui::progress::start_anchored(
+					"Image",
+					&tag,
+					"Building",
+					Some("Container"),
+					Some(&container_name),
+				),
+				None => crate::ui::progress::start("Image", &tag, "Building"),
+			}
+		}
+
+		// The captured stream of this image: needed on a terminal failure
+		// path, where the notes buffer only kept the last 4 lines and the
+		// rest has to be replayed as scrollback so the reason is on screen.
+		// Off a terminal, every line is already in stderr through `note_for`,
+		// so this stays empty in the test runs.
+		let mut capture: Vec<String> = Vec::new();
+		// Track the last image id the stream emitted, so the success path
+		// can put it on stdout when stdout is not a terminal. Buildah
+		// closes with a `--> sha256:<64-hex>` line, which is what a script
+		// capturing stdout wants; on a terminal it is dropped (the row
+		// already says it landed). `None` until the first matching line.
+		let mut last_image_id: Option<String> = None;
+		let mut progress = BuildStreamProgress::new();
+
+		while let Some(result) = stream.next().await {
+			match result {
+				Ok(output) => {
+					if !output.stream.is_empty() {
+						let trimmed = output.stream.trim_end().to_string();
+						if !opts.quiet && !trimmed.is_empty() {
+							// `STEP n/m:` lines advance the row verb. Every
+							// other line is a tail note, painted dimmed under
+							// the row on a terminal and prefixed on stderr in
+							// a pipe.
+							if let Some(verb) = progress.observe(&trimmed) {
+								crate::ui::progress::start("Image", &tag, &verb);
+							}
+							// The image id line is the one carry-over from
+							// today that a script reading stdout needs. It
+							// goes to notes/live as any other line, and is
+							// additionally stashed so the success path can
+							// echo it to stdout when stdout is not a tty.
+							if let Some(id) = parse_image_id_line(&trimmed) {
+								last_image_id = Some(id);
+							}
+							crate::ui::progress::note_for("Image", &tag, &trimmed);
+						}
+						capture.push(trimmed);
+					}
+					if let Some(err) = output.error_detail.and_then(|e| e.message) {
+						return Err(self.fail_build(&tag, err, capture, opts.quiet));
+					}
+					if let Some(err) = output.error {
+						if !err.is_empty() {
+							return Err(self.fail_build(&tag, err, capture, opts.quiet));
+						}
+					}
+				}
+				Err(e) => return Err(ComposeError::Podman(e)),
+			}
+		}
+
+		// Success: close the row with `Built`. The trailing image id goes to
+		// stdout only when stdout is not a terminal, so a script reading
+		// `podup build | awk '{print $1}'` can still pluck the id; on a
+		// terminal the row says it landed and the id would only be noise.
+		if !opts.quiet {
+			crate::ui::progress_line("Image", &tag, "Built");
+		}
+		if !std::io::stdout().is_terminal() {
+			let resolved = match last_image_id {
+				Some(id) => Some(id),
+				None => match self.image_id(&tag).await {
+					Ok(Some(id)) => Some(id),
+					_ => None,
+				},
+			};
+			if let Some(id) = resolved {
+				use std::io::Write;
+				let _ = writeln!(std::io::stdout(), "{id}");
+			}
+		}
+
+		self.apply_extra_tags(build, &tag).await?;
+		Ok(())
+	}
+
+	/// Apply any `build.tags` aliases to the freshly built image.
+	///
+	/// The primary `tag` is skipped: when no `image:` is set it is already
+	/// `tags[0]`, which the build itself produced, so re-tagging it onto itself
+	/// would be a no-op API call.
+	async fn apply_extra_tags(&self, build: &BuildConfig, tag: &str) -> Result<()> {
+		for extra_tag in build.tags() {
+			if extra_tag == tag {
+				continue;
+			}
+			let (repo, tag_str) = extra_tag
+				.rsplit_once(':')
+				.map(|(r, t)| (r.to_string(), t.to_string()))
+				.unwrap_or_else(|| (extra_tag.clone(), "latest".to_string()));
+			let encoded_tag = urlencoded(tag);
+			let tag_path = format!(
+				"{API_PREFIX}/images/{encoded_tag}/tag?repo={}&tag={}",
+				urlencoded(&repo),
+				urlencoded(&tag_str),
+			);
+			// Returning () here meant `build` could not report a failed tag at
+			// all: it exited 0 with the requested tags missing.
+			self.client
+				.post_empty_ok(&tag_path)
+				.await
+				.map_err(ComposeError::Podman)?;
+		}
+		Ok(())
+	}
+}

--- a/internal/engine/container/mod_tests.rs
+++ b/internal/engine/container/mod_tests.rs
@@ -23,7 +23,7 @@ async fn x_podman_autoupdate_puts_the_label_on_the_container_spec() {
 	let file =
 		crate::parse_str("services:\n  web:\n    image: img\n    x-podman-autoupdate: registry\n")
 			.unwrap();
-	e.up_with_options(&file, false, &[], &[], false, false, false)
+	e.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect("a healthy up must succeed");
 
@@ -68,7 +68,7 @@ async fn x_podman_autoupdate_rejects_a_bogus_value_at_create_time() {
 		crate::parse_str("services:\n  web:\n    image: img\n    x-podman-autoupdate: always\n")
 			.unwrap();
 	let err = e
-		.up_with_options(&file, false, &[], &[], false, false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect_err("a bogus autoupdate value must be rejected at create time");
 	let msg = err.to_string();

--- a/internal/engine/lifecycle/images.rs
+++ b/internal/engine/lifecycle/images.rs
@@ -57,9 +57,11 @@ impl Engine {
 		// start the previous image. It also made `--build` look like a no-op,
 		// since the default already always built.
 		//
-		// `--build` is handled before this by an explicit `build_all`, so a forced
-		// rebuild has already happened and the image is present by the time we get
-		// here.
+		// `--build` is handled before this by an inline build pass at the top of
+		// `run_up` (#1700), so a forced rebuild has already happened and the
+		// image is present by the time we get here. The `start_anchored` path
+		// below is the missing-image case: an `up` without `--build` whose
+		// image is absent from the host, built lazily on the `up` board.
 		let needs_build = if service.build.is_some() && !self.no_build {
 			!self
 				.image_present(&self.service_image_tag(name, service))

--- a/internal/engine/lifecycle/images_tests.rs
+++ b/internal/engine/lifecycle/images_tests.rs
@@ -46,7 +46,7 @@ async fn warm_up_does_not_pull_an_image_the_host_already_has() {
 	)
 	.unwrap();
 
-	e.up_with_options(&file, false, &[], &[], false, false, false)
+	e.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect("a warm up on a present image must succeed");
 
@@ -80,7 +80,7 @@ async fn an_always_policy_still_pulls_an_image_another_service_saw_present() {
 	)
 	.unwrap();
 
-	e.up_with_options(&file, false, &[], &[], false, false, false)
+	e.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect("an always-policy up must succeed");
 
@@ -104,7 +104,7 @@ async fn a_platform_pinned_service_still_pulls_an_image_the_host_already_has() {
 	)
 	.unwrap();
 
-	e.up_with_options(&file, false, &[], &[], false, false, false)
+	e.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect("a platform-pinned up must succeed");
 
@@ -219,7 +219,7 @@ async fn up_with_a_missing_image_builds_on_the_same_board() {
 
 	let capture = Capture::start();
 	engine
-		.up_with_options(&compose, true, &[], &[], false, false, false)
+		.up_with_options(&compose, true, &[], &[], false, false, false, false)
 		.await
 		.expect("an up that builds its missing image succeeds");
 

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -57,7 +57,7 @@ pub(crate) struct ExistingContainer {
 impl Engine {
 	/// Start all services defined in the compose file, creating containers that do not exist.
 	pub async fn up(&self, file: &ComposeFile) -> Result<()> {
-		self.up_with_options(file, false, &[], &[], false, false, false)
+		self.up_with_options(file, false, &[], &[], false, false, false, false)
 			.await
 	}
 

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -82,7 +82,7 @@ impl Engine {
 					.map(|set| set.into_iter().filter(|n| n != service_name).collect())
 					.unwrap_or_default();
 			if !deps.is_empty() {
-				self.up_with_options(file, true, &[], &deps, false, false, false)
+				self.up_with_options(file, true, &[], &deps, false, false, false, false)
 					.await?;
 			}
 		}

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -160,7 +160,7 @@ impl Engine {
 		// `--scale` override against the last-wins target (so duplicate pairs such
 		// as `svc=1 svc=3` can no longer drive create and prune to disagree).
 		let targets: Vec<String> = pairs.iter().map(|(s, _)| s.clone()).collect();
-		self.up_with_options(file, true, &[], &targets, true, false, true)
+		self.up_with_options(file, true, &[], &targets, true, false, true, false)
 			.await?;
 		Ok(())
 	}

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -90,7 +90,7 @@ async fn up_prefetches_every_levels_image_before_any_container_create() {
 	)
 	.unwrap();
 
-	e.up_with_options(&file, false, &[], &[], false, false, false)
+	e.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect("a healthy two-level up must succeed");
 
@@ -141,7 +141,7 @@ async fn up_creates_and_starts_every_scaled_replica() {
 
 	let file = crate::parse_str("services:\n  web:\n    image: img\n    scale: 3\n").unwrap();
 
-	e.up_with_options(&file, false, &[], &[], false, false, false)
+	e.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect("a healthy scaled-up must succeed");
 
@@ -192,7 +192,7 @@ async fn up_replica_fanout_surfaces_deterministic_first_error_after_attempting_t
 	let file = crate::parse_str("services:\n  web:\n    image: img\n    scale: 3\n").unwrap();
 
 	let err = e
-		.up_with_options(&file, false, &[], &[], false, false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.expect_err("a genuine replica start failure must propagate, not exit 0");
 	assert!(
@@ -240,7 +240,7 @@ async fn up_replica_fanout_preserves_the_no_recreate_skip_per_replica() {
 
 	// `no_recreate = true` (docker compose create / the `scale` path): an
 	// already-present replica is left in place instead of being recreated.
-	e.up_with_options(&file, false, &[], &[], true, false, false)
+	e.up_with_options(&file, false, &[], &[], true, false, false, false)
 		.await
 		.expect("a partially-existing scaled up must succeed");
 

--- a/internal/engine/lifecycle/up.rs
+++ b/internal/engine/lifecycle/up.rs
@@ -9,12 +9,19 @@ use crate::compose::types::ComposeFile;
 use crate::error::Result;
 
 use crate::libpod::API_PREFIX;
+use crate::ui::progress::Kind;
 
 use super::super::profiles::{active_profiles_set, enabled_profile_services};
 use super::super::Engine;
 
 impl Engine {
 	/// Start services with explicit options. When `no_recreate` is true, running containers are left untouched. On partial failure, staging directories are cleaned up.
+	///
+	/// `build` is the CLI `--build` flag: when set, every service with a
+	/// `build:` block is built before the network/volume/container stages run,
+	/// inside the same `up` board (`#1700`). The image rows are seeded at the
+	/// top so the build verb appears above the container rows that depend on
+	/// it.
 	#[allow(clippy::too_many_arguments)]
 	pub async fn up_with_options(
 		&self,
@@ -25,6 +32,7 @@ impl Engine {
 		no_recreate: bool,
 		force_recreate: bool,
 		no_deps: bool,
+		build: bool,
 	) -> Result<()> {
 		self.run_up(
 			file,
@@ -34,6 +42,7 @@ impl Engine {
 			force_recreate,
 			no_deps,
 			true,
+			build,
 		)
 		.await
 	}
@@ -60,6 +69,7 @@ impl Engine {
 			force_recreate,
 			no_deps,
 			false,
+			false,
 		)
 		.await
 	}
@@ -74,6 +84,7 @@ impl Engine {
 		force_recreate: bool,
 		no_deps: bool,
 		start: bool,
+		build: bool,
 	) -> Result<()> {
 		let result = async {
 			// Reject any volume/network/container name Podman's regex would refuse
@@ -155,7 +166,44 @@ impl Engine {
 			// compose file — while every progress event in the tree fires once
 			// its work is already over. A board grown from those events would be
 			// a transcript with extra steps.
-			crate::ui::progress::begin(self.up_resources(file, &enabled, &target_set));
+			let mut resources = self.up_resources(file, &enabled, &target_set);
+			// `up --build` shares one board with the build phase (#1700): the
+			// image rows are seeded at the top, in `build_all`'s order, so they
+			// read as the prerequisite of the network/container rows that
+			// follow. The loop runs below, inside this same `up` board, so the
+			// build's `Building`/`Built` verbs land on the same rows the rest
+			// of `up` is drawing on.
+			let build_names = if build && !self.no_build {
+				up_build_targets(file, &enabled, &target_set)
+			} else {
+				Vec::new()
+			};
+			let image_tags = crate::engine::build::build_image_tags(self, file, &build_names);
+			if !image_tags.is_empty() {
+				let image_rows = image_tags
+					.iter()
+					.cloned()
+					.map(|tag| (Kind::Image, tag))
+					.collect::<Vec<_>>();
+				resources.splice(0..0, image_rows);
+			}
+			crate::ui::progress::begin(resources);
+
+			// Run the build inline on the same board, right after seeding. A
+			// failed build fails `up` the way a failed network create does
+			// today: the `?` propagates, the outer `end` still runs, the
+			// board closes once. The build itself is unchanged: same requests,
+			// same `Building n/m` verbs, same folded tail and failure replay
+			// as a standalone `build`. Only the surrounding board is now the
+			// one `up` already opened.
+			if !build_names.is_empty() {
+				self.build_images_in_session(
+					file,
+					&build_names,
+					&crate::engine::BuildOptions::default(),
+				)
+				.await?;
+			}
 
 			self.create_networks(file).await?;
 			self.create_volumes(file).await?;
@@ -253,3 +301,39 @@ impl Engine {
 		result
 	}
 }
+
+/// The services `up --build` should build, in the order `build_all` would
+/// iterate them. Filters the file's services through the same profile and
+/// target checks the rest of the `up` walk applies (`#1700`), then keeps
+/// only those that have a `build:` block. With no explicit targets and no
+/// active target set, that is every service with `build:` in the file.
+/// The same "build every service with `build:`" rule the standalone `build`
+/// command follows when called without arguments.
+fn up_build_targets(
+	file: &crate::compose::types::ComposeFile,
+	enabled: &std::collections::HashSet<String>,
+	target_set: &Option<std::collections::HashSet<String>>,
+) -> Vec<String> {
+	file.services
+		.iter()
+		.filter(|(name, service)| {
+			if service.build.is_none() {
+				return false;
+			}
+			if !enabled.contains(*name) {
+				return false;
+			}
+			if let Some(set) = target_set {
+				if !set.contains(*name) {
+					return false;
+				}
+			}
+			true
+		})
+		.map(|(name, _)| name.clone())
+		.collect()
+}
+
+#[cfg(all(test, unix))]
+#[path = "up_build_board_tests.rs"]
+mod up_build_board_tests;

--- a/internal/engine/lifecycle/up_build_board_tests.rs
+++ b/internal/engine/lifecycle/up_build_board_tests.rs
@@ -1,0 +1,169 @@
+//! `up --build` draws a single board, with the image row at the top and the
+//! network/container rows that follow.
+//!
+//! Two assertions, kept on the same file because they pin the two halves of
+//! the `#1700` contract:
+//!
+//! - `up_with_a_missing_image_builds_on_the_same_board` (in `images_tests.rs`)
+//!   pins the *missing-image* path: an `up` without `--build` whose image is
+//!   not local builds it on the `up` board, with the image row above the
+//!   service's container row. That path is the one `#1681` kept on purpose.
+//!
+//! - `up_build_draws_a_single_board_with_the_image_row_first` (here) pins the
+//!   `--build` path: a forced rebuild runs in the *same* board the rest of
+//!   `up` is drawing on, with the image row first and the build verb closing
+//!   before any container row moves. Before this fix the build drew its own
+//!   board first and `up` opened a second one.
+
+use crate::engine::fake_podman::{self, FakeReply};
+use crate::engine::Engine;
+use crate::ui::progress::capture::Capture;
+use crate::ui::progress::Kind;
+
+const STREAM: &[&str] = &[
+	"{\"stream\":\"STEP 1/2: FROM docker.io/library/alpine:3.20\\n\"}\n",
+	"{\"stream\":\"--> 3f3c8b769775\\n\"}\n",
+	"{\"stream\":\"STEP 2/2: CMD [\\\"echo\\\",\\\"hi\\\"]\\n\"}\n",
+	"{\"stream\":\"--> 9f3c8b769775\\n\"}\n",
+	"{\"stream\":\"COMMIT localhost/ux-up-build:1\\n\"}\n",
+	"{\"stream\":\"--> sha256:1111111111111111111111111111111111111111111111111111111111111111\\n\"}\n",
+	"{\"stream\":\"Successfully tagged localhost/ux-up-build:1\\n\"}\n",
+];
+
+/// `up -d --build` on a two-service project where exactly one service has a
+/// `build:` block draws one board: the image row first, then the network and
+/// container rows, and the image row's `Built` verb closes before any
+/// container row moves. The build verb itself is the same `Building`/`Built`
+/// pair the standalone `build` produces. Only the surrounding board is the
+/// one `up` already opened.
+#[tokio::test]
+async fn up_build_draws_a_single_board_with_the_image_row_first() {
+	let chunks: Vec<String> = STREAM.iter().map(|s| s.to_string()).collect();
+	let fake = fake_podman::start_replying(move |method, target| {
+		if method == "POST" && target.contains("/build?") {
+			FakeReply::ChunkedEnd(chunks.clone())
+		} else if method == "POST" && target.contains("/images/") && target.contains("/tag") {
+			FakeReply::Body(200, String::new())
+		} else if method == "POST" && target.contains("/images/pull") {
+			// The sidecar's image has to be pullable for `start_services_by_dependency`
+			// to land its create/start path. The build service's image is absent
+			// before its build runs, so its inspect returns 404 below.
+			FakeReply::Body(200, String::new())
+		} else if method == "GET" && target.contains("/images/") && target.contains("/json") {
+			if target.contains("ux-up-build") {
+				// The build service's image is absent before its build runs.
+				FakeReply::Body(404, r#"{"message":"no such image"}"#.to_string())
+			} else {
+				// The sidecar's image is present locally.
+				FakeReply::Body(200, r#"{"Id":"sha256:cafe"}"#.to_string())
+			}
+		} else if method == "GET" && target.contains("/containers/json") {
+			FakeReply::Body(200, "[]".to_string())
+		} else if method == "POST" && target.contains("/containers/create") {
+			FakeReply::Body(200, "{}".to_string())
+		} else if method == "POST" && target.contains("/start") {
+			FakeReply::Body(200, String::new())
+		} else {
+			FakeReply::Body(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+
+	let ctx = tempfile::tempdir().expect("tempdir");
+	std::fs::write(
+		ctx.path().join("Dockerfile"),
+		b"FROM docker.io/library/alpine:3.20\nCMD [\"echo\",\"hi\"]\n",
+	)
+	.expect("write Dockerfile");
+	let mut engine = Engine::with_base_dir(fake.client(), "proj".into(), ctx.path().to_path_buf());
+	engine.no_warn = true;
+
+	let compose = crate::parse_str(
+		"\
+services:
+  app:
+    image: localhost/ux-up-build:1
+    build:
+      context: .
+    command: [\"echo\",\"hi\"]
+  sidecar:
+    image: docker.io/library/alpine:3.20
+    command: [\"echo\",\"hi\"]
+",
+	)
+	.unwrap();
+
+	let capture = Capture::start();
+	engine
+		.up_with_options(&compose, true, &[], &[], false, false, false, true)
+		.await
+		.expect("an up --build that builds its image succeeds");
+
+	// One board: the seed before this fix was a separate `build_all` board
+	// that opened and closed before `up` opened its own.
+	let boards = capture.boards();
+	assert_eq!(
+		boards.len(),
+		1,
+		"`up --build` must draw a single board: {boards:?}"
+	);
+
+	// The image row sits before the network and container rows the rest of
+	// `up` is responsible for. Two services, one with a build: the build
+	// service's image is on top, the sidecar's container row follows.
+	let names = capture.names();
+	assert!(
+		names.first().map(String::as_str) == Some("localhost/ux-up-build:1"),
+		"the image row is first: {names:?}"
+	);
+	assert!(
+		names.iter().any(|n| n == "proj-app-1"),
+		"the build service's container row is on the same board: {names:?}"
+	);
+	assert!(
+		names.iter().any(|n| n == "proj-sidecar-1"),
+		"the sidecar's container row is on the same board: {names:?}"
+	);
+
+	// Build verb lifecycle on the same board: `Building` then `Built`, and
+	// `Built` lands before any container row's first verb. Captured from
+	// the per-thread event log so the test does not depend on whether the
+	// engine opened a live region.
+	let verbs = capture.verbs();
+	let built_pos = verbs
+		.iter()
+		.position(|(_, n, v)| n == "localhost/ux-up-build:1" && v == "Built")
+		.expect("the image row closes Built");
+	let first_container_pos = verbs
+		.iter()
+		.position(|(_, n, _)| n == "proj-app-1" || n == "proj-sidecar-1")
+		.expect("at least one container row receives an event");
+	assert!(
+		verbs
+			.iter()
+			.any(|(_, n, v)| n == "localhost/ux-up-build:1" && v == "Building"),
+		"the image row opens Building: {verbs:?}"
+	);
+	assert!(
+		built_pos < first_container_pos,
+		"the image row's Built verb lands before any container row's first event: {verbs:?}"
+	);
+
+	// All rows are the kinds the board is responsible for: one Image row at
+	// the top, plus Networks and Containers below. A wrong kind here would
+	// mean a row got seeded against the wrong column.
+	let rows = capture.rows();
+	assert!(
+		rows.iter().any(|(kind, _)| *kind == Kind::Image),
+		"an Image row sits on the board: {rows:?}"
+	);
+	assert!(
+		rows.iter()
+			.all(|(kind, _)| matches!(kind, Kind::Image | Kind::Network | Kind::Container)),
+		"every row is an Image, Network or Container: {rows:?}"
+	);
+
+	assert!(
+		capture.every_board_ended(),
+		"the single board closes on the way out"
+	);
+}

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -134,10 +134,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 	let name_width = board
 		.live_rows()
 		.iter()
-		.map(|r| r.name.chars().count())
-		.max()
-		.unwrap_or(0)
-		.clamp(12, 40);
+		.fold(0, |width, r| name_column_width(width, &r.name));
 	let region = live.then(|| live::Region::new(live::Target::Stderr));
 	if let Ok(mut slot) = SESSION.lock() {
 		*slot = Some(Session {
@@ -213,6 +210,11 @@ pub fn start_anchored(
 				} else {
 					session.board.start(kind, name, verb, Instant::now());
 				}
+				// A row that was not seeded (the image row `up` inserts for a
+				// missing image, #1684) can be wider than the column `begin`
+				// sized from the seeded names; without this it rendered as
+				// `localhost/u…` while every seeded row fit (#1700).
+				session.name_width = name_column_width(session.name_width, name);
 				if session.region.is_some() {
 					Sink::Live
 				} else {
@@ -299,6 +301,23 @@ fn push_note_live(
 
 #[cfg(test)]
 pub(crate) const MAX_NOTES_PER_ROW_FOR_TESTS: usize = MAX_NOTES_PER_ROW;
+
+/// The name column is as wide as the widest name it has seen, never under
+/// 12 or over 40 cells; a name past 40 is cut with an ellipsis by the row
+/// renderer. Applied at `begin` over the seeded rows and again for every row
+/// `start` adds later.
+fn name_column_width(current: usize, name: &str) -> usize {
+	current.max(name.chars().count()).clamp(12, 40)
+}
+
+#[cfg(test)]
+pub(crate) fn name_width_for_tests() -> usize {
+	SESSION
+		.lock()
+		.ok()
+		.and_then(|slot| slot.as_ref().map(|s| s.name_width))
+		.unwrap_or(0)
+}
 
 #[cfg(test)]
 pub(crate) fn push_note_live_for_tests(

--- a/internal/ui/progress/mod_tests.rs
+++ b/internal/ui/progress/mod_tests.rs
@@ -300,3 +300,38 @@ fn notes_keep_the_last_four_lines_per_row() {
 		"the cap is enforced on every push"
 	);
 }
+
+/// A row inserted after `begin` widens the name column to fit it. `up`
+/// inserts the image row for a missing image that way (#1684), and the
+/// column had been sized from the seeded rows only, so the image name came
+/// out as `localhost/u…` (#1700).
+#[test]
+fn a_row_added_after_begin_widens_the_name_column() {
+	let _session = hold_session();
+	let prev_progress = super::super::progress_enabled();
+	super::super::set_progress(true);
+	super::super::progress::begin(vec![
+		(Kind::Network, "p_default".to_string()),
+		(Kind::Container, "p-web-1".to_string()),
+	]);
+	assert_eq!(
+		super::super::progress::name_width_for_tests(),
+		12,
+		"the seeded names are shorter than the 12-cell floor"
+	);
+	super::super::progress::start_anchored(
+		"Image",
+		"localhost/a-rather-long-image:1",
+		"Building",
+		Some("Container"),
+		Some("p-web-1"),
+	);
+	assert_eq!(
+		super::super::progress::name_width_for_tests(),
+		"localhost/a-rather-long-image:1".len(),
+		"the inserted row's name sets the column width"
+	);
+	super::super::progress::end();
+	reset_plain_buffer();
+	super::super::set_progress(prev_progress);
+}

--- a/tests/engine_integration/build_images.rs
+++ b/tests/engine_integration/build_images.rs
@@ -572,7 +572,7 @@ async fn up_keeps_the_image_a_no_cache_build_produced() {
 	let after_build = image_id(&tag);
 
 	engine
-		.up_with_options(&file, true, &[], &[], false, false, false)
+		.up_with_options(&file, true, &[], &[], false, false, false, false)
 		.await
 		.unwrap();
 	let after_up = image_id(&tag);

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -539,7 +539,7 @@ async fn engine_up_renew_anon_volumes_recreates_cleanly() {
 	engine.up(&file).await.unwrap();
 	// Force recreate: the v=true delete path runs for the existing container.
 	let second = engine
-		.up_with_options(&file, false, &[], &[], false, true, false)
+		.up_with_options(&file, false, &[], &[], false, true, false, false)
 		.await;
 	engine.down(&file).await.unwrap();
 	second.expect("forced re-up with --renew-anon-volumes must succeed");

--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -49,7 +49,7 @@ fn active_profiles_via_env() {
 			.unwrap();
 			// Pass empty active_profiles slice so it falls back to COMPOSE_PROFILES env
 			engine
-				.up_with_options(&file, false, &[], &[], false, false, false)
+				.up_with_options(&file, false, &[], &[], false, false, false, false)
 				.await
 				.unwrap();
 			let mut names = engine
@@ -297,7 +297,16 @@ async fn target_services_skips_non_dep() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
+		.up_with_options(
+			&file,
+			false,
+			&[],
+			&["web".to_string()],
+			false,
+			false,
+			false,
+			false,
+		)
 		.await
 		.unwrap();
 	let mut names = engine
@@ -334,7 +343,7 @@ async fn dep_on_profile_filtered_service() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &[], false, false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.unwrap();
 	let mut names = engine

--- a/tests/engine_integration/lifecycle.rs
+++ b/tests/engine_integration/lifecycle.rs
@@ -79,7 +79,7 @@ async fn up_no_recreate_skips_running() {
 	)
 	.unwrap();
 	engine
-		.up_with_options(&changed, false, &[], &[], true, false, false)
+		.up_with_options(&changed, false, &[], &[], true, false, false, false)
 		.await
 		.unwrap();
 	let with_flag = engine
@@ -128,7 +128,16 @@ async fn up_target_services_only() {
 
 	// Only start web (and its dep db)
 	engine
-		.up_with_options(&file, false, &[], &["web".to_string()], false, false, false)
+		.up_with_options(
+			&file,
+			false,
+			&[],
+			&["web".to_string()],
+			false,
+			false,
+			false,
+			false,
+		)
 		.await
 		.unwrap();
 	let mut names = engine

--- a/tests/engine_integration/lifecycle_query.rs
+++ b/tests/engine_integration/lifecycle_query.rs
@@ -428,7 +428,7 @@ async fn up_skips_recreate_when_config_unchanged() {
 
 	// force_recreate -> recreate even though config is unchanged.
 	engine
-		.up_with_options(&file, false, &[], &[], false, true, false)
+		.up_with_options(&file, false, &[], &[], false, true, false, false)
 		.await
 		.unwrap();
 	let after_force = engine

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -50,7 +50,7 @@ async fn named_volume_created_on_up() {
 		.await
 		.unwrap();
 	engine
-		.up_with_options(&file, false, &[], &[], false, true, false)
+		.up_with_options(&file, false, &[], &[], false, true, false, false)
 		.await
 		.unwrap();
 	let after = engine
@@ -480,7 +480,7 @@ async fn profile_filtered_service_skipped() {
 	.unwrap();
 
 	engine
-		.up_with_options(&file, false, &[], &[], false, false, false)
+		.up_with_options(&file, false, &[], &[], false, false, false, false)
 		.await
 		.unwrap();
 	let mut names = engine


### PR DESCRIPTION
Closes #1700. Measured under a pseudo-terminal with the branch binary, frames deduplicated:

```
$ podup up -d --build
[+] Running 0/3
 ✔ Image     localhost/ux-talker:1 Built   0.3s
[+] Running 1/3
 ✔ Network   tup_default           Created   0.0s
[+] Running 2/3
 ✔ Container tup-talker-1          Started   0.1s
```

One board. The image rows sit at the top and are built one after another, in `build`'s order, before the network and container stages start; `dispatch.rs` no longer calls `build_all` for `--build`. `build` alone still draws its own board (`[+] Running 0/1`), and `up` with a missing image and no `--build` keeps the image row above the container row on the up board.

Two things found on the way:

- `build/mod.rs` went past the line limit, so `build_service` lives in `build/service.rs` now (private module of `build`); `build/mod.rs` is 167 code lines.
- The image row `up` inserts for a missing image rendered as `localhost/u…` while the seeded rows fit: the name column was sized at `begin` from the seeded names only. A row added after `begin` now widens it (same 12 to 40 clamp), with a unit test.

Tests: `up_build_draws_a_single_board_with_the_image_row_first` (one board, image row first, `Built` before any container event, against the fake Podman), `a_row_added_after_begin_widens_the_name_column`; the existing missing-image and build board tests stay green. Suite, contract tests, clippy and fmt clean locally.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>