### PR TITLE
chore(release): bump to 5.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.9.0"
+version = "5.9.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.9.0"
+version = "5.9.1"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (5.9.1) unstable; urgency=medium
+
+  * `up --build` draws one board: the image rows sit at the top and are
+    built one after another before the network and container rows follow
+    on the same board. A row added to a board after it opened widens the
+    name column, so the image row `up` inserts for a missing image is no
+    longer cut short.
+  * `port` on a port the service does not publish says so plainly instead
+    of calling it an unsupported feature; `config` prints the resolved
+    `name:` of every network, the default one included; CREATED in `ps`
+    and `images` reads `3 seconds ago`, not `3s`.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 04 Sep 2026 23:35:54 -0500
+
 podup (5.9.0) unstable; urgency=medium
 
   * Every command that acts on resources draws the live board: `up`, `down`,


### PR DESCRIPTION
Patch release for the CLI polish that landed after 5.9.0: one board for
up --build, the widened name column, port's plain message, config's
resolved network names and CREATED as a moment. No engine change.

## Verified

The three version comparisons of release.yml run locally: crate=5.9.1
lock=5.9.1 deb=5.9.1, GATE OK; cargo metadata --locked accepts the
lockfile.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>