### PR TITLE
docs: rewrite the em-dash sentences across docs, comments and generated text

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,7 +89,7 @@ updates:
   # Both group every update type, majors included, unlike the crate above. The
   # reason the main entry leaves majors out is that a major can change what
   # podup does for a user; nothing here is shipped, so a major in either is the
-  # same question as a patch — does the harness still build and run.
+  # same question as a patch: does the harness still build and run.
   - package-ecosystem: "cargo"
     directory: "/fuzz"
     schedule:

--- a/.github/podman-known-failures-5
+++ b/.github/podman-known-failures-5
@@ -1,9 +1,9 @@
 # Integration tests that fail on the Podman 5 nested-virt lane for environmental
 # reasons, not because podup is broken. The lane fails when a failing test is NOT
-# on this list — a new identity is a real regression, whatever the pass count says.
+# on this list: a new identity is a real regression, whatever the pass count says.
 #
 # Adding a line here is a claim that a test cannot pass under nested-virt. Make
-# that claim with a run, not a guess — the whole point of this file is that the
+# that claim with a run, not a guess: the whole point of this file is that the
 # 2026-07 regression (#1072) hid inside a count-only gate for a day and a
 # release. Remove a line the moment its test starts passing in the lane.
 #
@@ -11,13 +11,13 @@
 # nested virt. Podman's journald log driver could not open its library in this
 # image, so every logs request returned HTTP 500 and the VM served no logs at
 # all. With the file-based driver configured the lane went from 10 failures to
-# 2 — the six run/attach tests and cli_run_subcommand and cli_logs_tail_limits_output
+# 2: the six run/attach tests and cli_run_subcommand and cli_logs_tail_limits_output
 # all pass now. The claim "cannot pass under nested virt" was made honestly, with
 # a run, and was still wrong: the physical host that proved 155/155 also had a
 # working journald, so the comparison could not see the difference.
 #
 # 2026-07-25: the same mistake again, and the same shape. run_flags::engine_run_
-# applies_volume_publish_and_interactive was never about nested virt either — it
+# applies_volume_publish_and_interactive was never about nested virt either; it
 # bind-mounted a host directory with no SELinux relabel, so on an enforcing host
 # the container read it as `Permission denied`. Measured on Fedora 44 + Podman
 # 5.8.1 with plain `podman run`, no podup involved: without `z` the read is
@@ -27,8 +27,8 @@
 #
 # 2026-07-27: and with that the last entry goes too. The lane printed its own
 # stale-entry notice for niche::engine_events_stream_connects in three
-# consecutive runs — 30237701219, 30239588499 and the 12:26 nightly on main,
-# 30265944631 — each carrying `test niche::engine_events_stream_connects ... ok`
+# consecutive runs (30237701219, 30239588499 and the 12:26 nightly on main,
+# 30265944631) each carrying `test niche::engine_events_stream_connects ... ok`
 # in the log, 172 passed and 0 failed on both legs, and no retry fired on either.
 # The events stream was never the nested-virt casualty this line claimed it was;
 # the journald fix of 2026-07-20 is the likeliest reason it stopped failing, and
@@ -37,4 +37,4 @@
 # So this file is empty now, and so is its Podman 6 counterpart. That is the
 # loudest shape either can have: on both majors, any failing test is a regression
 # until a run says otherwise. If one appears here, classify it with a run and add
-# it back with the evidence — do not add it to make the red go away.
+# it back with the evidence; do not add it to make the red go away.

--- a/.github/podman-known-failures-6
+++ b/.github/podman-known-failures-6
@@ -1,13 +1,13 @@
 # Integration tests that fail on the Podman 6 nested-virt lane for environmental
 # reasons, not because podup is broken. The lane fails when a failing test is NOT
-# on this list — a new identity is a real regression, whatever the pass count says.
+# on this list: a new identity is a real regression, whatever the pass count says.
 #
 # The list is deliberately EMPTY. That is a claim, and here is the evidence for it.
 #
 # Podman 6 ran without an identity list for months because its failing set carried
 # a variable tail that a list built from observation would have turned into false
 # reds. It gated on the pass-count floor alone, and that floor reported the leg
-# GREEN through 31 failures in run 30222778630 — 141 passed against a floor of
+# GREEN through 31 failures in run 30222778630: 141 passed against a floor of
 # 115. The floor also loses resolution as the suite grows: those 31 were the same
 # environment defect as the historical 8–12, with more container-dependent tests
 # added for it to knock over.
@@ -15,7 +15,7 @@
 # The tail turned out to be one cause. Serialising the leg (#1039, run
 # 30225458799) took it from 31 failures to zero, with the
 # `rootless netns: mount resolv.conf … stub-resolv.conf: no such file or
-# directory` signature — four occurrences in the previous run — absent from the
+# directory` signature, four occurrences in the previous run, absent from the
 # log entirely. Podman 5 stayed at two threads as the control and produced its
 # usual timing, so the change was not in the harness. Concurrent container
 # creation against the shared rootless netns was the cause; nested virtualisation,
@@ -28,13 +28,13 @@
 # genuinely gone or whether one run was luck.
 #
 # When that happens: classify it with a run, the way every Podman 5 entry was, and
-# add it here with the evidence. Do NOT delete this file to make the red go away —
+# add it here with the evidence. Do NOT delete this file to make the red go away:
 # an empty list is what makes a regression loud, and going back to a count gate is
 # how #1072 shipped a bug with the pass count sitting comfortably above the floor.
 #
 # ONE THING TO KNOW BEFORE CLASSIFYING ANYTHING HERE: this leg's environment is not
 # fixed. It boots whatever Fedora Rawhide compose is newest when the job runs, so
-# most days it is a different operating system — different kernel, different
+# most days it is a different operating system: different kernel, different
 # systemd, everything below Podman. Two runs of this leg are not two observations
 # of one environment, which is very likely part of why the tail this file's header
 # describes resisted classification for as long as it did. The gate now prints the

--- a/.github/scripts/sign.py
+++ b/.github/scripts/sign.py
@@ -12,7 +12,7 @@ standard base64. When output-sig-file is omitted, writes <input-file>.sig.
 Rotation is by dual-TRUST, not dual-sign: consumers (install.sh, install.ps1,
 verify-debs.sh, internal/update/verify.rs) bake BOTH accepted public keys and
 accept a release signed by either, so the active signer can be switched to the
-second key with no consumer change. Only one detached .sig is ever produced — the
+second key with no consumer change. Only one detached .sig is ever produced, the
 one signature every verifier reads. Fails closed (exit 1) when the key is unset,
 to never publish an unsigned artifact.
 """

--- a/.github/scripts/verify-signing-key.py
+++ b/.github/scripts/verify-signing-key.py
@@ -92,7 +92,7 @@ def main() -> None:
 		"The signing secret and the keys baked into install.sh / install.ps1 / "
 		"internal/update/verify.rs disagree, so this release would be unverifiable "
 		"and uninstallable. Refusing to publish. Fix whichever side is wrong before "
-		"retagging — the tag is immutable once the release exists."
+		"retagging; the tag is immutable once the release exists."
 	)
 
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,17 +1,17 @@
 # Compose-tool benchmark.
 #
 # The published numbers must come from a controlled runner (a self-hosted runner
-# or the maintainer's machine), never a shared GitHub runner — shared runners are
+# or the maintainer's machine), never a shared GitHub runner; shared runners are
 # too noisy to be trustworthy. So this workflow has two jobs:
 #
-#   smoke      — on a shared GitHub runner, validates the harness code itself:
+#   smoke      runs on a shared GitHub runner and validates the harness itself:
 #                shell syntax, Python syntax, and the aggregation stats path run
 #                against inline sample rows. It does NOT install Podman or drive
-#                podup — ubuntu-latest ships Podman 4.9, below podup's floor
+#                podup: ubuntu-latest ships Podman 4.9, below podup's floor
 #                (Podman >= 5.0), so a shared-runner engine run would either fail
 #                or exercise an unsupported configuration. It produces NO
 #                published numbers and proves nothing about podup on real Podman.
-#   benchmark  — on a self-hosted runner (manual dispatch), runs the full suite
+#   benchmark  runs on a self-hosted runner (manual dispatch) over the full suite
 #                and uploads the report artifact. It is skipped until a runner with
 #                the `bench` label exists.
 name: benchmark
@@ -58,7 +58,7 @@ jobs:
       - name: Check the timer resolves below 10 ms
         # The defect this timer was written for was an instrument that could not
         # see under 10 ms, so it published `/bin/true` as 0.000 s. Assert the
-        # observable effect — a non-zero wall clock and a plausible RSS — rather
+        # observable effect (a non-zero wall clock and a plausible RSS) rather
         # than that the binary merely runs.
         run: |
           row="$(bench/timeit/target/release/timeit /bin/true)"

--- a/.github/workflows/binary-budget.yml
+++ b/.github/workflows/binary-budget.yml
@@ -1,8 +1,8 @@
 # A ceiling on the shipped binary, so an unexplained jump is a red run rather
 # than something noticed in a table months later.
 #
-# The releases standard asks for exactly this — "keep a size budget per artifact;
-# treat a large unexplained growth as a regression to investigate, not ship" —
+# The releases standard asks for exactly this: "keep a size budget per artifact;
+# treat a large unexplained growth as a regression to investigate, not ship",
 # and #1296 gave peak memory one. The binary had none: it went from 7,228,256
 # bytes at v3.3.0 to 7,347,248 on develop with nothing watching.
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       # gate `rust / Extra platforms` instead, which names no platform. #1552.
       extra-test-os: "[\"macos-latest\", \"windows-latest\"]"
       # Measured against the WHOLE crate, deliberately. The gate used to read 90%
-      # while a `coverage-ignore-regex` hid 36% of the code — 14,432 of 39,681
-      # regions — so it protected 58% of podup at 90% and said nothing about the
+      # while a `coverage-ignore-regex` hid 36% of the code (14,432 of 39,681
+      # regions) so it protected 58% of podup at 90% and said nothing about the
       # rest. The exclusion was justified when those modules ran under a live
       # Podman in this job; `a5cd4b4` removed that in June 2026 and the
       # justification expired with it. Since then the only thing exercising them
@@ -30,7 +30,7 @@ jobs:
       #
       # 79 is lower than 90 and stricter than it was: 100% of the crate at 79
       # leaves nothing invisible, where 90 of 63% left a third of podup
-      # unmeasured. It is a ratchet, not a target — raise it when real coverage
+      # unmeasured. It is a ratchet, not a target: raise it when real coverage
       # rises, never lower it to make a red build green.
       #
       # It is deliberately NOT the measured 78.96%: a floor set exactly at
@@ -39,8 +39,8 @@ jobs:
       # 79, not the org standard's 90, and not because podup is short of it.
       #
       # Measured 2026-08-03: the full suite covers **91.52%** of lines. This job
-      # cannot run it — the integration tests need a live Podman and skip
-      # themselves on a runner without one — so what it measures is `--lib
+      # cannot run it (the integration tests need a live Podman and skip
+      # themselves on a runner without one) so what it measures is `--lib
       # --bins` alone, which is **79.39%**. The two numbers describe different
       # things and only one of them is checkable here.
       #
@@ -49,8 +49,8 @@ jobs:
       # locks in what holds today rather than demanding new work, which is what
       # the testing standard asks for when adopting a floor.
       #
-      # The 90 gate belongs where the tests can actually run — the `podman-vm`
-      # lane — and that is tracked separately rather than papered over here.
+      # The 90 gate belongs where the tests can actually run, in the `podman-vm`
+      # lane, and that is tracked separately rather than papered over here.
       # 72 is lower than 79 and the gate got stricter, not looser. Measured
       # 2026-09-02 with the CI command (cargo llvm-cov --workspace
       # --all-features, no Podman reachable) on the same commit before and

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -49,7 +49,7 @@ jobs:
     with:
       paths: "install.ps1"
       # install.ps1 is piped to `iex`, so human-facing status must go through
-      # Write-Host — Write-Output would leak into the stream the pipe feeds.
+      # Write-Host, because Write-Output would leak into the stream the pipe feeds.
       # Same exclusion the previous inline job carried.
       exclude-rules: "PSAvoidUsingWriteHost"
 

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -19,7 +19,7 @@ name: pin-watch
 # `toolchain` input, and there is no single value here to hand it.
 #
 # Weekly, not daily: these move on the scale of months, and a daily run would
-# be noise. 05:00 Monday keeps it off audit.yml's 06:00 and fuzz.yml's 07:00 —
+# be noise. 05:00 Monday keeps it off audit.yml's 06:00 and fuzz.yml's 07:00;
 # stacking crons on the same minute only invites GitHub's scheduling delays.
 on:
   schedule:
@@ -45,7 +45,7 @@ jobs:
           set -euo pipefail
           # Every `python3 -c` below is ONE line, deliberately. Automatic dedent
           # of `-c` source arrived in CPython 3.13 and this runner ships 3.12,
-          # where indented source is an IndentationError — measured against a
+          # where indented source is an IndentationError, measured against a
           # real 3.12, not assumed. Un-indenting to column 0 is not the way out
           # either: inside a YAML `run: |` block a line at column 0 ends the
           # block. One line sidesteps both traps.
@@ -129,7 +129,7 @@ jobs:
 
           # ---- 3. Standards-Version -------------------------------------------
           # The regex MUST admit FOUR components. A three-component one silently
-          # truncates 4.7.4.1 to 4.7.4 and reports a false match — that exact
+          # truncates 4.7.4.1 to 4.7.4 and reports a false match; that exact
           # mistake was already made once on #1526.
           PINNED_STD=$(grep -oE '^Standards-Version:[[:space:]]+[0-9]+(\.[0-9]+){2,3}' debian/control \
             | head -n1 | awk '{print $2}')
@@ -365,7 +365,7 @@ jobs:
           # Idempotent: the title never changes, so a week that finds the same
           # drift again does not open a second issue.
           if gh issue list --state open --search "in:title $TITLE" --json title --jq '.[].title' | grep -qxF "$TITLE"; then
-            echo "Drift found, but the issue is already open — nothing to do."; exit 0
+            echo "Drift found, but the issue is already open; nothing to do."; exit 0
           fi
           {
             echo "| Pin | Pinned at | Pinned | Upstream |"
@@ -379,7 +379,7 @@ jobs:
             echo "The container digest has no bump path through Dependabot: the \`github-actions\` ecosystem does not update a workflow's \`container:\` image, so it has to be raised by hand."
           } > "$BODY"
           # Label on creation. An unlabelled issue is a process bug, and one filed
-          # by a bot is no exception — podman-watch carries the same note because
+          # by a bot is no exception; podman-watch carries the same note because
           # #673 and #1016 both landed bare.
           gh issue create --title "$TITLE" \
             --label "type:ci" --label "prio:P2" --label "status:ready" \

--- a/.github/workflows/podman-lane-develop-nightly.yml
+++ b/.github/workflows/podman-lane-develop-nightly.yml
@@ -1,5 +1,5 @@
 name: podman-lane (develop nightly)
-# Nightly live-Podman coverage on the `develop` branch — early-warning signal
+# Nightly live-Podman coverage on the `develop` branch: early-warning signal
 # for coverage drift that the `main` nightly (#1326) cannot see (#1380).
 #
 # The `main` nightly runs on the default branch only, so a regression landing on
@@ -11,7 +11,7 @@ name: podman-lane (develop nightly)
 #
 # Coverage is the only output consumed. The suite's pass/fail gate is unchanged
 # from the per-PR lane and still lives there; this job is an observation
-# (per #1326's own recommendation — a second instrumented build per PR is too
+# (per #1326's own recommendation; a second instrumented build per PR is too
 # expensive to gate on).
 on:
   workflow_dispatch:
@@ -22,7 +22,7 @@ permissions:
 jobs:
   podman-vm:
     runs-on: ubuntu-24.04
-    # Same wall-clock budget as the per-PR lane (#1338) — the coverage run
+    # Same wall-clock budget as the per-PR lane (#1338): the coverage run
     # serialises a second instrumented build inside the VM, and the Podman 6
     # leg finished at 89% of this budget on the most recent measurement.
     timeout-minutes: 95
@@ -89,7 +89,7 @@ jobs:
                 # Emit exactly one `PODUP_COVERAGE=<pct>` line for the gate step
                 # to parse. The previous script printed the coverage only as part
                 # of the tail output, which the gate's `grep -oE 'PODUP_COVERAGE=…'`
-                # never matched — the gate treated the whole run as a missing
+                # never matched, so the gate treated the whole run as a missing
                 # number and exited 0 with a `::warning::`. Branch is fixed in
                 # one place so the gate (the contract the lane actually measures)
                 # sees a clean number.
@@ -115,7 +115,7 @@ jobs:
           L="$RUNNER_TEMP/vm.log"
           COV=$(grep -oE 'PODUP_COVERAGE=[^ ]+' "$L" | tail -1 | cut -d= -f2)
           if [ -z "$COV" ]; then
-            echo "::warning::no coverage number reported on develop — VM did not complete the run or the instrumented build failed"
+            echo "::warning::no coverage number reported on develop; the VM did not complete the run or the instrumented build failed"
             tail -20 "$L"
             exit 0
           fi
@@ -124,11 +124,11 @@ jobs:
           # Nightly floor on develop: same 88% the `main` nightly applies
           # (#1326), reported on the Podman 6 leg. A regression that
           # takes develop below 88% is the early warning this workflow
-          # exists to surface — the same shape of break, in the half-life
+          # exists to surface: the same shape of break, in the half-life
           # before the next release PR.
           # `cargo llvm-cov` emits a percent like `91.30%`. Strip the
           # trailing `%` and the fractional part (`cut -d. -f1`) so
-          # `printf '%d'` gets an integer — `printf '%.0f' "91.30"` errors
+          # `printf '%d'` gets an integer: `printf '%.0f' "91.30"` errors
           # with `invalid number`, and the whole job fails closed exactly
           # when a regression would otherwise have been missed.
           COV_INT=$(printf '%d' "$(echo "$COV" | tr -dc '0-9.' | cut -d. -f1)")

--- a/.github/workflows/podman-lane.yml
+++ b/.github/workflows/podman-lane.yml
@@ -5,9 +5,9 @@ name: podman-lane
 # when checking this workflow by hand. Measured 2026-08-24; the repository's own
 # workflow-lint job is unaffected because it runs actionlint with its own flags.
 # Live-Podman integration for podup, validated against the FULL supported window.
-# Support policy: the latest Podman major + the one below it — today Podman 5 and 6.
+# Support policy: the latest Podman major + the one below it, today Podman 5 and 6.
 # Every engine PR runs the integration suite on BOTH majors (matrix), each inside a
-# Fedora qemu VM booted in the runner (nested-virt — the ubuntu-24.04 runner exposes
+# Fedora qemu VM booted in the runner (nested-virt: the ubuntu-24.04 runner exposes
 # /dev/kvm) with full systemd, as a rootless user. Podman 6 = Fedora rawhide;
 # Podman 5 = Fedora 44.
 
@@ -24,7 +24,7 @@ on:
   schedule:
     - cron: "0 9 * * *"
   # Runs on EVERY pull request (no path filter) so it can be a required status
-  # check that always reports — runtime behaviour is podup's whole point, so it
+  # check that always reports. Runtime behaviour is podup's whole point, so it
   # gates the merge. The internal suite distinguishes nested-virt flakes from real
   # failures and retries a transient once.
   pull_request:
@@ -112,7 +112,7 @@ jobs:
     #
     # Raised again for the coverage path. Capping the coverage run to the same
     # thread count as the gating run (#1338) means the Podman 6 leg now runs two
-    # serialised suites, and it came in at 66m27s of the 75 on run 30879785232 —
+    # serialised suites, and it came in at 66m27s of the 75 on run 30879785232,
     # 89% of the budget. That is not a failure yet, which is the only useful
     # moment to change it: a slower runner or a heavier rawhide image tips it
     # over, and the run that dies tells you nothing about the coverage it was
@@ -154,7 +154,7 @@ jobs:
           echo "image: $img"
           # Carry it to the gate step. The name resolves to whatever compose is
           # newest at this moment, so the Podman 6 leg boots a DIFFERENT operating
-          # system most days — and until now that fact lived only in the middle of
+          # system most days, and until now that fact lived only in the middle of
           # this step's log. Two runs of this leg are not the same environment, and
           # anyone comparing a failure against the run before it has to know which
           # one they got (#1222).
@@ -178,13 +178,13 @@ jobs:
           write_files:
             # Podman's default log driver on Fedora is journald, and in this image
             # every logs request comes back `500 ... unable to open a handle to the
-            # library` — its go-systemd binding cannot open the journal. Installing
+            # library`, because its go-systemd binding cannot open the journal. Installing
             # systemd-devel does not help (measured: the package installs and the
             # error persists), so rather than keep guessing at the dlopen, use the
             # file-based driver, which has no library to open.
             #
             # This is not cosmetic. With logs unavailable the suite's five logs
-            # tests passed without fetching a byte — `logs` swallowed the 500 and
+            # tests passed without fetching a byte: `logs` swallowed the 500 and
             # returned success, so their `unwrap()` succeeded on nothing.
             - path: /etc/containers/containers.conf
               content: |
@@ -203,13 +203,13 @@ jobs:
                 # flawless 155-pass run and clear the floor comfortably.
                 export PODUP_REQUIRE_PODMAN=1
                 cd "$HOME/podup" || exit 90
-                # Coverage runs on the scheduled and manual paths only — never on a
+                # Coverage runs on the scheduled and manual paths only, never on a
                 # pull request. The number is worth having where the integration
                 # tests can actually run (#1326: the CI coverage job sees 79% because
                 # every integration test skips itself without Podman, while the full
                 # suite covers 91.5%), but instrumenting doubles nothing here for
                 # free: it is a second full build inside the VM. Gating on it is
-                # deliberately NOT done yet — a threshold set from a number never
+                # deliberately NOT done yet: a threshold set from a number never
                 # observed in this environment is how a phantom check gets born.
                 COVERAGE=__COVERAGE__
                 # Capture the FULL output: the per-failure detail (where the flake
@@ -219,7 +219,7 @@ jobs:
                 # failure reproduces on the second run, so this stabilises the lane for
                 # required-check gating without masking genuine bugs.
                 #
-                # WHAT COUNTS AS A DROP — defined once, used by both the retry above and
+                # WHAT COUNTS AS A DROP, defined once, used by both the retry above and
                 # the FLAKY counter below, because the two drifting apart is how this
                 # went wrong (#1104). The list used to hold only the head-level shapes,
                 # and a dropped BODY is none of them: measured against a socket that
@@ -228,17 +228,17 @@ jobs:
                 # the cut lands between chunks and IncompleteBody when it lands
                 # mid-payload, with the Display form "error reading a body from
                 # connection". None matched, so a drop mid-body was neither retried nor
-                # counted — it just reddened the leg, which is exactly what happened to
+                # counted; it just reddened the leg, which is exactly what happened to
                 # fifteen streaming tests when a mid-stream error was made fatal.
                 #
                 # EXPERIMENT (#1039): the thread cap is per major, substituted into
-                # this script when the seed is built — Podman 6 runs at 1, Podman 5
+                # this script when the seed is built: Podman 6 runs at 1, Podman 5
                 # stays at 2 as the control.
                 #
                 # Every hypothesis for Podman 6's failing tail has been falsified in
                 # turn: journald, SELinux, and a boot race on systemd-resolved, the
                 # last one killed by its own instrumentation. What survives is the
-                # shape of the error — the path that is missing is the mount
+                # shape of the error: the path that is missing is the mount
                 # DESTINATION inside Podman's rootless-netns tree, not a host file,
                 # which reads as the shared netns being torn down under a concurrent
                 # container creation. One thread is the cheapest way to test that: if
@@ -252,7 +252,7 @@ jobs:
                 # (VM-in-runner) transport, and that a single-level VM "never
                 # drops a byte". **That is measured false** (2026-08-03, #1322):
                 # on a plain KVM guest with Podman 6.0.2, the same suite fails
-                # 17 of 27 at eight test threads and 3 at one — a clean
+                # 17 of 27 at eight test threads and 3 at one, a clean
                 # dose-response curve in thread count, reproducible across
                 # repetitions. Nesting makes it worse; it does not cause it.
                 #
@@ -281,7 +281,7 @@ jobs:
                 echo "PODUP_TESTS_RC_BEGIN rc=$RC PODUP_TESTS_RC_END"
                 echo "PODUP_SUMMARY_BEGIN pass=${PASS:-0} fail=${FAIL:-0} flaky=${FLAKY:-0} PODUP_SUMMARY_END"
                 # Coverage, measured where the integration tests can actually run.
-                # Reported, never gated — see the note where COVERAGE is set. A
+                # Reported, never gated; see the note where COVERAGE is set. A
                 # failure here must not redden the leg: this is an observation, and
                 # the suite's own result above is what gates.
                 if [ "$COVERAGE" = "1" ]; then
@@ -293,7 +293,7 @@ jobs:
                   # stdout and stderr already point at the console, inherited
                   # from the root caller that launched this script.
                   # cargo-llvm-cov looks for the `llvm-tools-preview` rustup
-                  # component, and there is no rustup here — Rust comes from dnf.
+                  # component, and there is no rustup here: Rust comes from dnf.
                   # It accepts the two tools directly instead, and Fedora's `llvm`
                   # package (already installed above) carries both. Taking them
                   # from the distribution is also what keeps the versions in step:
@@ -320,8 +320,8 @@ jobs:
                     # drives its own `cargo test` and does NOT inherit it, which
                     # is measurable rather than theoretical: on the Podman 6 leg
                     # the gating run took 1743s and passed 178/178, and the
-                    # coverage run of the same code in the same boot took 441s —
-                    # four times faster because it was parallel — and failed 5
+                    # coverage run of the same code in the same boot took 441s,
+                    # four times faster because it was parallel, and failed 5
                     # with hyper IncompleteMessage. Uncapped, this step measures
                     # a different suite than the one that gates.
                     cargo llvm-cov --all-features --summary-only \
@@ -345,7 +345,7 @@ jobs:
                 # The floor gate can only tighten to a per-test known-flaky
                 # allowlist once the flaky set is small and stable (#1039), and
                 # building that allowlist starts with observing which tests
-                # actually fail across nested-virt runs — which the count alone
+                # actually fail across nested-virt runs, which the count alone
                 # cannot tell you. cargo prints a final `failures:` block of bare
                 # test names (the earlier block carries `---- name stdout ----`
                 # detail lines, which the 4-space-exact match skips); no failures
@@ -396,12 +396,12 @@ jobs:
         run: |
           L="$RUNNER_TEMP/vm.log"
           echo "=== key lines ==="; grep -E 'DISK_BEGIN|PODMAN_BEGIN|test result:|PODUP_TESTS_RC_BEGIN|No space' "$L" | tail -10 || true
-          grep -q 'No space left' "$L" && { echo "::error::VM disk full — run invalid"; exit 1; }
+          grep -q 'No space left' "$L" && { echo "::error::VM disk full; run invalid"; exit 1; }
           VER=$(perl -0777 -ne 'while (/PODMAN_BEGIN\s+version=podman version ([0-9.]+)(?s:(?:(?!PODMAN_BEGIN).)*?)PODMAN_END/g) { print "$1\n" }' "$L" | tail -1)
           [ -n "$VER" ] || { echo "::error::Podman not detected in VM"; exit 1; }
           # The VM must be able to serve logs. Gate on that, not on which driver
           # provides it: Fedora 44's journald cannot open its library here and every
-          # logs request 500s, while rawhide's works fine — so requiring a specific
+          # logs request 500s, while rawhide's works fine, so requiring a specific
           # driver reddens the major that never had the problem.
           #
           # This is not cosmetic. With logs unavailable, the five tests that only
@@ -410,7 +410,7 @@ jobs:
           # than red, so the signature is a hard failure.
           echo "log driver: $(perl -0777 -ne 'while (/LOGDRIVER_BEGIN\s+value=([a-z0-9-]+)(?s:(?:(?!LOGDRIVER_BEGIN).)*?)LOGDRIVER_END/g) { print "$1\n" }' "$L" | tail -1)"
           if grep -q 'unable to open a handle to the library' "$L"; then
-            echo "::error::the VM could not serve logs (journald cannot open its library) — the logs tests would pass without reading anything"
+            echo "::error::the VM could not serve logs (journald cannot open its library); the logs tests would pass without reading anything"
             exit 1
           fi
           # Guard the matrix: the VM must actually run the Podman major it was asked to.
@@ -421,7 +421,7 @@ jobs:
           # Read the machine-readable summary the VM computed from the FULL cargo
           # log (the console here is tail-truncated, so don't recount from it).
           SUM=$(perl -0777 -ne 'while (/PODUP_SUMMARY_BEGIN\s+pass=(\d+)(?s:(?:(?!PODUP_SUMMARY_BEGIN).)*?)fail=(\d+)(?s:(?:(?!PODUP_SUMMARY_BEGIN).)*?)flaky=(\d+)\s+PODUP_SUMMARY_END/g) { print "PODUP_SUMMARY pass=$1 fail=$2 flaky=$3\n" }' "$L" | tail -1)
-          [ -n "$SUM" ] || { echo "::error::no PODUP_SUMMARY from VM on Podman $VER — suite did not report"; exit 1; }
+          [ -n "$SUM" ] || { echo "::error::no PODUP_SUMMARY from VM on Podman $VER; the suite did not report"; exit 1; }
           # Coverage, when this run asked for it. Reported into the job summary.
           # Gated on the scheduled + manual paths only, on Podman 6 (the leg that
           # represents the latest stable major). The CI coverage job without
@@ -439,7 +439,7 @@ jobs:
               # `91.5` for `91.5%`).
               COV_INT=$(printf '%.0f' "${COV%%%}")
               if [ "$COV_INT" -lt 88 ]; then
-                echo "::error::Podman 6 coverage $COV is below the 88% nightly floor (#1326). The full suite measured $COV — likely a regression that the floor is here to catch."
+                echo "::error::Podman 6 coverage $COV is below the 88% nightly floor (#1326). The full suite measured $COV, likely a regression that the floor is here to catch."
                 exit 1
               fi
             fi
@@ -454,14 +454,14 @@ jobs:
           # environment next to the counts, and the rawhide leg's environment
           # changes under it (#1222).
           {
-            echo "### Podman $VER — $PASS passed, $FAIL failed, $FLAKY drop-like"
+            echo "### Podman $VER: $PASS passed, $FAIL failed, $FLAKY drop-like"
             echo ""
             echo "image: \`${VM_IMAGE:-unknown}\`"
           } >> "$GITHUB_STEP_SUMMARY"
           # Strip CR: the VM talks to us over `-serial stdio`, so every line of
           # this log arrives CRLF-terminated. The counts survive because they are
           # extracted with numeric patterns, but the identity list keeps the CR on
-          # its final element — which then matches nothing in the classified list
+          # its final element, which then matches nothing in the classified list
           # and reports the last failing test as an unexpected regression. That is
           # exactly how this gate false-reddened on its first run.
           FAILED_TESTS=$(perl -0777 -ne 'while (/PODUP_FAILED_TESTS_BEGIN\s+tests=((?:(?!PODUP_FAILED_TESTS_BEGIN).)*?)\s+PODUP_FAILED_TESTS_END/sg) { print "$1\n" }' "$L" | tail -1 | tr -d '\r' || true)
@@ -475,7 +475,7 @@ jobs:
           # Derive the major from the Podman the VM actually booted (the matrix
           # guard above already proved they agree), so dropping in a
           # podman-known-failures-<major> file is all it takes to gate a new
-          # major — no edit here.
+          # major, no edit here.
           major="${VER%%.*}"
           known="$GITHUB_WORKSPACE/.github/podman-known-failures-$major"
           if [ -f "$known" ]; then
@@ -489,15 +489,15 @@ jobs:
             printf '%s' "$FAILED_TESTS" | tr ',' '\n' | sed '/^$/d' | sort -u > "$RUNNER_TEMP/failed.txt"
             unexpected="$(comm -23 "$RUNNER_TEMP/failed.txt" "$RUNNER_TEMP/known.txt")"
             if [ -n "$unexpected" ]; then
-              echo "::error::Podman $VER: these failing tests are not in $(basename "$known") — a test that used to pass is failing, which is a regression, not nested-virt noise:"
+              echo "::error::Podman $VER: these failing tests are not in $(basename "$known"): a test that used to pass is failing, which is a regression, not nested-virt noise:"
               echo "$unexpected" | awk '{print "  " $0}'
-              echo "Environment: Podman $VER on ${VM_IMAGE:-an unrecorded image}. Before concluding, check whether the run you are comparing against booted the same one — the rawhide leg usually does not (#1222)."
+              echo "Environment: Podman $VER on ${VM_IMAGE:-an unrecorded image}. Before concluding, check whether the run you are comparing against booted the same one; the rawhide leg usually does not (#1222)."
               echo "If a run proves the failure is environmental, add it to that file with the evidence; do not add it to make this red go away."
               exit 1
             fi
             stale="$(comm -13 "$RUNNER_TEMP/failed.txt" "$RUNNER_TEMP/known.txt")"
             if [ -n "$stale" ]; then
-              echo "::notice::Podman $VER: listed as environmentally-broken but passing in this run — drop them from $(basename "$known") once that holds:"
+              echo "::notice::Podman $VER: listed as environmentally-broken but passing in this run; drop them from $(basename "$known") once that holds:"
               echo "$stale" | awk '{print "  " $0}'
             fi
             echo "Podman $VER: every failure is on the classified list ($(wc -l < "$RUNNER_TEMP/known.txt") entries)."
@@ -512,8 +512,8 @@ jobs:
           # legs. At 115 the floor had 57 tests of slack, so a suite that executed
           # two thirds of itself and reported them all green would have passed the
           # only check that can see a half-executed run. 165 keeps a small margin
-          # for the identity gate's own territory — a handful of classified
-          # failures must not redden the floor too — without leaving room for a
+          # for the identity gate's own territory (a handful of classified
+          # failures must not redden the floor too) without leaving room for a
           # third of the suite to vanish unnoticed.
           #
           # The floor is a second, cruder signal: it catches "fewer tests ran"
@@ -521,7 +521,7 @@ jobs:
           # which the identity gate above cannot see. It stays for both majors.
           #
           # Why the failure COUNT is still only a warning: it never separated a
-          # regression from noise — measured on this lane, Podman 5 fails the
+          # regression from noise: measured on this lane, Podman 5 fails the
           # same ~10 streaming/attach/run tests every run with ZERO
           # connection-drop signatures, so "FAIL <= drop count" would redden
           # every run. The identity gate replaces it for any major with a
@@ -531,30 +531,30 @@ jobs:
           # suite on a real host (155/155) while the lane reported failures.
           #
           # Podman 6 went without a list because its failing set carried a
-          # variable tail that observation would have turned into false reds —
+          # variable tail that observation would have turned into false reds,
           # and the floor it gated on instead reported the leg green through 31
           # failures (141 passed, floor 115). That tail was one cause:
           # serialising the leg removed it, and its list is now empty, so any
           # failure there is a regression. See the file's own header for the
           # evidence and for how thin it is.
           BASELINE="$(cat "$GITHUB_WORKSPACE/.github/podman-baseline-tests")"
-          [ "$PASS" -ge "$BASELINE" ] || { echo "::error::core suite degraded on Podman $VER ($PASS passed, baseline >= $BASELINE) — real regression or fewer tests ran"; exit 1; }
+          [ "$PASS" -ge "$BASELINE" ] || { echo "::error::core suite degraded on Podman $VER ($PASS passed, baseline >= $BASELINE): a real regression, or fewer tests ran"; exit 1; }
           if [ "$FAIL" -gt "$FLAKY" ]; then
-            echo "::warning::Podman $VER: $FAIL failures, $FLAKY match a connection-drop signature — the rest are the known nested-virt-unstable subset (see the failures section). Not gated until that flakiness is reduced."
+            echo "::warning::Podman $VER: $FAIL failures, $FLAKY match a connection-drop signature; the rest are the known nested-virt-unstable subset (see the failures section). Not gated until that flakiness is reduced."
           fi
           echo "GREEN: podup core PASSED on Podman $VER ($PASS tests >= baseline $BASELINE; $FAIL in the nested-virt-noisy subset)."
 
   podman-majors:
     name: Supported Podman majors
     # A required status check is matched by name, and `podman-vm (5)` / `podman-vm (6)`
-    # carry the matrix values. The support policy moves that matrix — when Podman 7
-    # ships, `["5", "6"]` becomes `["6", "7"]` — and on that pull request the required
+    # carry the matrix values. The support policy moves that matrix: when Podman 7
+    # ships, `["5", "6"]` becomes `["6", "7"]`, and on that pull request the required
     # name `podman-vm (5)` stops being emitted while the ruleset still requires it, so
     # the pull request that carries the change blocks itself. This name does not move.
     # See #1552.
     needs: podman-vm
     # `needs` on its own SKIPS this job when the matrix fails, and a skipped required
-    # check does not block a merge — the exact failure this job exists to prevent.
+    # check does not block a merge, the exact failure this job exists to prevent.
     if: always()
     runs-on: ubuntu-latest
     # Bound: worst of the last three successful runs on 2026-09-02 was 4s. Ten times that, rounded up, never under ten

--- a/.github/workflows/podman-watch.yml
+++ b/.github/workflows/podman-watch.yml
@@ -1,6 +1,6 @@
 name: podman-version-watch
 # Notifies (opens an issue) when Podman ships a release newer than the version
-# podup was last validated against AND at least one distro has packaged it — the
+# podup was last validated against AND at least one distro has packaged it, the
 # signal to run the validation lane. The last-validated version lives in
 # .github/podman-baseline; bump it after a successful validation.
 on:
@@ -29,7 +29,7 @@ jobs:
           LATEST=$(gh api repos/containers/podman/releases/latest --jq '.tag_name' | sed 's/^v//')
           # LATEST is a third-party-controlled release tag. Reject anything but a
           # plain SemVer before it is used anywhere else in this script.
-          [[ "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::unexpected Podman release tag '$LATEST' — not a plain version"; exit 1; }
+          [[ "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::unexpected Podman release tag '$LATEST'; not a plain version"; exit 1; }
           echo "baseline=$BASELINE  latest=$LATEST"
           # Nothing to do unless LATEST is strictly newer than BASELINE.
           if [ "$LATEST" = "$BASELINE" ] || \
@@ -43,24 +43,24 @@ jobs:
             "https://repology.org/api/v1/project/podman" \
             | LATEST="$LATEST" python3 -c "import os,sys,json;d=json.load(sys.stdin);latest=os.environ['LATEST'];print(', '.join(sorted({p['repo'] for p in d if p.get('version')==latest})))")
           if [ -z "$DISTROS" ]; then
-            echo "Podman $LATEST is released but not packaged in any distro yet — keep watching."; exit 0
+            echo "Podman $LATEST is released but not packaged in any distro yet; keep watching."; exit 0
           fi
           echo "Podman $LATEST is packaged in: $DISTROS"
           # Major bump => full sweep; otherwise a lighter re-check.
           MAJ_NEW=${LATEST%%.*}; MAJ_OLD=${BASELINE%%.*}
           KIND="patch/minor re-check"; EFFORT="effort:M"
           if [ "$MAJ_NEW" != "$MAJ_OLD" ]; then
-            KIND="MAJOR — full command-by-command sweep + wire-field re-probe"
+            KIND="MAJOR: full command-by-command sweep + wire-field re-probe"
             # A major re-probes the wire fields on top of the suite: a size more.
             EFFORT="effort:L"
           fi
           TITLE="Validate podup on Podman $LATEST (now packaged)"
           # Idempotent: skip if an issue for this version is already open.
           if gh issue list --state open --search "in:title $TITLE" --json title --jq '.[].title' | grep -qxF "$TITLE"; then
-            echo "Issue already open — nothing to do."; exit 0
+            echo "Issue already open; nothing to do."; exit 0
           fi
           # Label on creation. An unlabelled issue is a process bug, and one filed
-          # by a bot is no exception — #673 and #1016 both landed bare because this
+          # by a bot is no exception: #673 and #1016 both landed bare because this
           # step never passed --label, and both had to be labelled by hand later.
           gh issue create --title "$TITLE" \
             --label "type:test" --label "prio:P2" --label "status:ready" \
@@ -70,7 +70,7 @@ jobs:
           This is **$KIND**.
 
           Validation steps:
-          - [ ] Run the nested-virt Podman-$LATEST lane (Fedora rawhide / a distro that ships it) — command-by-command + the integration suite
+          - [ ] Run the nested-virt Podman-$LATEST lane (Fedora rawhide / a distro that ships it): command-by-command + the integration suite
           - [ ] If a new MAJOR: re-probe wire fields (healthcheck / secrets / quadlet) and check the upstream breaking-changes notes
           - [ ] File issues for any regressions
           - [ ] If green: bump \`.github/podman-baseline\` to **$LATEST** and refresh the README badge + ai-context

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         # is a separate hand-maintained file. 1.9.0 shipped with the bump applied
         # to Cargo.toml but not here, so the release carried podup_1.8.0_*.deb:
         # apt saw the version it already had, reported no upgrade, and Debian
-        # users were stranded — with no self-update either, since podup redirects
+        # users were stranded, with no self-update either, since podup redirects
         # a dpkg-owned binary to `apt upgrade`. The tag check above cannot catch
         # this; only comparing the two versions can.
         run: |
@@ -81,7 +81,7 @@ jobs:
 
       - name: Cargo.lock must record the released version
         # Cargo.lock carries podup's own version too, and `cargo build --locked`
-        # in the build jobs would catch a stale one — but only after the matrix
+        # in the build jobs would catch a stale one, but only after the matrix
         # has started, mid-release. Gate it here in verify, before anything is
         # built, so all three version files (Cargo.toml, debian/changelog,
         # Cargo.lock) are proven to agree at the same fail-fast point. Match the
@@ -250,8 +250,8 @@ jobs:
           PYTHONUTF8: "1"
         run: |
           # The installer/updater verifies this Ed25519 signature; a release
-          # without it cannot be consumed. Rotation is by dual-TRUST — consumers
-          # bake both accepted public keys — so only the active key signs here,
+          # without it cannot be consumed. Rotation is by dual-TRUST (consumers
+          # bake both accepted public keys) so only the active key signs here,
           # producing the single .sig every verifier reads. Fail closed when the
           # key is absent instead of publishing unsigned binaries.
           if [ -z "$GLYNDOR_RELEASE_ED25519_KEY" ]; then
@@ -446,12 +446,12 @@ jobs:
         # lists only that platform's dependencies").
         #
         # cargo-cyclonedx's --target uses cargo's --filter-platform resolution,
-        # which needs only the triple, not an installed std — so the six
+        # which needs only the triple, not an installed std, so the six
         # cross-platform binary targets resolve here without `rustup target add`.
         # The binaries carry the default feature set; the .debs are built
         # --no-default-features --features watch,completions (debian/rules), so
         # their SBOMs pass the same flags or they would misdeclare the package.
-        # License attribution (NOTICES.html) stays a single union — over-listing
+        # License attribution (NOTICES.html) stays a single union: over-listing
         # licenses is the safe direction for attribution, never under-listing.
         run: |
           cargo install --locked cargo-cyclonedx --version "=0.5.9"
@@ -466,7 +466,7 @@ jobs:
               --override-filename "${out}.cdx" "$@"
           }
 
-          # Binaries — default feature set, one SBOM per target triple.
+          # Binaries: default feature set, one SBOM per target triple.
           gen_sbom podup-linux-x86_64        x86_64-unknown-linux-musl
           gen_sbom podup-linux-arm64         aarch64-unknown-linux-musl
           gen_sbom podup-darwin-arm64        aarch64-apple-darwin
@@ -474,7 +474,7 @@ jobs:
           gen_sbom podup-windows-x86_64.exe  x86_64-pc-windows-msvc
           gen_sbom podup-windows-arm64.exe   aarch64-pc-windows-msvc
 
-          # Debian packages — the packaged binary drops the `update` feature and
+          # Debian packages: the packaged binary drops the `update` feature and
           # links glibc (gnu), not musl. Name each SBOM after its own .deb.
           for arch in amd64 arm64; do
             case "$arch" in
@@ -642,12 +642,12 @@ jobs:
           set -euo pipefail
           # The asset-contract gate compares install.sh against this file and
           # answers "do the two agree on the names". It cannot answer "does the
-          # release produce them" — a workflow file is a statement of intent,
+          # release produce them": a workflow file is a statement of intent,
           # not proof that a step ran. This is where that question is
           # answerable: everything is built, signed and checksummed, and the
           # release is not immutable yet. The script derives what to look for
           # from install.sh's own ${BASE_URL} fetches, so it covers
-          # SHA256SUMS.sig too — install.sh aborts without it, and nothing
+          # SHA256SUMS.sig too: install.sh aborts without it, and nothing
           # upstream of here ever checked it was produced.
           python3 scripts/verify-release-assets.py \
             --workdir . \

--- a/.github/workflows/reusable-dco.yml
+++ b/.github/workflows/reusable-dco.yml
@@ -33,7 +33,7 @@ jobs:
           # event payload, not refs/pull/N/merge (the synthetic merge commit
           # actions/checkout builds when it checks out a PR ref). That
           # synthetic commit is never in this BASE_SHA..HEAD_SHA range to
-          # begin with — it isn't an ancestor of HEAD_SHA — so `--no-merges`
+          # begin with (it isn't an ancestor of HEAD_SHA), so `--no-merges`
           # below has nothing to do with excluding it; it skips real merge
           # commits that may exist on the PR branch itself. Those are covered
           # separately by "Detect evil merges" below, which checks
@@ -75,7 +75,7 @@ jobs:
         #     be recomputed, fails closed rather than being waved through:
         #     `git merge-tree --write-tree` exiting non-zero means we cannot
         #     recompute what the merge should have produced, and a
-        #     hand-resolved conflict is unverifiable by construction — there
+        #     hand-resolved conflict is unverifiable by construction: there
         #     is no way to distinguish a faithful resolution from one that
         #     also smuggled in an unrelated change. This org's flow is
         #     squash-only, so merge commits inside a PR range are rare and
@@ -91,13 +91,13 @@ jobs:
           bad=0
           stderr_file="$(mktemp)"
           merges="$(git rev-list --merges "${BASE_SHA}..${HEAD_SHA}")" || {
-            echo "::error::could not enumerate merge commits between ${BASE_SHA} and ${HEAD_SHA} — history may be corrupted or incomplete; this check fails closed"
+            echo "::error::could not enumerate merge commits between ${BASE_SHA} and ${HEAD_SHA}; history may be corrupted or incomplete, and this check fails closed"
             exit 1
           }
           for m in $merges; do
             read -r -a parents <<< "$(git show -s --format='%P' "$m")"
             if [ "${#parents[@]}" -ne 2 ]; then
-              echo "::error::merge commit $m has ${#parents[@]} parents — evil-merge detection only supports ordinary two-parent merges; an octopus merge is rejected rather than assumed safe"
+              echo "::error::merge commit $m has ${#parents[@]} parents. Evil-merge detection only supports ordinary two-parent merges; an octopus merge is rejected rather than assumed safe"
               bad=1
               continue
             fi
@@ -110,7 +110,7 @@ jobs:
               continue
             fi
             if [ "$clean_tree" != "$actual_tree" ]; then
-              echo "::error::merge commit $m's tree does not match the clean merge of its parents ${parents[0]} and ${parents[1]} — it introduces changes present in neither parent"
+              echo "::error::merge commit $m's tree does not match the clean merge of its parents ${parents[0]} and ${parents[1]}: it introduces changes present in neither parent"
               bad=1
             fi
           done

--- a/.github/workflows/reusable-dependabot-freshness.yml
+++ b/.github/workflows/reusable-dependabot-freshness.yml
@@ -4,7 +4,7 @@ name: Dependabot freshness (reusable)
 # calling repository.
 #
 # The companion guard `schedule-freshness.yml` fails when a *workflow* stops
-# firing. Dependabot is not a workflow — it is an integration with its own
+# firing. Dependabot is not a workflow; it is an integration with its own
 # schedule, and a silent Dependabot emits nothing. "All up to date" and
 # "Dependabot is dead" produce the same signal: silence. This job converts
 # that silence into a red check on ordinary work, by treating the newest
@@ -42,8 +42,8 @@ name: Dependabot freshness (reusable)
 # cannot elevate beyond the permissions of the workflow that calls it, and
 # reading public PR history through the API needs that scope.
 #
-# Add the check only once Dependabot has opened at least one PR in the repo
-# — with nothing on record the job reports that as a failure, which for a
+# Add the check only once Dependabot has opened at least one PR in the repo.
+# With nothing on record the job reports that as a failure, which for a
 # live Dependabot is exactly right (it means we cannot even prove Dependabot
 # is alive here).
 #
@@ -126,15 +126,15 @@ jobs:
           # jq avoids the GitHub API's known wrinkle where
           # `state=all&sort=created&per_page=1` does not always include
           # closed/merged PRs in the sort order one would expect, and depends
-          # on the bot author being a queryable user login (it is —
-          # dependabot[bot] — not the app slug `app/dependabot`).
+          # on the bot author being a queryable user login (it is
+          # dependabot[bot], not the app slug `app/dependabot`).
           #
           # The window has to be paged, not fixed. A single page of 20 is a
           # window on *total* PR activity, not on Dependabot's: in a busy
           # repository the bot's newest pull request falls off the end and the
           # check reports it as never having run. Measured on Glyndor/podup,
           # where the twenty newest PRs contained none from Dependabot while
-          # ten sat within the newest forty — the gate failed on a repository
+          # ten sat within the newest forty, so the gate failed on a repository
           # where Dependabot had opened ten pull requests that same day.
           #
           # Three pages of 100 is a 300-PR window, and the loop stops at the
@@ -176,7 +176,7 @@ jobs:
             printf '%s\n' "$behind" | sed 's/^/  /'
             echo "A silent Dependabot reports nothing, so treat this as the alert it never sent." >&2
             echo "GitHub runs Dependabot on its own schedule, hours late; a small overrun right at the boundary" >&2
-            echo "is not the problem — a multiple of the period is. Check dependabot.yml is still on the default" >&2
+            echo "is not the problem; a multiple of the period is. Check dependabot.yml is still on the default" >&2
             echo "branch and that the package ecosystem is configured, then disable/enable Dependabot to" >&2
             echo "re-register it, and check the next scheduled scan rather than the next few minutes." >&2
             exit 1

--- a/.github/workflows/reusable-installer-contract.yml
+++ b/.github/workflows/reusable-installer-contract.yml
@@ -6,7 +6,7 @@ name: Installer contract (reusable)
 # the release workflow publishes a fixed list of assets. If the two drift, the
 # installer breaks for users. This catches the drift on the PR, before any tag.
 #
-# Scope — this gate reads declarations, and only declarations. It compares two
+# Scope: this gate reads declarations, and only declarations. It compares two
 # files and answers "do install.sh and release.yml agree on the asset names?".
 # That is a cross-reference between two statements of intent, and parsing YAML
 # is the right way to answer it.
@@ -16,7 +16,7 @@ name: Installer contract (reusable)
 # appear among the parsed `asset:` keys. Those keys are the build matrix, and
 # the manifest is computed FROM the matrix outputs in a later step, so it can
 # never be one of them: the check was unpassable by construction, and the only
-# way to satisfy it was to declare a matrix entry that produced nothing — the
+# way to satisfy it was to declare a matrix entry that produced nothing, the
 # exact defect it existed to catch. It had never run green in any repository.
 # Existence is answered where it can be answered honestly, against the staged
 # files at release time, by `scripts/verify-release-assets.py`.
@@ -102,7 +102,7 @@ jobs:
                   f"workflow does not declare:\n{lines}\n"
                   f"declared: {sorted(published)}\n"
                   "This gate reads the workflow's asset declarations only. It "
-                  "does not check that the release produces them — "
+                  "does not check that the release produces them; "
                   "scripts/verify-release-assets.py does that against the "
                   "staging directory at release time."
               )

--- a/.github/workflows/reusable-line-limit.yml
+++ b/.github/workflows/reusable-line-limit.yml
@@ -1,7 +1,7 @@
 name: Line limit (reusable)
 
 # Enforce the file-size standard: warn past the soft limit, fail past the hard
-# limit. Language-agnostic — scans tracked source files by extension. Counts
+# limit. Language-agnostic: it scans tracked source files by extension. Counts
 # CODE lines only: blank lines and comment-only lines (including the required
 # doc comments) do not count, so documenting a public API never pushes a file
 # over the limit. The comment detection is a pragmatic heuristic (lines whose
@@ -80,10 +80,10 @@ jobs:
                 code++ }
               END { print code + 0 }' "$f")"
             if [ "$n" -gt "$HARD" ]; then
-              echo "::error file=$f::$f has $n code lines (hard limit $HARD — split required)"
+              echo "::error file=$f::$f has $n code lines (hard limit $HARD, split required)"
               fail=1
             elif [ "$n" -gt "$SOFT" ]; then
-              echo "::warning file=$f::$f has $n code lines (soft limit $SOFT — look for a split point)"
+              echo "::warning file=$f::$f has $n code lines (soft limit $SOFT, look for a split point)"
             fi
           done < <(git ls-files -z)
           if [ "$fail" -ne 0 ]; then

--- a/.github/workflows/reusable-powershell-ci.yml
+++ b/.github/workflows/reusable-powershell-ci.yml
@@ -3,7 +3,7 @@ name: PowerShell CI (reusable)
 # PSScriptAnalyzer lint for repositories shipping .ps1 scripts (podup's
 # install.ps1 today; unitpm and klyradb are expected to gain their own
 # PowerShell installers later). Replaces podup's inline
-# .github/workflows/lint-powershell.yml with one reviewed implementation —
+# .github/workflows/lint-powershell.yml with one reviewed implementation;
 # the swap itself is Phase 4.2, not part of this change.
 #
 # Runner is windows-latest and `defaults: run: shell: pwsh` is deliberate, not
@@ -12,19 +12,19 @@ name: PowerShell CI (reusable)
 # PowerShell variable, not the environment, so env-passed values silently
 # become empty strings. That trap only bites a job whose *content* is meant to
 # be POSIX shell running on Windows. This job's content IS PowerShell, so pwsh
-# is the correct shell, not the thing being guarded against — and every input
+# is the correct shell, not the thing being guarded against, and every input
 # below is still read via `$env:VAR` (pwsh's real environment-variable syntax)
 # rather than a bare `$VAR`, for the same reason the standard calls out.
 #
 # pssa-version's default was checked against the live PowerShell Gallery
-# (podup's own lint-powershell.yml has no pin at all — floats on whatever
+# (podup's own lint-powershell.yml has no pin at all, floating on whatever
 # `Install-Module PSScriptAnalyzer -Force` resolves to that day); 1.25.0 was
 # the current non-prerelease release at the time this default was set.
 #
 # `paths` is a "<dir>/**/<pattern>"-shaped glob (default "**/*.ps1"), but the
 # **-segment is stripped rather than handed to Get-ChildItem: its own docs
 # warn against combining -Path with -Recurse for wildcard matching and confirm
-# there is no "**" arbitrary-depth token at all — the documented way to match
+# there is no "**" arbitrary-depth token at all: the documented way to match
 # a pattern at every depth is -LiteralPath (a plain directory) + -Recurse +
 # -Include, which is what the step below builds from this input.
 
@@ -46,7 +46,7 @@ on:
         description: >-
           Comma-separated PSScriptAnalyzer rule names to exclude from the
           gate (passed to -ExcludeRule), for rules a script violates on
-          purpose — e.g. PSAvoidUsingWriteHost in an installer that talks to
+          purpose, e.g. PSAvoidUsingWriteHost in an installer that talks to
           a human over stdout. Empty excludes nothing.
         type: string
         default: ""

--- a/.github/workflows/reusable-rust-audit.yml
+++ b/.github/workflows/reusable-rust-audit.yml
@@ -11,7 +11,7 @@ on:
         description: Directory containing the Cargo workspace
         type: string
         default: "."
-      # Pinned, not the runner's floating preinstalled Rust — see rust-ci.yml's
+      # Pinned, not the runner's floating preinstalled Rust; see rust-ci.yml's
       # toolchain input for why an unpinned toolchain is a problem.
       toolchain:
         description: Rust toolchain to pin the audit and deny jobs to
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install cargo-audit
         # A bare "X.Y.Z" passed to `cargo install --version` already installs
-        # that exact release — caret ("^") matching is a Cargo.toml dependency
+        # that exact release: caret ("^") matching is a Cargo.toml dependency
         # rule, not a `cargo install` one. The leading "=" here is redundant,
         # kept only to make the exact pin explicit at a glance.
         run: command -v cargo-audit >/dev/null || cargo install cargo-audit --version "=$TOOL_VERSION" --locked

--- a/.github/workflows/reusable-rust-ci.yml
+++ b/.github/workflows/reusable-rust-ci.yml
@@ -9,7 +9,7 @@ on:
         default: "."
       # Pinned, not `stable`: an unpinned toolchain moves on its own the day
       # upstream ships a release, and every consumer's pull requests go red at
-      # once for a change nobody made. That is not hypothetical — Rust 1.97.0
+      # once for a change nobody made. That is not hypothetical: Rust 1.97.0
       # landed on 2026-07-07, widened a clippy lint, and reddened every open PR
       # in podup until the lint was fixed. Bump this pin deliberately, in a
       # pull request of its own, so the lints it gains are read and fixed on
@@ -156,7 +156,7 @@ jobs:
     defaults:
       run:
         # This is the only job that can land on a Windows runner, where the
-        # default shell is PowerShell — and there `$VAR` reads a PowerShell
+        # default shell is PowerShell, and there `$VAR` reads a PowerShell
         # variable, not the environment, so every `env:` value silently becomes
         # an empty string. Pin the shell so steps behave the same on all three
         # OSes, as release.yml's cross-OS matrix already does.

--- a/.github/workflows/reusable-rust-supply-chain.yml
+++ b/.github/workflows/reusable-rust-supply-chain.yml
@@ -12,14 +12,14 @@ on:
         description: Directory containing the Cargo workspace
         type: string
         default: "."
-      # Pinned, not the runner's floating preinstalled Rust — see rust-ci.yml's
+      # Pinned, not the runner's floating preinstalled Rust; see rust-ci.yml's
       # toolchain input for why an unpinned toolchain is a problem.
       #
       # Keep this equal to rust-ci.yml's `toolchain`. It was 1.97 while rust-ci
       # was already on 1.98, because the bump raised one and not the other and
       # nothing compared them. A repository whose SBOM is produced by a compiler
       # its test suite never ran is the defect podup#1487 recorded, and podup
-      # now has a test asserting its own two pins agree — nothing asserts it
+      # now has a test asserting its own two pins agree, but nothing asserts it
       # across these two reusables, so it is written here instead.
       toolchain:
         description: Rust toolchain to pin the SBOM and license job to
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install generators
         # `cargo install --version X.Y.Z` already installs that exact release;
-        # the leading "=" below is redundant, kept only for readability —
+        # the leading "=" below is redundant, kept only for readability:
         # caret ("^") matching is a Cargo.toml dependency rule, not this one.
         run: |
           command -v cargo-cyclonedx >/dev/null || cargo install --locked cargo-cyclonedx --version "=$CYCLONEDX_VERSION"
@@ -109,7 +109,7 @@ jobs:
           suffix="$WORKING_DIRECTORY"
           suffix="${suffix#./}"
           # "." and "./" both strip down to the same "root" case; so does an
-          # empty input ("") — none of them denote a real subdirectory name,
+          # empty input (""): none of them denote a real subdirectory name,
           # and left alone they'd produce a trailing-hyphen artifact name
           # ("sbom-and-notices-") instead of one qualified by directory.
           if [ "$suffix" = "." ] || [ -z "$suffix" ]; then

--- a/.github/workflows/reusable-schedule-freshness.yml
+++ b/.github/workflows/reusable-schedule-freshness.yml
@@ -8,7 +8,7 @@ name: Schedule freshness (reusable)
 # workflow in the org stopped. podup and apt recovered on 07-15 because they
 # happened to get activity and a disable/enable cycle; authcore, epistle, unitpm
 # and glyndor.net stayed dark for four more weeks, all of them reporting
-# `active` the whole time. It cost a real finding — authcore's GO-2026-5856 was
+# `active` the whole time. It cost a real finding: authcore's GO-2026-5856 was
 # caught by a hand-run of govulncheck, not by the weekly audit that exists for
 # exactly that.
 #
@@ -21,8 +21,8 @@ name: Schedule freshness (reusable)
 # workflow cannot elevate beyond the permissions of the workflow that calls it,
 # and reading run history needs that scope. Without it the run does not start.
 #
-# Add the check only once the schedule has fired successfully at least once —
-# with no successful run on record there is nothing to measure and the job
+# Add the check only once the schedule has fired successfully at least once.
+# With no successful run on record there is nothing to measure and the job
 # reports that as a failure, which for an established workflow is exactly right.
 
 on:

--- a/.github/workflows/reusable-shell-ci.yml
+++ b/.github/workflows/reusable-shell-ci.yml
@@ -117,16 +117,16 @@ jobs:
       # A script invoked as `./path` needs the executable bit recorded IN GIT.
       # `chmod +x` in a working tree is local state; the mode git stores is what
       # reaches the runner, and when it disagrees the job dies with exit 126 and
-      # "Permission denied" — a message about the file, not about the mode, which
+      # "Permission denied", a message about the file, not about the mode, which
       # is why it costs a round trip to diagnose every time.
       #
       # This happened twice in one day in Glyndor/apt (2026-08-23): once on
       # scripts/build-installers.sh, once on tests/build-installers.test.sh.
       #
-      # Deliberately narrow. It does NOT assert that every `.sh` is 0755 — that
+      # Deliberately narrow. It does NOT assert that every `.sh` is 0755; that
       # would be wrong. `apt/scripts/install-template.sh` is a template that is
       # read and substituted, never executed, and is correctly 0644; and repos
-      # that invoke their scripts as `bash path` (podup, helmly, unitpm — 21
+      # that invoke their scripts as `bash path` (podup, helmly, unitpm, with 21
       # non-executable scripts between them) have nothing to fix. The check is
       # derived from how the workflows actually call each script, so a repo that
       # never uses `./path` finds nothing and passes.

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -99,7 +99,7 @@ jobs:
       # are reachable from code outside this organisation. Keeping the
       # install out of any job that holds a secret bounds that reach to
       # nothing. `pip install --require-hashes` is the exception because a
-      # hash-pinned install resolves nothing — the artifacts are fixed by
+      # hash-pinned install resolves nothing, since the artifacts are fixed by
       # the lockfile, so no surprise tree appears.
       - name: A job holding a secret must not install third-party tooling
         if: ${{ inputs.tooling-isolation }}
@@ -113,7 +113,7 @@ jobs:
 
           # `secrets.<id>` is how every GitHub Actions expression reaches a
           # secret. `secrets: inherit` and `secrets:` declarations on
-          # reusable calls don't match — those are declaration blocks, not
+          # reusable calls don't match, because those are declaration blocks, not
           # references, and `secrets:` does not contain a `.`.
           SECRET_RE = re.compile(r"(?<!\w)secrets\.[A-Za-z_]\w*")
 
@@ -201,7 +201,7 @@ jobs:
                   for path, job_id, line in violations:
                       msg = (
                           f"job `{job_id}` installs third-party tooling while holding a secret: "
-                          f"`{line.strip()}` — see Glyndor/apt#121. Fix by moving the install "
+                          f"`{line.strip()}`. See Glyndor/apt#121. Fix by moving the install "
                           f"into a job that holds no secrets, or pin it by hash "
                           f"(e.g. `pip install --require-hashes`)."
                       )

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ debian/*.log
 bench/results/
 
 # Local tooling scratch directories. These are ignored on my machine by a global
-# gitignore and by .git/info/exclude, neither of which travels with the repo —
+# gitignore and by .git/info/exclude, neither of which travels with the repo,
 # so on a fresh clone, on CI, or for anyone else, they were unprotected. This is
 # a public repository and a single `git add -A` would publish them permanently.
 .claude/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ path = "internal/lib.rs"
 # (`test_exec_capture`, `test_project_container_names`) that live behind the
 # `test-helpers` feature so they never reach a release build. Without the
 # feature the target does not compile, and `debian/rules` builds with
-# `--no-default-features --features watch,completions` — so it broke there while
+# `--no-default-features --features watch,completions`, so it broke there while
 # every other caller passed either `--all-features` or `--features test-helpers`
 # and stayed green.
 #

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ curl -fsSL https://apt.glyndor.net/install/podup | sudo sh
 
 That is the whole install on Debian and Ubuntu. It registers the signed Glyndor
 apt repository, verifies the archive key's fingerprint before trusting it, and
-installs podup with apt — so upgrades and signing-key renewals arrive through
+installs podup with apt, so upgrades and signing-key renewals arrive through
 `apt upgrade` like any other package. Root is needed because it installs
 packages. It leaves nothing of its own behind: the download is removed, and so
 is anything it had to install just to check the key.
@@ -54,23 +54,23 @@ socket still has to be listening:
 systemctl --user enable --now podman.socket
 ```
 
-### Optional — macOS
+### Optional: macOS
 
 ```sh
 brew install glyndor/tap/podup
 ```
 
-### Optional — Windows
+### Optional: Windows
 
 ```powershell
 scoop bucket add glyndor https://github.com/Glyndor/scoop-bucket
 scoop install podup
 ```
 
-Scoop clones the bucket with git, so git has to be installed first — Scoop's own
+Scoop clones the bucket with git, so git has to be installed first; Scoop's own
 installer does not bring it.
 
-### Optional — Linux without apt
+### Optional: Linux without apt
 
 ```sh
 curl -fsSL https://glyndor.net/podup/install/unix | bash
@@ -110,12 +110,12 @@ podup tracks the **latest stable Podman** and supports its **last two majors,
 Podman 5.x and 6.x**. It talks to Podman's native libpod API, requesting the
 `/v5.0.0/libpod` path that Podman 6 still serves; the gate is the major version
 the engine reports, so it needs **Podman ≥ 5.0**. When a new major ships, it is
-added and the oldest is dropped — but only once the **newest LTS of each
+added and the oldest is dropped, but only once the **newest LTS of each
 distribution family carries the new one or better**, so nobody on a current
 release is stranded. Both supported majors run the
 integration suite in CI on every engine change (Fedora 44 for the latest 5.x,
 rawhide for 6.x). Many distributions still ship 4.x, so `podman --version` is
-worth checking before installing — and a distribution never changes its Podman
+worth checking before installing, and a distribution never changes its Podman
 major version mid-release, so an LTS that shipped below the floor stays below
 it for its whole supported life.
 
@@ -187,8 +187,8 @@ sequenceDiagram
 Peak memory and per-operation latency against docker-compose and podman-compose,
 **all three driving the same rootless Podman**, same digest-pinned images,
 median of 10 measured runs (12 iterations, 2 warm-up discarded), on podup 5.7.1.
-podup is fastest in all 29 measured rows, though three teardown rows —
-`deep-chain`, `many-services` and `multi-healthcheck` — win by less than their
+podup is fastest in all 29 measured rows, though three teardown rows
+(`deep-chain`, `many-services` and `multi-healthcheck`) win by less than their
 own standard deviation and should be read as ties; the widest gaps are the ones
 with many services.
 

--- a/about.hbs
+++ b/about.hbs
@@ -10,7 +10,7 @@ Apache-2.0 license (§4(d)) and equivalents.
 
 Used by:
 {{#each used_by}}
-- {{crate.name}} {{crate.version}}{{#if crate.repository}} — {{crate.repository}}{{/if}}
+- {{crate.name}} {{crate.version}}{{#if crate.repository}} ({{crate.repository}}){{/if}}
 {{/each}}
 
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,13 +1,13 @@
 # Compose-tool benchmark
 
 A reproducible, **fair** wall-clock comparison of compose tools. The point is not
-to win — it is to publish honest, equitable numbers across identical scenarios.
+to win; it is to publish honest, equitable numbers across identical scenarios.
 A podup loss is published exactly like a podup win.
 
 ## What is compared
 
 - **podup** and **podman-compose** both drive **Podman**, so comparing them is a
-  pure *tool* comparison — same engine, only the orchestrator differs. This is the
+  pure *tool* comparison: same engine, only the orchestrator differs. This is the
   apples-to-apples result.
 - **docker-compose** is pointed at the **Podman socket** through `DOCKER_HOST`,
   which is what makes it comparable: same engine, so the only difference left is
@@ -25,7 +25,7 @@ A podup loss is published exactly like a podup win.
 - **Controlled environment.** The real run happens on a dedicated/self-hosted
   runner or the maintainer's machine, with the CPU governor pinned and the tool
   process taskset-pinned to reduce variance. **Shared CI runners are too noisy for
-  published numbers** — CI only checks the harness (`bash -n`, a Python
+  published numbers**: CI only checks the harness (`bash -n`, a Python
   compile, `aggregate.py --self-test` on fixture rows, and a build of `timeit`
   with an assertion that it resolves `/bin/true` below 10 ms), never running the
   scenarios or the numbers in the README.
@@ -35,14 +35,14 @@ A podup loss is published exactly like a podup win.
 
 | scenario | what it exercises |
 |---|---|
-| `single` | one container — minimal lifecycle cost |
+| `single` | one container, minimal lifecycle cost |
 | `multi-healthcheck` | `depends_on: service_healthy` gate on `up` |
 | `deep-chain` | a dependency chain behind a fast service: where a level-barrier scheduler loses to a per-service DAG (#1071) |
-| `wide-level` | 41 services in one level plus one dependent — the batching cost the two-service `deep-chain` cannot show |
+| `wide-level` | 41 services in one level plus one dependent, the batching cost the two-service `deep-chain` cannot show |
 | `scale` | `--scale app=5` replica fan-out |
 | `network-ipam` | custom bridge network with explicit IPAM |
 | `volume-heavy` | several named volumes created/removed |
-| `secrets` | six `file:` secrets — materialised as Podman-native secrets since 3.1.0, which is an API call per secret each way |
+| `secrets` | six `file:` secrets, materialised as Podman-native secrets since 3.1.0, which is an API call per secret each way |
 | `warm-restart` | a second `up` on an already-running project |
 | `many-services` | a 12-service compose file, the realistic upper end |
 | `running-ops` | `ps`, `logs`, `exec`, `restart` on a running stack |
@@ -60,7 +60,7 @@ container ignoring `SIGTERM` as PID 1.
 
 Every timed run goes through `bench/timeit`, so each row records **wall-clock,
 peak resident memory (max RSS) and CPU time** of the tool process. The memory and
-CPU figures are the **client-side** cost — the tool process and the processes it
+CPU figures are the **client-side** cost: the tool process and the processes it
 directly spawns and waits on. podup is a thin client to the long-running Podman
 service, so engine-side work is not charged to it; podman-compose shells out to
 `podman` per call and is charged for the work it waits on. The columns therefore
@@ -73,14 +73,14 @@ on first use; it lives outside the workspace, like `fuzz/`, so it is not part of
 a podup build.
 
 It replaced `/usr/bin/time -v`, whose `Elapsed` line resolves to 0.01 s. That put
-a floor under the suite's two fastest rows — `running-ops ps` and `config-heavy
-config`, both under 10 ms — which published as `0.000` while `raw.csv` stored
+a floor under the suite's two fastest rows (`running-ops ps` and `config-heavy
+config`, both under 10 ms), which published as `0.000` while `raw.csv` stored
 them as `%.6f` seconds.
 
 **Why the timer is compiled rather than a script.** `ru_maxrss` survives
 `execve`: a child inherits its parent's high-water mark, so a wrapper's own
 footprint becomes a floor under every memory figure it reports. Measured on
-`/bin/true`, whose real cost is about 1.3 MB — `/usr/bin/time -v` 1336 KB, this
+`/bin/true`, whose real cost is about 1.3 MB: `/usr/bin/time -v` 1336 KB, this
 binary 1312 KB, a `python3` wrapper 6304 KB with `fork` + `execvp` and 9792 KB
 with `posix_spawnp`. A ~6 MB floor under a column that reports podup at about
 8.9 MB would leave that column measuring the wrapper. The same run had the
@@ -100,7 +100,7 @@ python3 bench/aggregate.py
 # -> bench/results/report.md and bench/results/summary.json
 ```
 
-`--smoke` runs a single scenario once, for a quick local check against a real engine (CI no longer uses it — it static-checks the harness instead; see above).
+`--smoke` runs a single scenario once, for a quick local check against a real engine (CI no longer uses it; it static-checks the harness instead, see above).
 
 ## Output
 

--- a/bench/aggregate.py
+++ b/bench/aggregate.py
@@ -6,7 +6,7 @@ whose command failed (rc != 0), and reports median / p95 / stdev / n per
 (tool, scenario, op) for three metrics: wall-clock seconds, peak resident memory
 (max RSS), and CPU time. Emits results/report.md and results/summary.json.
 
-raw.csv and summary.json stay in seconds at full precision — one canonical unit.
+raw.csv and summary.json stay in seconds at full precision, one canonical unit.
 Only the report picks a readable one, per row (see row_unit).
 
 No number is invented here: every statistic is computed from the measured rows,
@@ -29,7 +29,7 @@ ENGINE = os.path.join(HERE, "results", "engine")
 def read_engine():
 	"""Which engine docker-compose drove, as recorded by run.sh next to raw.csv.
 
-	Empty when the file is absent — an older results directory, or a run where
+	Empty when the file is absent: an older results directory, or a run where
 	docker-compose was not measured at all.
 	"""
 	try:
@@ -41,7 +41,7 @@ def read_engine():
 # Preferred ordering only. Anything measured but not listed here is appended
 # rather than dropped: this list silently discarded four scenarios' worth of
 # results (config-heavy, wide-running-ops, deep-chain, wide-level) because it was
-# a filter, not an order — 972 rows measured, four scenarios never printed.
+# a filter, not an order: 972 rows measured, four scenarios never printed.
 SCEN_ORDER = [
 	"single", "multi-healthcheck", "deep-chain", "wide-level", "scale",
 	"network-ipam", "volume-heavy", "secrets", "warm-restart", "many-services",
@@ -97,8 +97,8 @@ def row_unit(cells, metric):
 	Returns (suffix, multiplier, decimals).
 
 	One unit per row, applied to every tool in it. Choosing per cell would break
-	the comparison the reader actually makes — one tool against another on the
-	same operation — by putting "90 ms" next to "0.11 s". Across rows the
+	the comparison the reader actually makes (one tool against another on the
+	same operation) by putting "90 ms" next to "0.11 s". Across rows the
 	workloads differ anyway, so a row is the widest scope where a shared unit
 	still means something.
 
@@ -116,8 +116,8 @@ def row_unit(cells, metric):
 		return ("ms", 1000.0, 1)
 	# Above a minute, seconds stop being readable at a glance: a scenario that
 	# takes two minutes printed as `120.000 s` makes the reader do the division.
-	# No published row reaches this yet — the slowest is `wide-level up` at 9.7 s
-	# for docker-compose — but the tier belongs here before a long scenario is
+	# No published row reaches this yet (the slowest is `wide-level up` at 9.7 s
+	# for docker-compose) but the tier belongs here before a long scenario is
 	# added rather than after, when the fix competes with reading the results.
 	if values and max(values) >= 60.0:
 		return ("min", 1.0 / 60.0, 2)
@@ -240,7 +240,7 @@ def main():
 				 "same compose file per scenario.\n")
 
 	metric_table(
-		"Wall-clock — pure tool comparison (all drive Podman)",
+		"Wall-clock, pure tool comparison (all drive Podman)",
 		"Lower is better. Median with p95 and stdev in parentheses. Each row "
 		"carries one unit, picked from the largest value in it, so the tools in "
 		"a row stay directly comparable; raw.csv and summary.json keep every "
@@ -250,14 +250,14 @@ def main():
 		"rather than at a Docker daemon.",
 		same, wall)
 	metric_table(
-		"Memory + CPU — pure tool comparison (all drive Podman)",
+		"Memory + CPU, pure tool comparison (all drive Podman)",
 		"Peak resident memory (max RSS) and CPU time of the tool process per "
 		"command, median. This is the client-side cost of running the tool: "
 		"podup is a static binary talking to the Podman service, podman-compose "
 		"is Python shelling out to `podman`.",
 		same, mem)
 	metric_table(
-		"Wall-clock — cross-engine stack (different daemon)",
+		"Wall-clock, cross-engine stack (different daemon)",
 		"docker-compose drives dockerd, so these are an end-to-end stack "
 		"comparison, not pure-tool. Only present when a Docker Engine was "
 		"available on the benchmark host.",
@@ -269,14 +269,14 @@ def main():
 
 	if self_test:
 		# The self-test runs on six fixture rows. Writing them out would replace a
-		# real report and summary — the output of a benchmark that takes the better
+		# real report and summary, the output of a benchmark that takes the better
 		# part of an hour and cannot be recomputed, since raw.csv is the only copy.
 		# Printed, not just built: the fixtures exist to exercise the formatting,
 		# and a table nobody looks at cannot show that a row picked the wrong
 		# unit or that a cell came out empty.
 		print("\n".join(lines))
 		# Exercise the budget gate in both directions. The fixture rows are
-		# synthetic, so they are not measured against the real budget — but a gate
+		# synthetic, so they are not measured against the real budget, but a gate
 		# nobody has watched fail is decoration, and this is the only place the
 		# shared-CI smoke run can watch it.
 		# The unit tiers, exercised rather than assumed: a row is rendered in one
@@ -322,7 +322,7 @@ def check_memory_budget(summary):
 	someone decided to, not a number that drifts inside a script.
 	"""
 	if not os.path.exists(BUDGET):
-		print(f"no memory budget at {BUDGET} — skipping the check", file=sys.stderr)
+		print(f"no memory budget at {BUDGET}; skipping the check", file=sys.stderr)
 		return 0
 	with open(BUDGET) as f:
 		budget = float(f.read().strip())

--- a/bench/chart.py
+++ b/bench/chart.py
@@ -2,7 +2,7 @@
 """Render the README's benchmark chart from the measured summary.
 
 The chart used to be hand-drawn SVG. It said "7 MiB vs 69 MiB, 7-15x faster"
-long after the measurements said 7.3 against 50.5 — nothing regenerated it and
+long after the measurements said 7.3 against 50.5; nothing regenerated it and
 nothing checked it, so it aged in silence while the numbers under it moved.
 Generating it from `summary.json` means the picture cannot disagree with the
 table beside it.
@@ -17,7 +17,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 SUMMARY = os.path.join(HERE, "results", "summary.json")
 OUT = os.path.join(os.path.dirname(HERE), "docs", "assets", "bench.svg")
 
-# (label, scenario, op, key) — the four the README quotes.
+# (label, scenario, op, key): the four the README quotes.
 ROWS = [
     ("memory per command", "single", "up", "rss_mib"),
     ("up · 42 services", "wide-level", "up", "seconds"),
@@ -70,7 +70,7 @@ def main() -> int:
         "  </style>",
         f'  <rect class="card" x="0.5" y="0.5" width="{width - 1}" height="{height - 1}" rx="10"/>',
         f'  <text class="t" x="24" y="30">podup vs docker-compose vs podman-compose '
-        f'— same rootless Podman</text>',
+        f'on the same rootless Podman</text>',
         f'  <text class="l" x="24" y="47">median of 10 measured runs · lower is better</text>',
     ]
 

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -18,7 +18,7 @@
 # client to the long-running Podman service, so engine-side work is not charged
 # to it; podman-compose shells out to the `podman` binary per call, whose work it
 # waits on and is charged for. The columns therefore measure client-side cost per
-# command — what running the tool costs on your machine — not engine work.
+# command, what running the tool costs on your machine, not engine work.
 #
 # Usage: bench/run.sh [--iters N] [--warmup W] [--cores CPUSET] [--smoke]
 set -u
@@ -76,7 +76,7 @@ declare -A OP=(
 # Every scenario must have an op, or the run dies partway through with an
 # unbound-variable error under `set -u`. deep-chain and wide-level were added to
 # SCENARIOS in #1123 and never added here, so the suite has been unable to
-# complete since — nobody noticed because those two were only ever run by hand,
+# complete since; nobody noticed because those two were only ever run by hand,
 # one at a time, to measure the scheduler change that introduced them.
 for _s in "${SCENARIOS[@]}"; do
 	[ -n "${OP[$_s]:-}" ] || { echo "bench: scenario '$_s' has no entry in OP" >&2; exit 2; }
@@ -85,11 +85,11 @@ if [ "$SMOKE" -eq 1 ]; then SCENARIOS=(single running-ops); fi
 
 TOOLS=(podup podman-compose)
 # docker compose is the tool podup targets for parity, so it is the comparison
-# that matters most — but WHICH engine it drives changes what the numbers mean.
+# that matters most, but WHICH engine it drives changes what the numbers mean.
 #
 #   against Podman  a pure tool comparison: same engine, so the difference is
 #                   the orchestrator and nothing else. This is the fair one, and
-#                   it needs no Docker installed — only DOCKER_HOST pointed at
+#                   it needs no Docker installed, only DOCKER_HOST pointed at
 #                   the Podman socket.
 #   against dockerd a whole-stack comparison: engine differences are folded in,
 #                   so it cannot be read as "tool A is faster than tool B".
@@ -99,7 +99,7 @@ TOOLS=(podup podman-compose)
 # Which engine docker-compose drove is written NEXT TO THE RESULTS, not only
 # exported. An env var dies with this process, and the documented flow is two
 # commands (`bash bench/run.sh`, then `python3 bench/aggregate.py`), so the
-# aggregator never saw it and fell back to assuming dockerd — printing a
+# aggregator never saw it and fell back to assuming dockerd, printing a
 # same-engine measurement under a heading that says "different daemon". The file
 # travels with raw.csv, which is the only thing that can still be read afterwards.
 ENGINE_FILE="$OUT_DIR/engine"
@@ -109,19 +109,19 @@ if command -v docker-compose >/dev/null 2>&1; then
 		TOOLS+=(docker-compose)
 		export BENCH_DOCKER_ENGINE=docker
 		echo docker > "$ENGINE_FILE"
-		echo "note: Docker Engine present — docker-compose measured as a CROSS-ENGINE (whole-stack) run."
+		echo "note: Docker Engine present; docker-compose measured as a CROSS-ENGINE (whole-stack) run."
 	elif [ -n "${DOCKER_HOST:-}" ] && docker-compose ls >/dev/null 2>&1; then
 		TOOLS+=(docker-compose)
 		# Recorded so the report puts these rows under the right heading; the
 		# tool's name does not say which engine it drove.
 		export BENCH_DOCKER_ENGINE=podman
 		echo podman > "$ENGINE_FILE"
-		echo "note: docker-compose driving Podman via DOCKER_HOST — measured as a SAME-ENGINE (pure tool) run."
+		echo "note: docker-compose driving Podman via DOCKER_HOST; measured as a SAME-ENGINE (pure tool) run."
 	else
-		echo "note: docker-compose found but no reachable engine — NOT measured. Set DOCKER_HOST to the Podman socket to include it."
+		echo "note: docker-compose found but no reachable engine; NOT measured. Set DOCKER_HOST to the Podman socket to include it."
 	fi
 else
-	echo "note: docker-compose not installed — NOT measured."
+	echo "note: docker-compose not installed; NOT measured."
 fi
 
 run() { # tool, compose-file, project, op-args...
@@ -209,7 +209,7 @@ for tool in "${TOOLS[@]}"; do
 				parse)
 					# The only op with no engine on the other side: read, interpolate,
 					# merge and re-render. No containers means no daemon variance, so
-					# this is the least noisy number the suite produces — and it is
+					# this is the least noisy number the suite produces, and it is
 					# what CI runs most, to validate a file before deploying it.
 					row config "$(timed "$tool" "$file" "$proj" config)"
 					;;

--- a/bench/scenarios/config-heavy/compose.yaml
+++ b/bench/scenarios/config-heavy/compose.yaml
@@ -1,6 +1,6 @@
 # Parse-heavy: the one scenario with no engine in it at all.
 #
-# `config` reads, interpolates, merges and re-renders — pure client-side work,
+# `config` reads, interpolates, merges and re-renders: pure client-side work,
 # so the numbers carry no container noise and no daemon variance. It is also
 # what CI does most often, to validate a compose file before deploying it.
 #
@@ -10,7 +10,7 @@
 #
 # Dependencies are deliberately SHALLOW. An earlier version of this file chained
 # all 24 services one after another, and podman-compose took 7.4s on it against
-# 0.10s for the same file with the chain removed — a 70x cost in dependency
+# 0.10s for the same file with the chain removed, a 70x cost in dependency
 # resolution, not in parsing. Leaving the chain in would have made this scenario
 # report that number as a parse cost, which is not what it is. The deep-chain
 # scenario is where dependency shape belongs.

--- a/bench/scenarios/deep-chain/compose.yaml
+++ b/bench/scenarios/deep-chain/compose.yaml
@@ -13,13 +13,13 @@
 #   level 3:  chain3      ->  chain2
 #
 # Under barriers, `after_fast` cannot start until `slow` is healthy, even though
-# it does not depend on it — and everything behind it inherits that wait. Under a
+# it does not depend on it, and everything behind it inherits that wait. Under a
 # DAG the whole chain runs while `slow` is still coming up.
 #
 # NOTE: this file does NOT show the scheduler cost, and that is worth knowing
 # before reading a run of it. Readiness is gated per dependency, so `after_fast`
 # starts while `slow` is still `starting` even under level barriers, and the
-# barrier looks free. The cost lives in level WIDTH, not depth — see the
+# barrier looks free. The cost lives in level WIDTH, not depth; see the
 # `wide-level` scenario. This one stays as the readiness-ordering case, which is
 # what it actually measures.
 services:

--- a/bench/scenarios/wide-level/compose.yaml
+++ b/bench/scenarios/wide-level/compose.yaml
@@ -3,7 +3,7 @@
 # `up` creates each dependency level with bounded concurrency
 # (MAX_LIFECYCLE_CONCURRENCY = 16), so a wide level is created in batches. Under
 # a level barrier, NOTHING in level 1 may start until the whole of level 0 has
-# been created — including services it does not depend on. A per-service DAG
+# been created, including services it does not depend on. A per-service DAG
 # starts a dependent the moment its own dependencies are up.
 #
 # 41 services in level 0 (2.5 batches) and one dependent behind exactly one of
@@ -13,7 +13,7 @@
 #   podup            809 ms
 #   docker compose   129 ms
 #
-# A two-service level shows nothing (see `deep-chain`) — readiness is already
+# A two-service level shows nothing (see `deep-chain`): readiness is already
 # gated per dependency. It is the batching that costs.
 services:
   anchor:

--- a/bench/scenarios/wide-running-ops/compose.yaml
+++ b/bench/scenarios/wide-running-ops/compose.yaml
@@ -1,6 +1,6 @@
 # Read-path cost across many containers, which running-ops (one service) cannot
 # show. `ps` renders a table of twelve rows, `logs` aggregates twelve streams and
-# prefixes each line with its service — the work grows with the container count,
+# prefixes each line with its service, so the work grows with the container count,
 # and every tool does it differently.
 services:
   svc01:

--- a/bench/timeit/src/main.rs
+++ b/bench/timeit/src/main.rs
@@ -1,12 +1,12 @@
 //! Times one command for the benchmark harness.
 //!
-//! Prints a single line — `wall_s max_rss_kb cpu_s rc` — which `bench/run.sh`
+//! Prints a single line (`wall_s max_rss_kb cpu_s rc`) which `bench/run.sh`
 //! appends to `raw.csv` in that field order.
 //!
 //! This replaces `/usr/bin/time -v`, whose `Elapsed` field is `h:mm:ss.SS`. At
 //! hundredths of a second the two fastest rows in the suite (`running-ops ps`
 //! and `config-heavy config`, both under 10 ms) published as `0.000`, while
-//! `raw.csv` stored them as `%.6f` seconds — precision the instrument did not
+//! `raw.csv` stored them as `%.6f` seconds, precision the instrument did not
 //! have.
 //!
 //! Everything else about the measurement is unchanged. `ru_maxrss` is already
@@ -33,7 +33,7 @@
 //! to `/proc/self/clear_refs` in the child before the exec does not help: the
 //! child's resident set at that moment is still the interpreter's.
 //!
-//! The same run showed the interpreter inflating the clock on short commands —
+//! The same run showed the interpreter inflating the clock on short commands:
 //! `/bin/true` timed at 1.0 ms through `posix_spawnp` against 0.50 ms here.
 //!
 //! Usage: `timeit COMMAND [ARG...]`

--- a/debian/changelog
+++ b/debian/changelog
@@ -276,7 +276,7 @@ podup (4.0.0) unstable; urgency=medium
   * Bridge networks are isolated from each other now. Docker does this and
     podman does not, so a service could reach ports on a neighbouring network
     that were never published. Measured with the same experiment on both
-    engines — a listener on an unpublished port in network B, a container in
+    engines: a listener on an unpublished port in network B, a container in
     network A dialling its address: docker 29.6.2 refused, podman 5.7.0
     connected. Inside one network docker connects, which is what makes that a
     measurement of isolation rather than of a broken dial.
@@ -302,8 +302,8 @@ podup (4.0.0) unstable; urgency=medium
     to warn that the condition "is not enforceable in Quadlet"; measured on
     podman 5.7.0 with a probe that takes ten seconds to pass, a dependant now
     starts ten seconds in rather than immediately. The warning is scoped to
-    what genuinely cannot work — a `service_healthy` naming a service with no
-    healthcheck, and `service_completed_successfully` — and names the service
+    what genuinely cannot work (a `service_healthy` naming a service with no
+    healthcheck, and `service_completed_successfully`) and names the service
     at fault.
 
   * `build.ulimits` reaches the build. It was reported as having no libpod
@@ -316,9 +316,9 @@ podup (4.0.0) unstable; urgency=medium
 
   * Namespace validation is per-slot. One allow-list served `pid`, `ipc`,
     `uts`, `cgroup` and `userns_mode`, which made it wrong for four of them.
-    It refused what podman accepts — `ipc: shareable`, and every
+    It refused what podman accepts: `ipc: shareable`, and every
     `userns_mode` value podman offers (`keep-id`, `auto`, `nomap`, and the
-    `keep-id:uid=…` and `auto:size=…` forms) — and accepted what podman
+    `keep-id:uid=…` and `auto:size=…` forms). It also accepted what podman
     refuses, `none` on four slots, which then came back as a libpod error
     naming no field. The error text now lists the modes the slot in hand
     accepts. A short but legal `ns:/x` was also rejected for being shorter
@@ -517,7 +517,7 @@ podup (3.6.0) unstable; urgency=medium
   Incompatible
 
   * `events` prints its TIME column in the reader's own time zone with the
-    offset that applied at that instant — `2026-08-03 09:44:27 -05:00`, matching
+    offset that applied at that instant, `2026-08-03 09:44:27 -05:00`, matching
     `podman events`. It was UTC and said so nowhere, which is worse than either
     alternative: a reader correlating a podup line against `podman events` or
     `journalctl` read it as their own wall clock and was silently wrong by the
@@ -531,8 +531,8 @@ podup (3.6.0) unstable; urgency=medium
     Podman 6 the archive endpoint applies the upload and closes without a
     response, and the confirmation asked whether the destination's mtime had
     moved. That runtime reports the mtime to whole seconds, so two copies inside
-    one second were indistinguishable — three failures in six back-to-back
-    copies, measured — and re-copying an unchanged file could never be confirmed
+    one second were indistinguishable (three failures in six back-to-back
+    copies, measured) and re-copying an unchanged file could never be confirmed
     at all, since the extracted file takes the source's own mtime. The
     confirmation now asks whether the destination matches what was uploaded.
     This matters most for `watch`, which fires on every write to a watched path.
@@ -540,7 +540,7 @@ podup (3.6.0) unstable; urgency=medium
   Added
 
   * `ps -s/--size` adds a SIZE column: what the container has written on top of
-    its image, then the image's own size — `143kB (virtual 225MB)`, the same
+    its image, then the image's own size: `143kB (virtual 225MB)`, the same
     shape `podman ps -s` prints. Opt-in because the runtime walks each
     container's writable layer to answer it.
   * `volumes -s/--size` adds SIZE and RECLAIMABLE. A volume a container still
@@ -587,7 +587,7 @@ podup (3.5.0) unstable; urgency=medium
   Changed
 
   * Sizes and durations now come from one formatter that is total over its input
-    type. `stats` used to saturate at TiB, rendering a petabyte as `1024.0TiB` —
+    type. `stats` used to saturate at TiB, rendering a petabyte as `1024.0TiB`:
     right arithmetic, wrong unit. Its own output is otherwise unchanged.
   * Durations read as up to three components whose units follow the magnitude:
     `5s`, `1h 5m 3s`, `1y 1mo 5d`. A year is 365 days and a month is 30.
@@ -611,8 +611,8 @@ podup (3.4.1) unstable; urgency=medium
   Fixed
 
   * `podup top` no longer aborts when a service has already stopped. A project
-    where anything has run to completion — a `migrate` that exits once is the
-    everyday shape — used to lose the services `top` had not reached yet and
+    where anything has run to completion (a `migrate` that exits once is the
+    everyday shape) used to lose the services `top` had not reached yet and
     exit non-zero. It now skips the stopped container and carries on, matching
     `docker compose top`, which was measured against the same Podman socket.
 
@@ -639,12 +639,12 @@ podup (3.4.0) unstable; urgency=medium
   The library API is unchanged; every item here is command-line output.
 
   * `podup build` writes its output to **stderr**, not stdout. `podup build >
-    build.log` now captures nothing — redirect stderr instead (`2> build.log`,
+    build.log` now captures nothing; redirect stderr instead (`2> build.log`,
     or `> build.log 2>&1`). stdout was documented as a clean pipe and `build`
     was the one command contradicting it.
 
-  * `podup wait` prints one line per container — its name and exit code in
-    aligned columns — instead of a bare exit code per service. Use the new
+  * `podup wait` prints one line per container, its name and exit code in
+    aligned columns, instead of a bare exit code per service. Use the new
     `--format json` for a stable machine-readable form.
 
   * `podup --version` prints `podup version v3.4.0`, matching `podup version`,
@@ -660,7 +660,7 @@ podup (3.4.0) unstable; urgency=medium
 
   * Each service now gets its own identity colour. The palette holds twenty
     colours instead of six and is assigned in sorted order rather than hashed,
-    so two services in a project no longer share a colour — measured on a
+    so two services in a project no longer share a colour: measured on a
     four-service project, two of them did. Every colour reads on a light
     terminal and a dark one alike, and sits away from the red, green and yellow
     that carry status meaning.
@@ -673,8 +673,8 @@ podup (3.4.0) unstable; urgency=medium
     the healthy colour everywhere else in podup and cyan is an identity colour,
     so the two most-read surfaces were competing for one vocabulary.
 
-  * `wait` prints one line per container — its name and exit code, in aligned
-    columns — instead of a bare exit code per service. A scaled service now
+  * `wait` prints one line per container, its name and exit code, in aligned
+    columns, instead of a bare exit code per service. A scaled service now
     reports each replica separately, which is the granularity docker compose
     reports at. New `--format json` emits one NDJSON object per container as
     that container exits.
@@ -700,7 +700,7 @@ podup (3.4.0) unstable; urgency=medium
     scrolling up and staying. In a pipe, a file, CI, under `NO_COLOR` or with
     `--ansi never`, the same events come out as plain append-only lines and no
     escape sequences. Both carry the intermediate transitions (`Creating` then
-    `Created`), which no renderer emitted before — so a log now says more than
+    `Created`), which no renderer emitted before, so a log now says more than
     it used to, never less.
 
   * `pull` reports through the progress layer and emits a matching `Pulled`. It
@@ -727,12 +727,12 @@ podup (3.4.0) unstable; urgency=medium
 
   * Ctrl-C out of a command drawing a live region left the cursor hidden. The
     restore ran from `Drop`, which covers a command that returns and nothing
-    else — Rust terminates on SIGINT without unwinding. `stats` is where it bit
+    else: Rust terminates on SIGINT without unwinding. `stats` is where it bit
     hardest, since Ctrl-C is the normal way to leave it.
 
   * `down` reported removing networks and volumes that never existed. On a
     project name that had never been created it announced three removals,
-    including a data volume — naming data the operator is told is gone.
+    including a data volume, naming data the operator is told is gone.
 
   * `podup --version` printed `podup 3.3.0` while `podup version` printed
     `podup version v3.4.0`, so a script probing the binary got a different
@@ -741,7 +741,7 @@ podup (3.4.0) unstable; urgency=medium
   * `autostart status` coloured `enabled: not-found` red while `installed: no`
     was dim, though both report the same uninstalled unit and neither is a
     failure. A unit that is on disk while systemd cannot find it still reports
-    red — that one is a broken install.
+    red; that one is a broken install.
 
   * `events` painted an event's actor name without escaping it. Names come from
     outside podup, so an escape sequence in one repainted the reader's terminal
@@ -804,7 +804,7 @@ podup (3.2.1) unstable; urgency=medium
 
   * A severed stream is now named `body-unexpected-eof` in podup's diagnostics
     instead of the catch-all `hyper-other`. `IncompleteMessage`, the predicate
-    that sounds like it covers this, is about the message head — a body cut
+    that sounds like it covers this, is about the message head: a body cut
     off mid-flight matched none of hyper's own predicates and fell through to
     the least informative label there is. Measured against a socket that
     severs a chunked body on purpose: both places a cut can land arrive as a
@@ -853,7 +853,7 @@ podup (3.1.0) unstable; urgency=medium
     host file's own permission bits, so 0644 stays 0644 and 0600 stays
     unreadable to a non-root container user. Note the trade: the payload
     is a copy taken at `up`, so editing the host file afterwards no longer
-    reaches an already-running container — recreate it to pick up a new
+    reaches an already-running container; recreate it to pick up a new
     value. An atomic replace never did reach one, since a file bind pins
     the inode.
 
@@ -972,7 +972,7 @@ podup (2.1.0) unstable; urgency=medium
     README and in the autostart guide.
   * `podup` with no subcommand printed a list of forty-five subcommand names
     instead of its help whenever COMPOSE_PROJECT_NAME, PODMAN_SOCKET or
-    COMPOSE_PROFILES was set — the normal state of a deployment. Both cases
+    COMPOSE_PROFILES was set, the normal state of a deployment. Both cases
     print the help now.
   * That help is also coloured, like every other screen. It was the only one
     that was not.
@@ -1013,7 +1013,7 @@ podup (2.0.0) unstable; urgency=medium
     success. The project is still torn down before the code is returned.
   * `--sig-proxy` accepts docker's bare form. It required a value, so
     `docker compose attach --sig-proxy web` failed with a usage error against
-    podup — inside the set of flags whose purpose is that such a script runs
+    podup, inside the set of flags whose purpose is that such a script runs
     unchanged.
   * autostart service mode bounds ExecStop above the project's longest
     stop_grace_period. systemd's own 90s default was cutting a slower stack off
@@ -1043,7 +1043,7 @@ podup (2.0.0) unstable; urgency=medium
   * Output carries colour consistently: one stable colour per container across
     ps, logs, stats, top, events and the up/down progress lines; status words
     tinted by meaning; CPU and memory banded by threshold. Two colours that
-    said the opposite of the truth are fixed — a half-running project rendered
+    said the opposite of the truth are fixed: a half-running project rendered
     entirely red, and a container that finished cleanly rendered as a failure.
     Machine output (--json, --quiet, config, port, wait) stays plain, and
     colour is off automatically when stdout is not a terminal.

--- a/debian/control
+++ b/debian/control
@@ -77,7 +77,7 @@ Architecture: any
 #   /etc/apt/apt.conf.d/51glyndor-unattended-upgrades  the Allowed-Origins entry
 #
 # Without it the daemon runs, the logs look healthy, and podup is never upgraded
-# — which is the exact outcome the unattended-upgrades dependency was added to
+# which is the exact outcome the unattended-upgrades dependency was added to
 # prevent. Two install paths reached that state: `dpkg -i` of the .deb from a
 # GitHub release, and adding the repository by hand rather than through the
 # bootstrap installer. #1602.
@@ -88,15 +88,15 @@ Architecture: any
 # `dpkg -i` with no repository at all fails on the unmet dependency, which is
 # the intended answer rather than a gap.
 #
-# A fork publishing its own archive — which install-template.sh supports through
-# KEYRING_URL and GLYNDOR_APT_FPR — must declare `Provides: glyndor-archive-keyring`
+# A fork publishing its own archive (which install-template.sh supports through
+# KEYRING_URL and GLYNDOR_APT_FPR) must declare `Provides: glyndor-archive-keyring`
 # on its own keyring package, or this relationship cannot be satisfied by it.
 Depends: ${shlibs:Depends}, ${misc:Depends}, podman (>= 5.0), unattended-upgrades, glyndor-archive-keyring
 Description: docker-compose translator and runner for rootless Podman
  podup parses docker-compose.yml files and drives rootless Podman to
  create the equivalent containers, networks and volumes. It provides
- the full Compose workflow — lifecycle, build/push, exec/run, inspection
- and Quadlet generation — as a single static binary with no daemon and
+ the full Compose workflow (lifecycle, build/push, exec/run, inspection
+ and Quadlet generation) as a single static binary with no daemon and
  no Python runtime. Run `podup --help` for the complete command list.
  .
  It supports compose-spec parsing including YAML anchors, extends,

--- a/debian/rules
+++ b/debian/rules
@@ -45,7 +45,7 @@ endif
 
 # Drop the self-update stack (ureq + TLS + Ed25519) from the packaged binary:
 # apt owns upgrades on Debian, so `podup update` is disabled here. `completions`
-# stays on — the install step below generates the shell scripts from the binary.
+# stays on: the install step below generates the shell scripts from the binary.
 CARGO_FEATURES = --no-default-features --features watch,completions
 
 %:

--- a/docs/assets/bench.svg
+++ b/docs/assets/bench.svg
@@ -6,7 +6,7 @@
     .v { fill:#e6edf3; font:600 12px ui-monospace,monospace; }
   </style>
   <rect class="card" x="0.5" y="0.5" width="759" height="543" rx="10"/>
-  <text class="t" x="24" y="30">podup vs docker-compose vs podman-compose — same rootless Podman</text>
+  <text class="t" x="24" y="30">podup vs docker-compose vs podman-compose on the same rootless Podman</text>
   <text class="l" x="24" y="47">median of 10 measured runs · lower is better</text>
   <text class="t" x="24" y="72">memory per command</text>
   <text class="l" x="168" y="97" text-anchor="end">podup</text>

--- a/docs/autostart.md
+++ b/docs/autostart.md
@@ -29,8 +29,8 @@ in who owns the containers, and in whether the boot path reconciles.
 
 | Mode | What it installs | Choose it when |
 |---|---|---|
-| `service` (default) | One `Type=oneshot` unit that runs `podup up -d` at boot and `podup stop` on shutdown. | You want the whole stack managed as a unit, the simplest option — one thing to enable, one to remove. |
-| `quadlet` | One native Podman Quadlet unit per service (`.container`/`.build`/`.volume`/`.network`), which systemd owns directly. | You want per-container supervision — systemd restarts, ordering and status for each service independently. |
+| `service` (default) | One `Type=oneshot` unit that runs `podup up -d` at boot and `podup stop` on shutdown. | You want the whole stack managed as a unit, the simplest option: one thing to enable, one to remove. |
+| `quadlet` | One native Podman Quadlet unit per service (`.container`/`.build`/`.volume`/`.network`), which systemd owns directly. | You want per-container supervision: systemd restarts, ordering and status for each service independently. |
 | `start` | One `Type=oneshot` unit whose `ExecStart` is `podman start`. Single-service projects only. | You want the boot to resume the container that already exists, with nothing else on the path. |
 
 ### Reconcile or restore
@@ -68,7 +68,7 @@ container was created, a boot would resume the old configuration. `podup` compar
 the container's `podup.config-hash` label against what the file renders and refuses
 to install over a mismatch, or over a container that does not exist yet.
 
-That check runs when you install, because there is no `podup` at boot to run it —
+That check runs when you install, because there is no `podup` at boot to run it,
 which is the point of the mode, and therefore also its limit. Editing the compose
 file after installing leaves the unit starting the old container silently. Run
 `podup up -d` after any change to the file, exactly as you would to deploy it.
@@ -120,7 +120,7 @@ the feature existed. The timer pair only appears when the flag is given, and
 `uninstall` detects which mode is installed and removes that one; you never pass
 `--mode` to it. `rebuild` applies to quadlet mode: a Quadlet `.build` unit is
 `Type=oneshot`, so an image only rebuilds when its build service is restarted, and
-the container is then restarted to pick it up. Service mode has no `rebuild` — it
+the container is then restarted to pick it up. Service mode has no `rebuild`; it
 builds at deploy time, whenever you run `podup up`.
 
 ## Why `--user` and `default.target`
@@ -182,7 +182,7 @@ the shim as present in exactly the case it is missing.
 ## Running `systemctl --user` for a login-less account
 
 An isolated service account has no login shell, so you cannot open a session for
-it — `su - appuser` and `machinectl shell appuser@` both bounce, because they try
+it: `su - appuser` and `machinectl shell appuser@` both bounce, because they try
 to launch a login shell that does not exist. With no session there is no D-Bus
 session bus, and `systemctl --user` without a bus fails:
 
@@ -213,10 +213,10 @@ a non-login SSH command has no runtime dir set, so export it before running
 For a dedicated service account the account itself needs the usual rootless
 Podman groundwork, done once:
 
-- **Subordinate UID/GID ranges** — rootless Podman maps container users into the
+- **Subordinate UID/GID ranges.** Rootless Podman maps container users into the
   host user's subordinate ranges. Ensure the account has entries in
   `/etc/subuid` and `/etc/subgid` (e.g. `appuser:100000:65536`).
-- **`podman system migrate` as the user** — run it **as the account**, never via
+- **`podman system migrate` as the user.** Run it **as the account**, never via
   `sudo` as root, so the migration writes the account's own storage config rather
   than root's:
 
@@ -225,7 +225,7 @@ Podman groundwork, done once:
        podman system migrate
   ```
 
-- **The Podman API socket** — `podman` is daemonless and needs no socket, so a
+- **The Podman API socket.** `podman` is daemonless and needs no socket, so a
   fresh account can run `podman` fine and still have every `podup` command fail
   with a connection error. podup speaks the libpod API, so the socket has to be
   listening:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,11 +18,11 @@
 All three tools drive **the same rootless Podman**, so this is a pure *tool*
 comparison: identical engine, identical digest-pinned and pre-pulled images,
 identical compose file per scenario, the same op flags for every tool. Each
-number is the median over **10 measured iterations** — 12 runs with the first
+number is the median over **10 measured iterations**: 12 runs with the first
 2 discarded as warm-up; p95 and standard deviation are in parentheses.
 
 `docker-compose` normally drives dockerd. Pointing it at the Podman socket
-through `DOCKER_HOST` is what makes it comparable here — the only difference
+through `DOCKER_HOST` is what makes it comparable here; the only difference
 left is the orchestrator. Run against a Docker daemon instead, the numbers
 would fold in the engine difference and could not be read as tool-versus-tool;
 the harness detects which engine it drove and labels the report accordingly.
@@ -34,7 +34,7 @@ never by the runner.
 
 Timing comes from `bench/timeit`, which forks the command, takes the clock
 across it, and reads peak RSS and CPU from `wait4`'s rusage. It replaced
-`/usr/bin/time -v`, whose `Elapsed` field resolves to 0.01 s — coarse enough
+`/usr/bin/time -v`, whose `Elapsed` field resolves to 0.01 s, coarse enough
 that the fastest rows here used to publish as `0.000` and podup's entire CPU
 column with them.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,12 +22,12 @@ These appear before the subcommand and may also come from the environment.
 
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
 | `--ansi <WHEN>` | | Colour output: `auto`, `always` or `never`. `always` forces colour even into a pipe or file. | 
-| `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it — when this is given, `.env` is not read. The process environment still takes precedence over both. |
-| `--no-warn` | | Suppress the host-binding / privilege-escalation warnings the engine emits during `up`/`create`/`run`/`exec` (e.g. `network_mode: host`, `privileged: true`, `pid: host`, `container:<id>` namespace sharing). Operators who wrote the compose file deliberately use this to silence the per-run warning. `podup config` still surfaces the active modes at default log level — that command is the "show me what will happen" path, where the warning is the whole point. | off |
+| `--env-file <PATH>` | | Env file(s) for interpolation. Repeatable; later files win. **Replaces** a project `.env` rather than adding to it: when this is given, `.env` is not read. The process environment still takes precedence over both. |
+| `--no-warn` | | Suppress the host-binding / privilege-escalation warnings the engine emits during `up`/`create`/`run`/`exec` (e.g. `network_mode: host`, `privileged: true`, `pid: host`, `container:<id>` namespace sharing). Operators who wrote the compose file deliberately use this to silence the per-run warning. `podup config` still surfaces the active modes at default log level, since that command is the "show me what will happen" path, where the warning is the whole point. | off |
 
 **Profiles activate their dependencies.** A service left out by profile
 filtering is still started when a service that *is* running declares
-`depends_on` on it, transitively — so a retained service never points at a
+`depends_on` on it, transitively, so a retained service never points at a
 dropped one. docker compose rejects that file instead. Give the dependant the
 same profile if you want neither to start. See
 [docker-migration.md](docker-migration.md#a-depends_on-target-behind-an-inactive-profile).
@@ -48,7 +48,7 @@ everywhere but cannot fully clear that bar: of the sixteen standard ANSI
 colours, only cyan and bright magenta stay readable on both a light and a dark
 background, and four of the fallback's own six fall short (magenta and blue
 against black, bright cyan against white, bright blue against black). ANSI-16
-colours have no fixed RGB — a terminal theme picks its own — so these figures,
+colours have no fixed RGB (a terminal theme picks its own), so these figures,
 like the wide palette's, are relative to the reference palette this branch's
 tests pin (`internal/ui/palette_tests.rs`, the standard VGA 16-colour set),
 not a universal guarantee. The fallback stays anyway, on the view that
@@ -61,8 +61,8 @@ Colour elsewhere carries meaning rather than identity, and each family is used
 for one thing only: green for something that now exists or is healthy, red for
 something gone or failed, yellow for something stopped that survives, dim for a
 default or unremarkable answer. That is why `volumes` marks an external volume
-yellow rather than green — it is not healthy or unhealthy, it is the one podup
-will not delete — and why `autostart status` reports an uninstalled unit dim
+yellow rather than green (it is not healthy or unhealthy, it is the one podup
+will not delete), and why `autostart status` reports an uninstalled unit dim
 throughout instead of colouring systemd's `not-found` red.
 
 ## Defaults
@@ -108,7 +108,7 @@ regardless.
 | `--wait-timeout <SECS>` | Maximum seconds to wait with `--wait` before giving up. | no limit |
 
 **`--wait` implies `-d`.** The flag means "return once the services are up", so
-`up --wait` does not stay attached to the logs afterwards — matching
+`up --wait` does not stay attached to the logs afterwards, matching
 `docker compose up --wait`.
 
 **Under `missing`, an image already present is not pulled again.** The effective
@@ -182,7 +182,7 @@ Build or rebuild service images (optionally only the named services).
 | `--no-cache` | Do not use the build cache. | off |
 | `--pull` | Always attempt to pull a newer base image. | off |
 | `--build-arg <KEY=VAL>` | Set a build-time variable. Repeatable. | none |
-| `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert — see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
+| `--progress <STYLE>` | `auto`, `plain` or `tty`. Validated but inert; see [accepted for compatibility](#accepted-for-compatibility). | `auto` |
 | `--push` | Push each built image to its registry after a successful build. | off |
 | `-q, --quiet` | Suppress the build output. | off |
 
@@ -269,7 +269,7 @@ there is no complete set to size against). `--format json` prints no header.
 **Bounding a feed needs both flags.** Measured against Podman 5.4.2 on 2026-07-29:
 `--since -2h --until -1h` ends the feed; `--until` alone, `--since` alone, and
 any `--until` in the future all leave it following indefinitely. podup warns
-when `--until` is given without `--since`. This also decides the exit code — see
+when `--until` is given without `--since`. This also decides the exit code; see
 [Exit status](#exit-status).
 
 ### `top [SERVICE...]`
@@ -288,8 +288,8 @@ containers. On a terminal the table repaints in place; anywhere else each frame
 is appended, so a redirected `stats` stays a file of readable frames rather than
 a file of cursor moves.
 
-CPU and memory percentages are coloured by band — dim below 5%, green to 50,
-yellow to 85, red above — so an idle container recedes and the one in trouble is
+CPU and memory percentages are coloured by band: dim below 5%, green to 50,
+yellow to 85, red above, so an idle container recedes and the one in trouble is
 the one that catches the eye. The absolute figures and the PID count are
 secondary detail and stay dim.
 
@@ -301,7 +301,7 @@ streaming, one pretty array with `--no-stream`.
 | `--no-stream` | Print one snapshot and exit. | stream |
 | `-a, --all` | Include non-running containers as zeroed rows. | running only |
 | `--no-trunc` | Do not truncate long container names. | truncate at 32 |
-| `--format <FMT>` | `table` or `json`. While streaming, `json` is NDJSON — one compact array per line. | `table` |
+| `--format <FMT>` | `table` or `json`. While streaming, `json` is NDJSON: one compact array per line. | `table` |
 
 ### `port <SERVICE> <PRIVATE_PORT>`
 Print the public binding for a port.
@@ -340,7 +340,7 @@ a restart, which is the point of having both: a container created three days ago
 and started four seconds ago reads `3 days ago` / `Up 4s`.
 
 `SIZE` appears only with `-s/--size`. It reads `143kB (virtual 225MB)`: the bytes
-the container has written on top of its image, then the image's own size — the
+the container has written on top of its image, then the image's own size, the
 same shape `podman ps -s` and `docker ps -s` print, and `virtual` is the image
 size rather than the total of the two.
 
@@ -366,7 +366,7 @@ its full size and **zero** reclaimable, which is the fact that matters when you
 are clearing disk space.
 
 A volume declared in the compose file but never created renders both cells empty
-rather than `0B` — an empty cell says it is not there, while `0B` would claim it
+rather than `0B`: an empty cell says it is not there, while `0B` would claim it
 exists and holds nothing.
 
 **It is opt-in because it is slow, not because it is verbose.** No libpod
@@ -401,7 +401,7 @@ neither creates nor deletes an external volume, so those are the ones a
 | Flag | Description | Default |
 |---|---|---|
 | `-q, --quiet` | Print volume names only. | off |
-| `-s, --size` | Add SIZE and RECLAIMABLE columns. Slow — see below. | off |
+| `-s, --size` | Add SIZE and RECLAIMABLE columns. Slow; see below. | off |
 | `--format <FMT>` | `table` or `json`. | `table` |
 
 An empty result prints `no volumes` on stderr and leaves stdout empty.
@@ -436,7 +436,7 @@ podup run --rm web sh -c 'echo hello'
 > **Differs from docker on purpose.** `run` removes the container by default
 > here; `docker compose run` keeps it unless you pass `--rm`. Migrating a script
 > means its existing `--rm` becomes a no-op and a container it expected to
-> inspect afterwards is gone — pass `--no-rm` to keep it.
+> inspect afterwards is gone; pass `--no-rm` to keep it.
 
 `run` allocates a pseudo-TTY and attaches your stdin when stdin is a
 terminal, so `podup run -it app sh` drops you into an interactive session that
@@ -503,7 +503,7 @@ container side, e.g. `podup cp web:/app/data ./local`.
 
 ### `attach <SERVICE>`
 Attach to a service container's output (stdout/stderr), streaming it until the
-container exits or you detach. Output only — stdin is never attached.
+container exits or you detach. Output only; stdin is never attached.
 
 | Flag | Description | Default |
 |---|---|---|
@@ -535,7 +535,7 @@ for `unpause`.
 
 ### `wait [SERVICE...]`
 Block until the named service containers (default: all) stop, printing one line
-per container as it exits — the container's name and its exit code, in aligned
+per container as it exits: the container's name and its exit code, in aligned
 columns, with a non-zero code in red. A scaled service reports each replica
 separately. The command's own exit status is the last non-zero code it saw.
 
@@ -548,7 +548,7 @@ A project with nothing to wait on prints nothing and exits 0.
 ### `scale <SERVICE=N>...`
 Set the number of running containers for one or more services, creating missing
 replicas and removing surplus ones. A service that publishes a **fixed host
-port** cannot be scaled past one replica — the command fails fast and tells you
+port** cannot be scaled past one replica; the command fails fast and tells you
 to drop the host port (`- "80"`, so Podman assigns one per replica), front it
 with a reverse proxy, or stay at one replica.
 
@@ -598,7 +598,7 @@ as it starts and finishes, leaving stdout a clean pipe.
 ## Generate
 
 ### `generate quadlet`
-Translate the compose file into Podman Quadlet unit files — one `.container` per
+Translate the compose file into Podman Quadlet unit files: one `.container` per
 service plus `.network` and `.volume` units. `gen` is an alias for `generate`.
 
 | Flag | Description | Default |
@@ -635,7 +635,7 @@ Print the resolved compose file (after substitution, extends, include, and
 `env_file`). `convert` is an alias.
 
 `env_file` entries are read and folded into `environment:`, and the key is
-dropped — the same thing `docker compose config` does. Before 3.1.0 the key was
+dropped, the same thing `docker compose config` does. Before 3.1.0 the key was
 printed unresolved, so a service taking its whole environment from a file
 rendered with no `environment:` at all, and `config` pointed away from the answer
 it is meant to give. `environment:` still wins over `env_file:`, a later file
@@ -743,14 +743,14 @@ Verification fails closed: a missing key, bad Ed25519 signature, or SHA-256
 mismatch aborts before the installed binary is touched. After the binary is
 written, a self-test runs `<binary> --version` and refuses the install if the
 reported version does not match the resolved release tag (strict equality,
-optional single `v` prefix) — a CDN or proxy that replays an older,
+optional single `v` prefix). A CDN or proxy that replays an older,
 *legitimately* signed release passes the signature and digest checks but fails
 this one, and the previous binary is restored. The shell installers
 (`install.sh`, `install.ps1`) run the same gate. See
 [self-update.md](self-update.md) for the trust model.
 
 ### `autostart` (alias `boot`)
-Manage a boot-time autostart unit for this compose project — rootless,
+Manage a boot-time autostart unit for this compose project: rootless,
 user-scope `systemctl --user` (enable lingering with
 `loginctl enable-linger` so the unit starts without a login session). See
 [Rootless autostart](autostart.md) for the full setup, the two backends, and
@@ -800,7 +800,7 @@ A tail region rather than a full-screen takeover, deliberately: `up` is a
 command that finishes, and handing the screen back blank would destroy the
 record of what it did.
 
-**Anywhere else** — a pipe, a file, CI, `NO_COLOR`, `--ansi never` — the same
+**Anywhere else** (a pipe, a file, CI, `NO_COLOR`, `--ansi never`), the same
 events come out as plain append-only lines with no escape sequences at all:
 
 **Progress lines on stderr never contradict themselves.** A transitional
@@ -827,8 +827,8 @@ terminal showed.
 
 Only what actually happened is reported: re-running `up` over existing
 resources reports no creation, and `down` on a project whose networks or volumes
-were never created reports no removal. A command that acted on nothing says so —
-`no containers to stop`, `no containers to start (project not created)` — rather
+were never created reports no removal. A command that acted on nothing says so:
+`no containers to stop`, `no containers to start (project not created)`, rather
 than exiting silently, which is indistinguishable from success.
 
 A container that is replaced reads differently from one that is created:
@@ -881,7 +881,7 @@ keys; they are called out below.
 
 | Key | Where | What it does | Portable |
 |---|---|---|---|
-| `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop` — what Podman does when the check flips to unhealthy. Default `none`. | yes |
+| `x-podman-on-failure` | under a service's `healthcheck:` | `none`, `kill`, `restart` or `stop`, naming what Podman does when the check flips to unhealthy. Default `none`. | yes |
 | `x-podman-pod` | top level | `true` puts every service of the project into one Podman pod named after the project; see [Pods](#pods). | yes |
 | `x-podman-autoupdate` | under a service | `registry` or `local`; see [Auto-update](#auto-update). | yes |
 | `noexec`, `nosuid`, `nodev` | under a long-form volume's `volume:` | mount-hardening flags; see [Per-mount hardening options](docker-migration.md#per-mount-hardening-options-noexec-nosuid-nodev). The short form carries them as raw mount options. | no |
@@ -975,7 +975,7 @@ audit, and one place ports are published; not for a faster `up`.
 ### Healthcheck timing on a `service_healthy` gate
 
 When `up` waits on `depends_on: {condition: service_healthy}`, podup drives the
-check itself — Podman schedules its own runs through systemd transient timers,
+check itself: Podman schedules its own runs through systemd transient timers,
 which never fire on a host without systemd, so a purely passive wait would block
 until the whole budget elapsed.
 
@@ -987,8 +987,8 @@ until the whole budget elapsed.
 
 Running a check executes a command *inside* the container, so it happens no
 faster than `interval` and the floor keeps `interval: 1ms` from becoming a
-thousand executions a second. Reading the status is a plain inspect — it runs no
-command — so it is cheap and frequent, and it is what notices promptly when
+thousand executions a second. Reading the status is a plain inspect that runs no
+command, so it is cheap and frequent, and it is what notices promptly when
 Podman's own timer flips the status between podup's runs.
 
 A container that fails during the wait is reported as soon as the next read sees
@@ -1001,13 +1001,13 @@ indefinitely.
 
 > **`kill` and a restart policy do not combine the way you would expect.**
 > `--health-on-failure=kill` with `restart: unless-stopped` leaves the container
-> **exited and never revived** — the kill is not the kind of exit the restart
+> **exited and never revived**: the kill is not the kind of exit the restart
 > policy acts on. Use `restart` if you want it to come back.
 >
 > podman-run(1) suggests `kill` or `stop` "when running inside of a systemd
 > unit… to make use of systemd's restart policy". That advice assumes the unit
 > restarts the container. `autostart --mode service` writes a
-> `Type=oneshot` + `RemainAfterExit=yes` unit, which does **not** — so under
+> `Type=oneshot` + `RemainAfterExit=yes` unit, which does **not**, so under
 > podup's own service-mode unit that recommendation turns a degraded container
 > into a stopped one.
 
@@ -1018,7 +1018,7 @@ drop the whole unit at daemon-reload.
 ## Accepted for compatibility
 
 These flags parse and are validated, so a script written against docker compose
-runs unchanged — but podup does not act on them. They are listed here because
+runs unchanged, but podup does not act on them. They are listed here because
 `--help` says "accepted for compatibility" without saying which flags that
 covers, and the only other way to find out was to read the dispatch code.
 
@@ -1056,7 +1056,7 @@ returns the last non-zero code it saw.
 **`up --abort-on-container-exit` and `up --exit-code-from`** make a foreground
 `up` a usable CI test harness: the project is brought up, the named service
 (or the first to exit) runs to completion, the rest are stopped, and the
-container's exit code is the process exit code — matching `docker compose v5.1.3`
+container's exit code is the process exit code, matching `docker compose v5.1.3`
 on the same Podman socket. The teardown is `stop`, not `down`: containers
 remain in `Exited` state, ready for the next `up`/`down`. A zero exit
 propagates as `0`, not `1`, so a clean run still reports success.
@@ -1068,7 +1068,7 @@ still torn down before the code is returned, so an interrupted `up` leaves
 nothing running.
 
 This matters most in CI: a job that runs `podup up` in the foreground and is
-cancelled — by a timeout, by an operator, by the runner shutting down — used to
+cancelled (by a timeout, by an operator, by the runner shutting down) used to
 report **success**. Anything gating on that exit status could not tell a
 completed run from an abandoned one.
 
@@ -1082,8 +1082,8 @@ adapting rather than working unchanged.
 commands: `logs`, `stats`, an attached `up`, `run`, and `events`.
 
 A stream ends when the container it follows stops, and libpod marks that end
-with a chunked terminator. A lost terminator — a dropped connection, or a
-version that omits it — is indistinguishable from a real mid-stream break at the
+with a chunked terminator. A lost terminator (a dropped connection, or a
+version that omits it) is indistinguishable from a real mid-stream break at the
 transport layer, so the transport is not asked. Four of the five re-check
 whether the container is still running: still running means live output was
 truncated, and the command exits `1`. `run` reports the transport error instead
@@ -1091,25 +1091,25 @@ of an exit code, since the command it was running never produced one.
 
 This matters for anything scraping them. `logs -f` used to return success after
 losing its socket, so a monitor could not tell "the container finished" from "my
-connection died" — and a script reading that `0` was already wrong, it just had
+connection died", and a script reading that `0` was already wrong, it just had
 no way to know. `docker compose logs -f` exits `1` on the same failure (measured
 against the same Podman socket), so the old `0` was a divergence rather than
 parity.
 
 A stream that ends because its containers stopped still exits `0`, as does
 `logs` without `-f` and a `logs -f` whose reader closes the pipe (`| head`).
-When the re-check itself cannot be made — usually because the same severed
-connection is needed for it — the command fails rather than assuming the end was
+When the re-check itself cannot be made, usually because the same severed
+connection is needed for it, the command fails rather than assuming the end was
 clean.
 
 **`events` decides it differently**, because a feed is project-scoped and
 follows no single container, so there is nothing to re-check. What the caller
 asked for answers it instead:
 
-- **A bounded window** — `--since` and `--until` together, both already elapsed
-  — closes on its own, so reaching the end exits `0`.
+- **A bounded window** (`--since` and `--until` together, both already elapsed)
+  closes on its own, so reaching the end exits `0`.
 - **Anything else** is an unbounded feed. libpod never ends one, so *any* end
-  means the stream was lost and the command exits `1` — including a clean end,
+  means the stream was lost and the command exits `1`, including a clean end,
   which no check on the error shape could have caught.
 - **A transport failure always fails**, bounded or not. A severed socket is not
   made expected by having asked for a window.
@@ -1124,8 +1124,8 @@ warns when `--until` is passed without `--since`.
 
 **`watch` is the exception.** A sync, rebuild, restart or exec that fails during
 a watch session is reported as a warning and the session keeps going; `watch`
-exits 0 unless it cannot start at all. This matches `docker compose watch` — a
-long-running developer loop should not die because one rebuild failed — but it
+exits 0 unless it cannot start at all. This matches `docker compose watch`: a
+long-running developer loop should not die because one rebuild failed. But it
 does mean the exit code of a `watch` session says nothing about whether every
 action in it succeeded. Read the warnings, not the status, and do not gate
 automation on it.

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -1,7 +1,7 @@
 # Debian packaging
 
 podup is distributed for Debian and Ubuntu through the self-hosted signed apt
-repository at [`apt.glyndor.net`](https://apt.glyndor.net) — that is the
+repository at [`apt.glyndor.net`](https://apt.glyndor.net); that is the
 supported path, described below. Inclusion in the official Debian/Ubuntu
 archives is explicitly **not** a goal. The `debian/` directory in this
 repository builds the `.deb` that the apt repository serves; this page covers
@@ -21,24 +21,24 @@ The packaged binary is built with the self-update feature **compiled out**:
 `debian/rules` builds with `--no-default-features --features watch,completions`,
 dropping the `update` feature (and its `ureq` + TLS + Ed25519 stack). This is
 why `podup update` on a deb-installed binary refuses outright and points back to
-the package manager — the capability is absent from the binary, not merely
+the package manager: the capability is absent from the binary, not merely
 gated at runtime by a dpkg-ownership check.
 
 ## Prebuilt .deb from releases
 
-Each tagged release attaches a signed `.deb` per architecture —
+Each tagged release attaches a signed `.deb` per architecture:
 `podup_<version>_amd64.deb` and `podup_<version>_arm64.deb` (each with its
 `.sig`, and an entry in the release `SHA256SUMS`). Each architecture is built
 natively in its own `debian:sid` container (amd64 on an x64 runner, arm64 on an
-arm64 runner — no emulation). Install the one matching your architecture
+arm64 runner, no emulation). Install the one matching your architecture
 directly:
 
 ```bash
 sudo apt install ./podup_<version>_amd64.deb   # or _arm64.deb on aarch64
 ```
 
-`podup update` refuses to self-replace a binary installed this way — it would
-desync dpkg's record of the file — and points back to the package manager;
+`podup update` refuses to self-replace a binary installed this way (it would
+desync dpkg's record of the file) and points back to the package manager;
 upgrade with `apt` instead.
 
 ## apt repository (apt.glyndor.net)
@@ -52,7 +52,7 @@ the release signing key, builds a signed `reprepro` repository, and publishes
 it to Cloudflare R2 behind `apt.glyndor.net`. It is rebuilt fresh each run, so
 it always carries the current version of every package (no old-version
 support). podup's only responsibility is to attach a
-`podup_<version>_<arch>.deb` asset (amd64 and arm64) to each release — which
+`podup_<version>_<arch>.deb` asset (amd64 and arm64) to each release, which
 the `build-deb` matrix in `release.yml` already does.
 
 ### One-line setup
@@ -73,8 +73,8 @@ gpg --show-keys keyring-check/usr/share/keyrings/glyndor.gpg
 ```
 
 Check the printed fingerprint against the one published in the
-[apt repository README](https://github.com/Glyndor/apt#verify-the-signing-key)
-— a channel independent of `apt.glyndor.net`. Only once it matches:
+[apt repository README](https://github.com/Glyndor/apt#verify-the-signing-key),
+a channel independent of `apt.glyndor.net`. Only once it matches:
 
 ```bash
 sudo dpkg -i glyndor-archive-keyring.deb
@@ -90,23 +90,23 @@ check happens before anything in it can execute.
 
 The signing key ships as the `glyndor-archive-keyring` package, so apt owns the
 key file. When the key is rotated or its expiry extended, a new keyring version
-is published and `apt upgrade` installs it — nothing for users to re-run.
+is published and `apt upgrade` installs it, with nothing for users to re-run.
 
 > **Debian compatibility note:** the MSRV is 1.85, which Debian trixie ships, so
 > trixie and sid can both build the package.
 
 ## What the skeleton covers
 
-- `debian/control` — source/binary stanzas, build dependencies, `Depends: podman
+- `debian/control`: source/binary stanzas, build dependencies, `Depends: podman
   (>= 5.0), unattended-upgrades, glyndor-archive-keyring`. The third is what aims
   the second: it ships the `.sources` file and the `Allowed-Origins` entry, so
   without it unattended-upgrades runs and never looks at Glyndor. A fork
   publishing its own archive must declare `Provides: glyndor-archive-keyring` on
   its own keyring package, or this relationship cannot be satisfied by it.
-- `debian/rules` — debhelper with cargo overrides, `--locked` release build, tests run during the build
-- `debian/podup.1` + `debian/podup.manpages` — the man page, installed by `dh_installman`
-- `debian/copyright` — DEP-5, MIT
-- Source format `3.0 (native)` — the repository is upstream
+- `debian/rules`: debhelper with cargo overrides, `--locked` release build, tests run during the build
+- `debian/podup.1` + `debian/podup.manpages`: the man page, installed by `dh_installman`
+- `debian/copyright`: DEP-5, MIT
+- Source format `3.0 (native)`: the repository is upstream
 
 ## Not the official Debian/Ubuntu archive
 

--- a/docs/docker-migration.md
+++ b/docs/docker-migration.md
@@ -1,6 +1,6 @@
 # Migrating from Docker Compose to podup
 
-Point podup at an existing `docker-compose.yml` and run it — no rewrite, no new
+Point podup at an existing `docker-compose.yml` and run it: no rewrite, no new
 file format. The short answer is: **most files work without any changes**.
 
 ```sh
@@ -25,14 +25,14 @@ Every core Compose spec key is supported:
 | Networking | `ports`, `expose`, `networks`, `network_mode`, `hostname`, `domainname`, `dns`, `dns_search`, `extra_hosts` |
 | Volumes | `volumes` (bind, named, tmpfs, npipe), `tmpfs`, `volumes_from` |
 | Secrets / configs | `secrets`, `configs` (file, inline content, environment source, and `external: true` Podman-native secrets) |
-| Dependencies | `depends_on` (with `condition:` — `service_started`, `service_healthy`, `service_completed_successfully`) |
+| Dependencies | `depends_on` (with `condition:` set to `service_started`, `service_healthy` or `service_completed_successfully`) |
 | Health checks | `healthcheck` (test, interval, timeout, retries, start_period, disable) |
 | Lifecycle hooks | `post_start`, `pre_stop` |
 | Restart policies | `restart`, `deploy.restart_policy` (`condition`, `max_attempts`) |
 | Replicas / scale | `deploy.replicas`, `scale:` |
 | Resource limits | `deploy.resources`, `mem_limit`, `cpus`, `cpu_shares`, `cpu_quota`, `pids_limit`, `ulimits`, `blkio_config` |
 | Devices | `devices`, `device_cgroup_rules` |
-| GPU | `deploy.resources.reservations.devices`, `gpus:` — see the note below |
+| GPU | `deploy.resources.reservations.devices`, `gpus:`; see the note below |
 | Security | `cap_add`, `cap_drop`, `security_opt`, `read_only`, `privileged`, `userns_mode` |
 | Namespaces | `pid`, `ipc`, `uts`, `cgroup`, `shm_size` |
 | Metadata | `labels`, `annotations`, `container_name`, `profiles` |
@@ -45,16 +45,16 @@ Every core Compose spec key is supported:
 but only for **NVIDIA** GPUs, and only when the host exposes them through CDI
 (the NVIDIA Container Toolkit must be installed and the CDI spec generated).
 Reservations for other drivers or capabilities are warned about and skipped.
-This is the common case Podman supports natively — but it depends on the host's
+This is the common case Podman supports natively, but it depends on the host's
 GPU driver and CDI setup, not on podup alone.
 
 ### External secrets and configs
 
 A secret or config declared `external: true` is mounted from an existing
-Podman secret rather than from a value in the project tree — the recommended
+Podman secret rather than from a value in the project tree, the recommended
 pattern for production credentials, since the secret material never appears in
-the compose file or its history. (Every other source — inline
-`content:`/`environment:` and `file:` alike — is injected as a Podman-native
+the compose file or its history. (Every other source, inline
+`content:`/`environment:` and `file:` alike, is injected as a Podman-native
 secret too, never a host bind mount, but its value still lives in the compose
 file or next to it.) Create the secret before running, exactly as you would with
 `docker secret`:
@@ -81,7 +81,7 @@ the Podman secret is named differently from the compose reference.
 
 ## Behaves differently under rootless Podman
 
-These are Podman behaviours, not podup limitations — they apply equally to any
+These are Podman behaviours, not podup limitations; they apply equally to any
 Podman-based tool. Each one is something to expect, with the workaround.
 
 ### `network_mode: bridge`
@@ -92,12 +92,12 @@ Podman-based tool. Each one is something to expect, with the workaround.
 | **Workaround** | Remove `network_mode: bridge` and let the container join the project's default network, or declare a shared `networks:` entry the services share. podup emits a warning when it sees `network_mode: bridge`. |
 
 ```yaml
-# before — siblings unreachable under Podman
+# before: siblings unreachable under Podman
 services:
   web:
     network_mode: bridge
 
-# after — services share a network and resolve each other by name
+# after: services share a network and resolve each other by name
 services:
   web:
     networks: [app]
@@ -244,14 +244,14 @@ services:
 ```
 
 Both forms of `depends_on` behave this way, short and long. When **both**
-services carry the profile, podup agrees with docker compose and starts neither
-— the profile is doing its job and nothing contradicts it.
+services carry the profile, podup agrees with docker compose and starts neither:
+the profile is doing its job and nothing contradicts it.
 
 **The Compose Specification does not decide this.** It says only that a service
 with `profiles` "is only started if the profile is activated", and says nothing
 about a dependency whose profile is inactive. Docker's own documentation treats
-it as something the author must fix — the dependency has to be "in the same
-profile, started separately, or not assigned to any profile" — so its rejection
+it as something the author must fix (the dependency has to be "in the same
+profile, started separately, or not assigned to any profile"), so its rejection
 is an implementation choice in a case the specification leaves open, not a rule
 podup is breaking.
 
@@ -259,7 +259,7 @@ podup is breaking.
 is rejected by docker compose, so it is not portable back. If you want the
 dependency to stay out, or you need the file to work under both tools, give the
 dependant the same profile; then neither starts, everywhere. Note also that
-docker compose's message is misleading — `db` is not undefined, it is defined
+docker compose's message is misleading: `db` is not undefined, it is defined
 and filtered.
 
 ## Accepted but has no effect
@@ -267,7 +267,7 @@ and filtered.
 These fields parse cleanly so existing compose files validate, but podup cannot
 translate them on single-host rootless Podman. **podup emits a warning for each
 one it finds**, so nothing is dropped silently. The list below is a set of
-**examples, not exhaustive** — when in doubt, run `podup up` and read the
+**examples, not exhaustive**; when in doubt, run `podup up` and read the
 warnings (see [Seeing the warnings](#seeing-the-warnings)).
 
 ### Swarm / cluster orchestration
@@ -285,12 +285,12 @@ warnings (see [Seeing the warnings](#seeing-the-warnings)).
 ### BuildKit / buildx-only build options
 
 `build.privileged`, `build.ssh`, `build.ulimits`, `build.isolation`,
-`build.entitlements`, `build.provenance`, `build.sbom` — these have no libpod
+`build.entitlements`, `build.provenance`, `build.sbom`: these have no libpod
 build-API equivalent and are ignored.
 
 ### Windows / Hyper-V-only
 
-`cpu_count`, `cpu_percent`, `credential_spec`, `isolation` — no rootless Podman
+`cpu_count`, `cpu_percent`, `credential_spec`, `isolation`: no rootless Podman
 equivalent.
 
 ### Other parsed-but-ignored fields
@@ -311,20 +311,20 @@ equivalent.
 | Feature | Status |
 |---|---|
 | `env_file.format` values other than `dotenv` | A **warning** is emitted (`format is not honored; podup always parses env files as dotenv`); the file is still read as dotenv |
-| `provider:` / model-runner services (`provider`, top-level `models`) | Modeled and parsed, but **not honored** — a not-honored warning is emitted (these are no rootless-Podman equivalent, *not* "unknown key" errors) |
+| `provider:` / model-runner services (`provider`, top-level `models`) | Modeled and parsed, but **not honored**; a not-honored warning is emitted (these are no rootless-Podman equivalent, *not* "unknown key" errors) |
 | Real-hardware smoke tests on macOS | Pending; the code paths exist but are untested on physical Apple hardware. Windows was validated end-to-end on real hardware (Windows 11, Podman 5.8.3), including the interactive `exec`/`run` path added in 3.0.0. |
 
 ## Nothing is dropped silently
 
-podup follows the Compose spec's forward-compatibility rule — an unknown key is
+podup follows the Compose spec's forward-compatibility rule: an unknown key is
 never a hard error, so `x-*` extensions and newer compose fields keep parsing.
 But anything podup cannot translate is **reported**, never silently ignored, so
 a typo or an unmapped feature can't hide. At parse time podup warns about:
 
 - unknown keys at the top level and inside every modeled object (services and
   their `healthcheck`, `deploy`, `develop.watch`; top-level `networks`,
-  `networks.*.ipam`, and `volumes`) — usually a typo such as `enviroment:`;
-- modeled fields it cannot honor on rootless Podman — the
+  `networks.*.ipam`, and `volumes`), usually a typo such as `enviroment:`;
+- modeled fields it cannot honor on rootless Podman, the
   [accepted-but-has-no-effect](#accepted-but-has-no-effect) fields above.
 
 This is what lets a compose file written for a newer Docker or Podman release
@@ -340,15 +340,15 @@ The `podup` CLI prints these warnings automatically. Run with
 events. See the [`RUST_LOG` reference in `commands.md`](commands.md#environment)
 for the full level table.
 
-If you embed podup as a **library**, `parse_file` itself stays quiet — call
+If you embed podup as a **library**, `parse_file` itself stays quiet; call
 `podup::collect_diagnostics` on the parsed file to obtain the same warnings and
 surface them to your users.
 
 ## File references and path confinement
 
 Compose files are **trusted input**, like a Makefile. Path-valued keys that the
-spec resolves relative to the compose file — `extends.file`, `env_file`,
-`label_file`, and `include` — may use `../` to reach files outside the project
+spec resolves relative to the compose file (`extends.file`, `env_file`,
+`label_file`, and `include`) may use `../` to reach files outside the project
 directory, matching docker-compose. Absolute paths are accepted too (an
 absolute `include:` is used as given, as in docker-compose). This is an
 intentional divergence from a fully sandboxed parser: do not feed podup a
@@ -362,7 +362,7 @@ Before running `podup up` on an existing compose file:
 - [ ] Replace `network_mode: bridge` with a shared `networks:` entry if services need to reach each other.
 - [ ] Remove or remap any host ports below 1024 if running fully rootless.
 - [ ] Add `:Z` to bind mounts on SELinux hosts if containers cannot write to them.
-- [ ] Check for `mac_address:` at the service level — move to `networks:` to silence the warning.
-- [ ] Check for Swarm-only `deploy.*` fields — they are harmless but can be cleaned up.
+- [ ] Check for `mac_address:` at the service level; move to `networks:` to silence the warning.
+- [ ] Check for Swarm-only `deploy.*` fields; they are harmless but can be cleaned up.
 - [ ] Verify `env_file` uses dotenv format (key=value lines, `#` comments).
 - [ ] For GPUs, confirm the host has an NVIDIA driver + CDI configured.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -14,7 +14,7 @@ residual risks.
   acquires no capabilities of its own.
 - It drives **rootless Podman** over the libpod REST API on a Unix socket. Any
   privilege a container ends up with is granted by Podman/the kernel, bounded by
-  the launching user's own privileges — a rootless container can never exceed
+  the launching user's own privileges; a rootless container can never exceed
   them. Fields that assume more (`privileged`, `oom_kill_disable`,
   `mem_swappiness`, `cpu_rt_*`) are forwarded but warned about, since they are
   reduced or ineffective rootless.
@@ -26,7 +26,7 @@ residual risks.
 
 | Boundary | Trusted? | Notes |
 |----------|----------|-------|
-| Podman socket (`PODMAN_SOCKET`/`DOCKER_HOST`) | Trusted, local-only | Whoever can reach it controls the engine; this is the primary boundary. Only `unix://`/`npipe://` are accepted — remote schemes are rejected fail-closed. |
+| Podman socket (`PODMAN_SOCKET`/`DOCKER_HOST`) | Trusted, local-only | Whoever can reach it controls the engine; this is the primary boundary. Only `unix://`/`npipe://` are accepted; remote schemes are rejected fail-closed. |
 | Compose file and its referenced files | **Trusted input** | Treated like a Makefile (see below). |
 | Release artifacts (`podup update`, installer) | Untrusted transport | Verified against an embedded Ed25519 key + provenance attestation, fail-closed. |
 | Container filesystem (e.g. `cp` archives) | Untrusted | Tar extraction refuses path-traversal (zip-slip) entries. |
@@ -37,7 +37,7 @@ residual risks.
 - The libpod socket is **strictly local**. Only a `unix://` socket path (or an
   `npipe://` named pipe on Windows) is accepted, whether it comes from
   `--socket`, `PODMAN_SOCKET`, `DOCKER_HOST`, or auto-detection. Remote schemes
-  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed** —
+  (`tcp://`, `ssh://`, `http(s)://`, `fd://`) are **rejected fail-closed**:
   podup never connects to a remote engine, so the socket boundary is always a
   local one.
 
@@ -48,13 +48,13 @@ trusting its author. Path-valued keys the spec resolves relative to the compose
 file (`extends.file`, `env_file`, `label_file`, `include`) may reference paths
 outside the project directory, including `../`. Do **not** run podup on a compose
 file from an untrusted source. `include` accepts an absolute path and uses it as
-given, the same as `extends.file` and `env_file` — there is no containment here
+given, the same as `extends.file` and `env_file`; there is no containment here
 to rely on.
 
 ## Container hardening (compose security keys)
 
 The compose keys that constrain a container are translated onto Podman's
-`SpecGenerator` and take effect on the running container — they are not silently
+`SpecGenerator` and take effect on the running container; they are not silently
 dropped. Everything below remains bounded by the rootless ceiling: a key can
 only tighten, never widen, what the launching user already has.
 
@@ -79,7 +79,7 @@ can be added to a CI gate without altering runtime behaviour.
   cgroup rules (a malformed entry is warned about and skipped, not fatal).
 - CDI devices (Container Device Interface, e.g. `nvidia.com/gpu=all`) requested
   under `devices:` are passed through to Podman, which resolves them by name.
-- Per-mount hardening — `noexec`, `nosuid` and `nodev` — is carried onto a
+- Per-mount hardening (`noexec`, `nosuid` and `nodev`) is carried onto a
   volume's mount options, so a mount can deny binary execution, ignore
   setuid/setgid bits, and block device nodes. The short form spells them as raw
   mount options (`cache:/app/cache:noexec`); the long form takes them as
@@ -90,7 +90,7 @@ can be added to a CI gate without altering runtime behaviour.
 
 - `secrets:`/`configs:` sourced from inline `content:` or `environment:`, and
   from a `file:` path, are created as Podman-native secrets over the libpod API
-  (under a project-scoped name) and injected into the container — podup writes no
+  (under a project-scoped name) and injected into the container; podup writes no
   secret material to a host directory. They are removed again on `podup down`.
 - `external: true` secrets/configs are injected as Podman-native secrets
   (pre-flighted for existence), pointing at a pre-existing `podman secret`.
@@ -100,8 +100,8 @@ can be added to a CI gate without altering runtime behaviour.
   secret stays unreadable to a non-root container user.
 - Because the payload is a copy taken at `up`, editing the host file afterwards
   does not reach an already-running container; recreate it to pick up a new
-  value. (A rotation that replaces the file atomically — write-new-then-rename,
-  which is what careful tools do — was never visible to a running container
+  value. (A rotation that replaces the file atomically, write-new-then-rename,
+  which is what careful tools do, was never visible to a running container
   either, because a file bind mount pins the inode.)
 - Dangerous secret file modes (setuid/setgid/sticky/executable) are rejected.
 - The `config` subcommand redacts inline `content:` secrets before printing.
@@ -123,7 +123,7 @@ individually justified with safety comments, and unit-tested.
 
 - Dependencies are pinned in `Cargo.lock`; `cargo deny` enforces a license
   allowlist and bans yanked crates, and `cargo audit` runs weekly in CI.
-- No third-party CI actions are used — only GitHub-owned (SHA-pinned) actions.
+- No third-party CI actions are used, only GitHub-owned (SHA-pinned) actions.
 - Releases are Ed25519-signed and carry GitHub build-provenance attestations; a
   CycloneDX SBOM and third-party license attribution are published with each
   release. See [self-update.md](self-update.md) for verification steps.
@@ -181,9 +181,9 @@ individually justified with safety comments, and unit-tested.
 
 ## Self-update
 
-The `podup update` mechanism and its release trust chain — the embedded Ed25519
+The `podup update` mechanism and its release trust chain (the embedded Ed25519
 keys, the verify-before-install flow, key rotation, and independent/offline
-verification — are documented in [self-update.md](self-update.md).
+verification) are documented in [self-update.md](self-update.md).
 
 ### Installer error classification
 
@@ -194,7 +194,7 @@ different remedies:
 - **Release-tampering (rc=1 / `Fail`)**: every embedded key rejected the
   signature. Treat as a release-side problem: do not retry, do not bypass.
 - **Configuration problem (rc=3 / `Fail`)**: at least one embedded key was
-  set but could not be decoded into a 32-byte Ed25519 point — a malformed
+  set but could not be decoded into a 32-byte Ed25519 point: a malformed
   `PODUP_RELEASE_PUBKEY_B64` / `PODUP_RELEASE_PUBKEY2_B64` (or, with a
   third rotation slot, `PODUP_RELEASE_PUBKEY3_B64`) override, a stray
   whitespace, a non-base64 character. The release itself may be fine; the
@@ -208,7 +208,7 @@ uses the same exit-code scheme.
 ### Per-asset .sig verification
 
 Every detached signature in a release is verified against the keys
-`install.sh` ships — not just `SHA256SUMS.sig`. Per-binary, per-deb, per-SBOM
+`install.sh` ships, not just `SHA256SUMS.sig`. Per-binary, per-deb, per-SBOM
 and per-installer signatures are checked at release time (CI step "Verify every
 signature against the keys consumers embed") and the installers themselves
 verify the per-asset signature of whatever they fetch. A per-binary
@@ -236,7 +236,7 @@ data into a process or onto disk:
 - **Quadlet values** are filtered through `escape_unit_value` /
   `safe_unit_stem`; the unit filename is checked again by `write_units` so
   a poisoned value cannot break out of the output directory.
-- **Signal names** are resolved to numbers through `resolve_stop_signal` —
+- **Signal names** are resolved to numbers through `resolve_stop_signal`:
   the libpod endpoint is a number, a string returns HTTP 500.
 - **Pull policies** are normalised through `libpod_pull_policy`; an
   unrecognised value is a hard error rather than a silent default, so a
@@ -267,7 +267,7 @@ filters above. They are not flaws; they are the conscious boundary.
   `env_file`, `extends.file`, `include`, `secrets.file`, `build.context`,
   and the bind sources in `volumes:` accept `../` and absolute paths; the
   spec treats them as trusted operator input. The operator who runs
-  `podup` on a compose file is the one choosing to honour those paths —
+  `podup` on a compose file is the one choosing to honour those paths,
   the same posture a `Makefile` has.
 - **Inline-secret `file:` sources have a point-in-time lifetime.** The
   bytes are read at `up`, copied into a Podman-native secret, and persist
@@ -283,7 +283,7 @@ filters above. They are not flaws; they are the conscious boundary.
 
 ## What the live integration lane validates
 
-The `podman-lane` workflow boots Fedora qemu VMs in the runner (nested-virt —
+The `podman-lane` workflow boots Fedora qemu VMs in the runner (nested-virt:
 `ubuntu-24.04` exposes `/dev/kvm`) with full systemd, once per supported
 Podman major (Fedora 44 for Podman 5, rawhide for Podman 6). Each VM runs
 the integration suite as a rootless user. The lane is a **required status
@@ -312,7 +312,7 @@ audit of podup are not decidable from source alone:
 - Whether the rollback attack via CDN re-sign of an older release would
   be accepted by a field binary. The PoC for that is in
   `install.sh:verify_version_self_test` and `install.ps1:Test-StagedVersion`
-  — the staged binary's `--version` is checked against the resolved
+  where the staged binary's `--version` is checked against the resolved
   release tag before the in-place swap, so a CDN that hands back a
   legitimately-signed older release is rejected.
 - Whether the race conditions in `cp_to_container`, `run_attached`, and

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -5,8 +5,8 @@ run resolves the newest release, verifies it, and installs it; `--check` reports
 whether a newer release exists and then stops, downloading nothing and never
 touching the installed binary; `--force` reinstalls the latest release even when
 it is not newer than the current build. The design goal is that **the update
-source is impossible to tamper with**: no attacker — even one who controls the
-network or the download host — can make `podup` install a modified binary.
+source is impossible to tamper with**: no attacker, not even one who controls the
+network or the download host, can make `podup` install a modified binary.
 
 ## Trust anchor
 
@@ -30,7 +30,7 @@ relied on for integrity.
    here without downloading anything.
 2. **Refuse a package-manager-managed binary.** If the running executable is
    owned by a package manager, `podup update` refuses **before downloading
-   anything** and names that manager's own command instead — overwriting the
+   anything** and names that manager's own command instead, because overwriting the
    file in place would desync its records. This applies even with `--force`.
    Three are recognised:
 
@@ -44,7 +44,7 @@ relied on for integrity.
    other two are read off the path: `brew` would cost a process spawn on every
    update to learn a prefix already visible in the path, and Scoop is a
    PowerShell function rather than an executable, so there is nothing to spawn.
-   Both path checks are shaped to fail one way only — a layout that merely looks
+   Both path checks are shaped to fail one way only: a layout that merely looks
    like theirs refuses an update that would have worked, which is visible and
    recoverable, rather than missing one and rewriting a file its manager still
    believes it knows.
@@ -57,8 +57,8 @@ relied on for integrity.
    half the story: unattended-upgrades installs only from origins its own
    configuration permits, and the rule permitting Glyndor is shipped by
    `glyndor-archive-keyring`. A machine with podup and without that package is
-   never upgraded automatically, and — because the rule that would have fixed it
-   travels in the update it never receives — never finds out. So the refusal
+   never upgraded automatically and, because the rule that would have fixed it
+   travels in the update it never receives, never finds out. So the refusal
    reads apt's merged configuration once, at that moment only, and appends the
    reason and the remedy when nothing will act.
 
@@ -70,7 +70,7 @@ relied on for integrity.
    all, nothing is said: that is a machine the question does not apply to rather
    than a broken one.
 3. Fetch `SHA256SUMS` and `SHA256SUMS.sig` and **verify the Ed25519 signature**
-   of `SHA256SUMS` against the embedded public key — *before* the binary is
+   of `SHA256SUMS` against the embedded public key, *before* the binary is
    downloaded, so a tampered or unsigned release is rejected without first
    buffering a large attacker-controlled payload. A missing/placeholder key,
    malformed signature, or bad signature aborts here. The manifest and signature
@@ -89,7 +89,7 @@ from a generic `1`) and leaves the installed binary untouched.
 ## install.sh
 
 The one-line installer applies the same fail-closed policy. With a release
-public key configured (the default — the key ships embedded in the script), the
+public key configured (the default, since the key ships embedded in the script), the
 **Ed25519 signature check is mandatory**: it requires `python3` with the
 `cryptography` package and refuses to install if the check cannot run, so the
 pinned key is never silently bypassed. The GitHub build-provenance attestation
@@ -101,14 +101,14 @@ Ed25519 signature before installing it as root.
 
 ### Version self-test (rollback gate)
 
-The signed manifest binds the asset bytes but **not** the release tag — a CDN
+The signed manifest binds the asset bytes but **not** the release tag. A CDN
 or transparent proxy able to spoof release metadata could replay an older,
 *legitimately* signed binary and matching `SHA256SUMS`, and both would still
 verify. Both `install.sh` and `install.ps1` therefore run the staged binary's
 `--version` and pin it to the resolved tag (resolved via the GitHub releases
 API when `PODUP_VERSION=latest`, or used as-is when an explicit `vX.Y.Z` is
 given). The comparison is **strict equality with one optional `v` prefix**, so
-a `3.7.0-dev` report does not slip past a `3.7.0` check — that is the rollback
+a `3.7.0-dev` report does not slip past a `3.7.0` check: that is the rollback
 case this gate exists to reject. A mismatch removes the staged file and aborts
 the install with exit code `1`; the operator sees:
 
@@ -123,20 +123,20 @@ and a failed self-test there rolls back to the previous binary.
 
 `install.sh` and `install.ps1` are themselves listed in the signed `SHA256SUMS`
 manifest and carry their own `install.sh.sig` / `install.ps1.sig`, so a user
-pinning a version can verify the script before piping it to a shell — the script
+pinning a version can verify the script before piping it to a shell, so the script
 is no longer the one unverifiable link in the chain.
 
 The embedded Python in both installers classifies a verification failure into
 two distinct exit codes, so the calling shell can report the right problem to
 the user:
 
-- **rc=1 (signature mismatch, `Fail`)** — every embedded key rejected the
+- **rc=1 (signature mismatch, `Fail`)**: every embedded key rejected the
   signature. Treat as a release-tampering problem; do not retry.
-- **rc=3 (key malformed, `Fail`)** — at least one embedded key was set but
+- **rc=3 (key malformed, `Fail`)**: at least one embedded key was set but
   could not be decoded into a 32-byte Ed25519 point. This is a user-side
   configuration problem (a bad `PODUP_RELEASE_PUBKEY_B64` /
   `PODUP_RELEASE_PUBKEY2_B64` override, a stray whitespace, a non-base64
-  character), not a release-tampering problem — the release itself may be
+  character), not a release-tampering problem; the release itself may be
   fine. The CLI distinguishes them so a fork maintainer debugging a
   configuration slip isn't told to chase a phantom signature mismatch.
   `install.sh` maps rc=3 to its own `return 3`; the bash and PowerShell
@@ -155,9 +155,9 @@ adding a `PODUP_RELEASE_PUBKEY3_B64` to `install.sh` is a one-line change when
 a third key is needed. Slot 0 holds the active key; later slots are the empty
 rotation slots, populated only during a rotation. Embedded in three places:
 
-- `internal/update/verify.rs` — `RELEASE_PUBKEYS[0]` and `[1]` (raw 32 bytes).
-- `install.sh` — `PODUP_RELEASE_PUBKEY_B64` and `PODUP_RELEASE_PUBKEY2_B64`.
-- `install.ps1` — `PubKeyB64` and `PubKey2B64`.
+- `internal/update/verify.rs`: `RELEASE_PUBKEYS[0]` and `[1]` (raw 32 bytes).
+- `install.sh`: `PODUP_RELEASE_PUBKEY_B64` and `PODUP_RELEASE_PUBKEY2_B64`.
+- `install.ps1`: `PubKeyB64` and `PubKey2B64`.
 
 A signature is trusted if it validates under **any** non-empty key. If every key
 is zeroed, both the binary and the installer fail closed and install nothing.
@@ -165,7 +165,7 @@ is zeroed, both the binary and the installer fail closed and install nothing.
 ### Key rotation
 
 Because each binary accepts up to two keys, the signing key can be rotated
-**without stranding installed binaries** — provided the outgoing private key is
+**without stranding installed binaries**, provided the outgoing private key is
 still available to sign the migration release. A two-release transition first
 ships the new key alongside the old (signed by the old key), so binaries already
 in the field accept the next release and gain the new key; a later release then
@@ -202,27 +202,27 @@ PY
 sha256sum --check --ignore-missing SHA256SUMS
 ```
 
-The release also ships a CycloneDX SBOM **per artifact** — one for each binary
+The release also ships a CycloneDX SBOM **per artifact**: one for each binary
 (e.g. `podup-linux-x86_64.cdx.json`) and each Debian package
 (`podup_<version>_amd64.deb.cdx.json`), listing only that target's actual
-dependencies rather than a union across every platform — plus a third-party
+dependencies rather than a union across every platform, plus a third-party
 license attribution (`NOTICES.html`). Each carries a detached `.sig` that
 verifies against the same key.
 
 ## Air-gapped installation
 
-Networks that block outbound GitHub have no opt-out from verification — they
+Networks that block outbound GitHub have no opt-out from verification; they
 carry the artifacts across the boundary instead:
 
 1. On a connected host, download the platform binary, `SHA256SUMS`,
    `SHA256SUMS.sig` (and optionally the SBOM/NOTICES and their `.sig` files).
 2. Transfer them to the isolated host on approved media.
 3. Verify the Ed25519 signature and checksum there with the offline snippet
-   above — the embedded key is the trust anchor, so no network is needed.
+   above: the embedded key is the trust anchor, so no network is needed.
 4. Install the verified binary manually (`install -m 0755 podup-linux-x86_64
    /usr/local/bin/podup`).
 
 For building from source in an air-gapped environment, vendor the crates on a
 connected host (`cargo vendor vendor`), include the `vendor/` tree in the source
-tarball, and build the Debian package offline — `debian/rules` automatically
+tarball, and build the Debian package offline; `debian/rules` automatically
 switches Cargo to `--frozen --offline` when `vendor/` is present.

--- a/fuzz/fuzz_targets/extract_tar.rs
+++ b/fuzz/fuzz_targets/extract_tar.rs
@@ -44,6 +44,6 @@ fuzz_target!(|data: &[u8]| {
 	};
 	// `extract_tar_guarded` returns `Result<()>`. Any `Err` is the documented
 	// outcome for a hostile header (zip-slip, unreadable mode, …) and not a
-	// finding — only a panic (caught by libFuzzer as a crash) would be.
+	// finding; only a panic (caught by libFuzzer as a crash) would be.
 	let _ = podup::fuzz_api::extract_tar_guarded(data, &scratch.path);
 });

--- a/install.sh
+++ b/install.sh
@@ -391,7 +391,7 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 	# /usr/local/bin during the window before the rename. The target's mode
 	# is then applied explicitly, masked with ~0o777 so a setuid/setgid/
 	# sticky bit on the target (planted or inherited) cannot ride onto the
-	# freshly installed binary — the same discipline the Rust updater
+	# freshly installed binary, the same discipline the Rust updater
 	# follows at internal/update/install.rs:237-298. Mirrors what the
 	# Rust `install_at` does, with `install` swapped for the equivalent
 	# `cp + chmod` because `-m` only sets the mode of the *new* file and
@@ -423,7 +423,7 @@ or python3 with the 'cryptography' package, or set PODUP_RELEASE_PUBKEY_B64, the
 	# are never world-readable in a shared directory (e.g. /usr/local/bin)
 	# during the window before the chmod applies the target's mode. The
 	# chmod then widens the file to the target's ordinary permission bits,
-	# with the special bits stripped — same discipline the Rust updater
+	# with the special bits stripped, the same discipline the Rust updater
 	# follows at internal/update/install.rs:237-298.
 	local copy_cmd=(install -m 0600 "${TMP_DIR}/${ARTIFACT}" "$staged")
 	local perms_cmd=(chmod "$target_mode" "$staged")

--- a/internal/autostart/mod.rs
+++ b/internal/autostart/mod.rs
@@ -1,7 +1,7 @@
 //! `podup autostart` service mode: a single rootless `systemctl --user` unit that
 //! brings a compose stack up at boot.
 //!
-//! Everything here is user-scope only — the unit lives under
+//! Everything here is user-scope only: the unit lives under
 //! `${XDG_CONFIG_HOME:-~/.config}/systemd/user/` and every action goes through
 //! `systemctl --user` / `loginctl`. No root, no `sudo`, nothing under `/etc` or
 //! the system systemd. External-command calls go through the `SystemCtl` seam so
@@ -62,7 +62,7 @@ impl SystemCtl for RealSystemCtl {
 /// default `DefaultTimeoutStopUSec` is 90s. `podup stop` honours each
 /// container's own grace period, so a stack whose slowest container needs more
 /// than that stops cleanly when a human runs it and gets killed mid-stop at
-/// reboot — the difference only shows up during an unattended shutdown, which
+/// reboot; the difference only shows up during an unattended shutdown, which
 /// is the worst version of it.
 ///
 /// `None` when no service sets one, or when none parses, so the unit simply
@@ -79,7 +79,7 @@ pub fn max_stop_grace_secs(file: &crate::compose::types::ComposeFile) -> Option<
 
 /// Options for [`install`].
 ///
-/// `#[non_exhaustive]`: see [`ServiceUnitOpts`] — same reason, same construction
+/// `#[non_exhaustive]`: see [`ServiceUnitOpts`], same reason, same construction
 /// pattern.
 #[non_exhaustive]
 #[derive(Default)]
@@ -186,7 +186,7 @@ fn quadlet_units_present(project: &str) -> Vec<PathBuf> {
 	found
 }
 
-/// Whether linger is enabled for `user` (so the user manager — and the stack —
+/// Whether linger is enabled for `user` (so the user manager, and the stack,
 /// survives logout and starts at boot). Parses `loginctl show-user <user>
 /// --value --property=Linger`, treating any error/unexpected output as "off".
 fn linger_enabled<S: SystemCtl>(sc: &S, user: &str) -> bool {
@@ -427,13 +427,13 @@ fn place_update_units<S: SystemCtl>(
 	Ok(())
 }
 
-/// Whether systemd knows anything about `unit` — loaded, enabled, running, or
+/// Whether systemd knows anything about `unit`: loaded, enabled, running, or
 /// merely present as a fragment.
 ///
 /// `systemctl is-active` exits **4** for a unit it has never heard of and
 /// something else for every other state (0 active, 3 inactive/failed/activating).
 /// That numeric 4 is the only reliable "there is nothing here" signal: the
-/// message text is localised, and the *fragment file* is not a proxy for it —
+/// message text is localised, and the *fragment file* is not a proxy for it:
 /// measured, a unit whose file is deleted out of band stays loaded, enabled and
 /// running, and `disable --now` still exits 0, removes its `.wants/` symlink and
 /// stops it. Gating on the file would delete the only way out of that state.
@@ -450,7 +450,7 @@ fn unit_is_known<S: SystemCtl>(sc: &S, unit: &str) -> bool {
 /// Uninstall the service-mode autostart unit: disable + stop it, remove the unit
 /// file, and reload the user manager.
 ///
-/// Idempotent — uninstalling when nothing is installed is a quiet no-op — but a
+/// Idempotent: uninstalling when nothing is installed is a quiet no-op, but a
 /// `disable` that genuinely fails is reported rather than swallowed, so the
 /// command cannot claim success while the service is still enabled and running.
 ///
@@ -467,7 +467,7 @@ pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	// there. `disable --now` is idempotent across every state it can be in
 	// (enabled, never enabled, running, stopped, fragment deleted out of band),
 	// so the only case worth skipping is the one where systemd has never heard
-	// of it — which is exactly what `unit_is_known` answers.
+	// of it, which is exactly what `unit_is_known` answers.
 	if unit_is_known(sc, &unit_name) {
 		checked(
 			sc.systemctl(&["disable", "--now", &unit_name]),
@@ -523,7 +523,7 @@ pub fn uninstall<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 }
 
 /// Which autostart mode, if any, is installed for a project. Service and quadlet
-/// mode cannot coexist — each install refuses the other — so at most one is present.
+/// mode cannot coexist (each install refuses the other) so at most one is present.
 /// `uninstall` uses this to remove whichever is there without the caller naming a
 /// mode (and mistakenly no-op'ing against the wrong one).
 pub enum InstalledMode {
@@ -531,7 +531,7 @@ pub enum InstalledMode {
 	Service,
 	/// Quadlet `<project>-*.container` units are present.
 	Quadlet,
-	/// Neither — nothing is installed.
+	/// Neither: nothing is installed.
 	None,
 }
 
@@ -672,7 +672,7 @@ pub fn collect_status<S: SystemCtl>(sc: &S, project: &str) -> StatusReport {
 pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	let r = collect_status(sc, project);
 	// Every line here is a yes/no an operator is scanning for, and the whole
-	// screen was one colour — so "is it actually running?" meant reading six
+	// screen was one colour, so "is it actually running?" meant reading six
 	// labels to find the one word that answers it. The label is scaffolding
 	// (dimmed); the value carries the meaning (tinted by what it says).
 	let row = |label: &str, value: &str| {
@@ -685,7 +685,7 @@ pub fn status<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<()> {
 	}
 	// With no unit file on disk, systemd's answers to both questions are the same
 	// negative the `installed: no` line above already gave, and neither is a
-	// failure — but `is-enabled` returns the word `not-found`, which the status
+	// failure, but `is-enabled` returns the word `not-found`, which the status
 	// vocabulary reads as an error and paints red. So an uninstalled project
 	// reported one dim `no` and one red `not-found` about the same unit.
 	//

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -6,7 +6,7 @@
 //! `generate quadlet` emits, so systemd owns boot, restart and dependency
 //! ordering directly. The generated `.container` units already carry
 //! `[Install] WantedBy=default.target`, so a `daemon-reload` wires them into boot
-//! on its own — this module writes them, reloads, and starts them now; it never
+//! on its own, so this module writes them, reloads, and starts them now; it never
 //! `enable`s a generated unit (systemd does not enable generator output).
 
 use std::path::{Path, PathBuf};
@@ -16,7 +16,7 @@ use crate::{quadlet, ComposeError};
 
 use super::{checked, config_home, emit_guards, unit_path, SystemCtl};
 
-/// `${XDG_CONFIG_HOME:-~/.config}/containers/systemd/` — where Quadlet reads a
+/// `${XDG_CONFIG_HOME:-~/.config}/containers/systemd/`, where Quadlet reads a
 /// user's units from. The same directory `generate quadlet` documents.
 pub fn quadlet_dir() -> PathBuf {
 	config_home().join("containers").join("systemd")
@@ -37,12 +37,12 @@ fn container_services(units: &[quadlet::QuadletUnit]) -> Vec<String> {
 ///
 /// This deliberately does NOT read the `Label=podup.project=<project>` line
 /// every unit builder in `crate::quadlet` also stamps (that label stays, but
-/// only for its original purpose — Podman uses `podup.project` for
+/// only for its original purpose; Podman uses `podup.project` for
 /// container/secret scoping at runtime). A compose service's user-supplied
 /// `labels:` renders into the very same `[Section]`, in the very same
 /// `Key=Value` shape, so a service declaring `labels: {podup.project:
 /// other}` produces a forged `Label=podup.project=other` line that is
-/// textually indistinguishable from the real one — and would be the FIRST
+/// textually indistinguishable from the real one, and would be the FIRST
 /// such line if it precedes the trusted stamp, defeating a scan that takes
 /// the first match. The `# podup-owner: <project>` marker every unit builder
 /// emits as its literal first line cannot be forged the same way: systemd
@@ -62,15 +62,15 @@ fn unit_owner(path: &Path) -> Option<String> {
 /// A file name starting with `<project>-` is only a candidate: project names
 /// may themselves contain `-`, so `app-extra-web.container` also starts with
 /// `app-`. Matching on that prefix alone (the old behaviour) meant
-/// `uninstall -p app` matched — and `uninstall_quadlet` then stopped and
-/// deleted — the sibling project `app-extra`'s units. Each candidate is
+/// `uninstall -p app` matched (and `uninstall_quadlet` then stopped and
+/// deleted) the sibling project `app-extra`'s units. Each candidate is
 /// therefore opened and kept only when its `# podup-owner:` marker equals
 /// `project` EXACTLY (see `unit_owner` above); the marker is exact by
 /// construction and, unlike the `Label=podup.project=` line, cannot be
 /// pre-empted by a forged line from the compose file's own `labels:`.
 ///
 /// A candidate with no marker at all (installed before this ownership check
-/// existed) cannot be proven to belong to `project` — treating "no marker" as
+/// existed) cannot be proven to belong to `project`: treating "no marker" as
 /// "assume it's ours" would just reopen the same hole for those legacy
 /// installs. So it is left in place, not deleted, and reported via
 /// `tracing::warn!` so the user can re-install (which re-marks it) or remove
@@ -98,7 +98,7 @@ fn installed_units(project: &str) -> Vec<PathBuf> {
 					tracing::warn!(
 						"quadlet unit {} has no podup-owner ownership marker and cannot be \
 						 proven to belong to '{project}'; skipping it rather than risking a \
-						 sibling project's unit — re-run `podup autostart install --mode quadlet` \
+						 sibling project's unit; re-run `podup autostart install --mode quadlet` \
 						 to re-mark it, or remove it by hand if it is stale",
 						path.display()
 					);
@@ -199,7 +199,7 @@ pub fn install_quadlet<S: SystemCtl>(
 }
 
 /// Uninstall quadlet-mode autostart: stop this project's container services, remove
-/// its `<project>-*` unit files, and reload the user manager. Idempotent — a
+/// its `<project>-*` unit files, and reload the user manager. Idempotent: a
 /// service that was never started, or a file already gone, is not an error.
 ///
 /// A service that *is* running and refuses to stop is a different matter: the
@@ -217,14 +217,14 @@ pub fn uninstall_quadlet<S: SystemCtl>(sc: &S, project: &str) -> crate::Result<(
 				// Stop unconditionally. There is no state here worth probing for
 				// first: measured against real systemd, `stop` on a unit whose
 				// fragment is on disk exits 0 whether it is running, inactive, or
-				// was never started at all — and every unit in this loop has its
+				// was never started at all, and every unit in this loop has its
 				// fragment on disk, because that is what `installed_units` found.
 				// (`stop` only fails with "not loaded" when no fragment exists,
 				// which cannot happen here.)
 				//
 				// Gating on `is-active` would be worse than redundant: a service
 				// that is still coming up reports `activating`, which `is-active`
-				// calls a failure — so a stack caught mid-start, or one sitting in
+				// calls a failure, so a stack caught mid-start, or one sitting in
 				// `activating (auto-restart)`, would be skipped and left running
 				// while uninstall deleted its units and reported success.
 				if let Err(e) = checked(sc.systemctl(&["stop", &service]), "stop") {
@@ -266,7 +266,7 @@ pub fn rebuild_quadlet<S: SystemCtl>(
 		.collect();
 	if builds.is_empty() {
 		return Err(ComposeError::Autostart(format!(
-			"no quadlet build units for '{project}' — nothing to rebuild. Only a service \
+			"no quadlet build units for '{project}'; nothing to rebuild. Only a service \
 			 with a compose `build:` produces a `.build` unit, and quadlet-mode autostart \
 			 must be installed first (`podup autostart install --mode quadlet`)."
 		)));

--- a/internal/autostart/quadlet/tests.rs
+++ b/internal/autostart/quadlet/tests.rs
@@ -214,7 +214,7 @@ fn uninstall_stops_removes_and_reloads() {
 /// An earlier version probed `is-active` first and skipped the stop when it
 /// failed. Measured against real systemd, that is wrong twice over: `stop` on a
 /// unit whose fragment is on disk exits 0 in *every* state (running, inactive,
-/// never started), so the probe bought nothing — and a service still coming up
+/// never started), so the probe bought nothing, and a service still coming up
 /// reports `activating`, which `is-active` calls a failure, so a stack caught
 /// mid-start would have been skipped and left running while its units were
 /// deleted.
@@ -250,7 +250,7 @@ fn uninstall_stops_unconditionally_without_probing_is_active() {
 }
 
 /// #1080: a running service that refuses to stop was swallowed by `let _ =`, so
-/// uninstall exited 0 with the container still up. It must now report — while
+/// uninstall exited 0 with the container still up. It must now report, while
 /// still removing the unit files and reloading, so the uninstall is not left
 /// half-done.
 #[test]
@@ -334,7 +334,7 @@ fn uninstall_scoped_by_ownership_label_leaves_sibling_project_untouched() {
 // `app-extra` declaring `labels: {podup.project: app}` therefore produces a
 // unit whose FIRST `Label=podup.project=` line reads `app` (forged) and
 // whose SECOND reads `app-extra` (the real stamp). A scope check that reads
-// the first `Label=podup.project=` match — the old behaviour — resolves this
+// the first `Label=podup.project=` match (the old behaviour) resolves this
 // unit's owner as `app`, so `uninstall -p app` deletes a sibling project's
 // unit again, through a different door than the filename-prefix bug above.
 // The `# podup-owner:` marker closes this because compose `labels:` can
@@ -355,7 +355,7 @@ fn uninstall_ignores_forged_project_label_from_sibling_compose_file() {
 		)
 		.unwrap();
 		// `app-extra`'s own service labels forge a `Label=podup.project=app`
-		// line ahead of its real `Label=podup.project=app-extra` stamp — the
+		// line ahead of its real `Label=podup.project=app-extra` stamp, the
 		// exact shape a hostile or careless compose file can produce.
 		let forged = "services:\n  web:\n    image: nginx\n    labels:\n      podup.project: app\n";
 		install_quadlet(

--- a/internal/autostart/service.rs
+++ b/internal/autostart/service.rs
@@ -32,7 +32,7 @@ pub struct ServiceUnitOpts {
 	/// Longest `stop_grace_period` across the project's services, in seconds.
 	///
 	/// systemd bounds the whole `ExecStop` independently of what podup does
-	/// inside it, and its default is 90s — so a stack whose slowest container
+	/// inside it, and its default is 90s, so a stack whose slowest container
 	/// needs longer gets killed mid-stop at reboot, while a manual `podup stop`
 	/// honours it. `None` leaves `TimeoutStopSec=` off, which is right when no
 	/// service asks for anything unusual.
@@ -104,7 +104,7 @@ fn is_bare_safe(token: &str) -> bool {
 /// during specifier expansion, a pass that happens before the line is split
 /// into arguments and runs whether or not the token ends up quoted. `%` is not
 /// in `is_bare_safe`'s allowed set, so a token containing it already takes the
-/// quoted path — but doubling it up front (rather than only inside the quoted
+/// quoted path, but doubling it up front (rather than only inside the quoted
 /// branch) means the escape holds even if that allowed set ever changes, and a
 /// bare-looking token like `50%off` still comes out as `50%%off`.
 pub(super) fn quote_arg_for_exec(token: &str) -> String {
@@ -292,7 +292,7 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// deploy time, where someone is watching.
 	let start = exec_line(opts, &["up", "-d"]);
 	// `stop`, not `down`: `down` REMOVES the containers, so a clean shutdown
-	// would delete the stack and every boot would recreate it from scratch —
+	// would delete the stack and every boot would recreate it from scratch,
 	// losing container identity and logs, and dragging the whole compose
 	// front-end (.env, interpolation, the parse) onto the boot path. `stop`
 	// leaves them on disk, which is exactly what ExecStart expects to find, and
@@ -322,9 +322,9 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// with `Result=success` and nothing in the journal, which is the behaviour
 	// those versions already had.
 	//
-	// `WorkingDirectory=` takes the rest of its line literally — unlike an
+	// `WorkingDirectory=` takes the rest of its line literally: unlike an
 	// exec-line token, it understands none of the C-style backslash escapes
-	// `quote_arg` uses — but `%%` is not one of those escapes: it is systemd's
+	// `quote_arg` uses. But `%%` is not one of those escapes: it is systemd's
 	// specifier-level escape, resolved during the same specifier-expansion pass
 	// that runs over every unit-file value before the value is otherwise
 	// interpreted. That pass does not care whether the value is a directive
@@ -336,7 +336,7 @@ pub fn render_service_unit(opts: &ServiceUnitOpts) -> String {
 	// above: systemd's specifier expansion runs over every unit-file value, not
 	// only the ones this module treats specially. `opts.project` is gated
 	// upstream by `is_safe_project_name` (which forbids `%`), but this module
-	// must not lean on that external guarantee for its own %-invariant — every
+	// must not lean on that external guarantee for its own %-invariant: every
 	// other interpolated value here is escaped regardless of what validates it
 	// elsewhere, so the project name is too.
 	let project = opts.project.replace('%', "%%");

--- a/internal/autostart/service_tests.rs
+++ b/internal/autostart/service_tests.rs
@@ -56,7 +56,7 @@ fn includes_profiles_and_env_files() {
 #[test]
 fn boot_neither_builds_nor_destroys() {
 	// The contract, pinned. `--build` on ExecStart puts an image build on the
-	// boot path of an unattended machine — it needs the network and a briefly
+	// boot path of an unattended machine: it needs the network and a briefly
 	// unreachable registry leaves the stack down. `down` on ExecStop removes
 	// the containers, so a clean shutdown would delete the stack and every
 	// boot would recreate it. Both shipped in 1.9.0; neither may come back
@@ -177,7 +177,7 @@ fn quote_arg_escapes_quotes_and_backslashes() {
 
 #[test]
 fn quote_arg_doubles_percent_even_in_a_bare_looking_token() {
-	// `50%off` has no space/quote/control byte — the only reason it must be
+	// `50%off` has no space/quote/control byte; the only reason it must be
 	// quoted at all is the `%`, and the `%` itself must be doubled so systemd's
 	// specifier expansion collapses it back to one literal `%` instead of
 	// trying to expand `%o` as a specifier.
@@ -225,7 +225,7 @@ fn render_service_unit_escapes_percent_in_project_description() {
 	// `Description=` interpolates `opts.project` directly; a literal `%` in
 	// it must be doubled exactly like every other in-unit value, so systemd's
 	// specifier expansion does not treat e.g. `%h` as a specifier. This holds
-	// regardless of the external `is_safe_project_name` gate — the module's
+	// regardless of the external `is_safe_project_name` gate: the module's
 	// own %-invariant should not depend on it.
 	let mut o = opts_single();
 	o.project = "50%h".to_string();
@@ -250,7 +250,7 @@ fn validate_accepts_percent_in_paths() {
 /// #1093: systemd bounds `ExecStop` independently of what podup does inside
 /// it, at a 90s default. A stack whose slowest container needs longer stops
 /// cleanly when a human runs `podup stop` and gets killed mid-stop at
-/// reboot — the difference only appears during an unattended shutdown,
+/// reboot; the difference only appears during an unattended shutdown,
 /// which is the worst version of it.
 #[test]
 fn render_service_unit_bounds_stop_above_the_longest_grace_period() {

--- a/internal/autostart/tests.rs
+++ b/internal/autostart/tests.rs
@@ -230,7 +230,7 @@ fn uninstall_reports_a_failed_disable() {
 }
 
 /// Uninstalling when systemd has never heard of the unit stays a silent
-/// no-op. `is-active` exit 4 ("no such unit") is the signal — not the unit
+/// no-op. `is-active` exit 4 ("no such unit") is the signal, not the unit
 /// file, which is a poor proxy: a fragment deleted out of band leaves the
 /// unit loaded, enabled and running, and only `disable --now` clears it.
 #[test]
@@ -259,7 +259,7 @@ fn uninstall_disables_a_known_unit_whose_file_is_already_gone() {
 	with_env(|root| {
 		let path = root.join("systemd/user/podup-app.service");
 		assert!(!path.exists());
-		// Default `is_active_code` is 0 — systemd knows the unit.
+		// Default `is_active_code` is 0: systemd knows the unit.
 		let sc = FakeCtl::new();
 		uninstall(&sc, "app").expect("uninstall must still succeed");
 		let calls = sc.systemctl_log();

--- a/internal/autostart_cmd.rs
+++ b/internal/autostart_cmd.rs
@@ -86,7 +86,7 @@ pub(crate) async fn dispatch(
 			let working_dir = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
 			// The longest stop_grace_period in the project. systemd bounds the whole
 			// ExecStop independently of what podup does inside it, and its default
-			// is 90s — so without this a stack whose slowest container needs longer
+			// is 90s, so without this a stack whose slowest container needs longer
 			// is killed mid-stop at reboot, while a manual `podup stop` honours it.
 			let max_grace = podup::autostart::max_stop_grace_secs(file);
 			let unit = podup::autostart::ServiceUnitOpts::new(exe, abs_files, project, working_dir)
@@ -128,7 +128,7 @@ pub(crate) async fn dispatch(
 			// The one check that needs a live Podman. Start mode restores what
 			// the store holds and deliberately does not reconcile, so a
 			// container that is absent, or present but no longer matching the
-			// file, must be refused HERE — at install, where a human is
+			// file, must be refused HERE, at install, where a human is
 			// watching. At boot there is no podup to notice: that is the cost of
 			// keeping it off the boot path, not an oversight.
 			//
@@ -153,11 +153,11 @@ pub(crate) async fn dispatch(
 			)
 		}
 		AutostartCommands::Uninstall { purge } => {
-			// Remove whichever mode is installed — the two never coexist, and asking
+			// Remove whichever mode is installed; the two never coexist, and asking
 			// the user to name the mode only risks a no-op against the wrong one.
 			// Hold the uninstall's outcome rather than `?`-ing it here. By the time
 			// it can fail, the unit files are already gone and `installed_mode`
-			// would no longer recognise the project — so short-circuiting would
+			// would no longer recognise the project, so short-circuiting would
 			// skip `--purge` exactly when the stack is still up and most needs
 			// tearing down, leaving its named volumes behind and the state
 			// unrecognisable. Purge first, report the failure after.

--- a/internal/cli/commands.rs
+++ b/internal/cli/commands.rs
@@ -301,7 +301,7 @@ pub(crate) enum Commands {
 		publish: Vec<String>,
 		/// Keep the container's STDIN open (sets `stdin_open`). Whether a live
 		/// terminal is attached is decided by stdin and stdout both being
-		/// terminals, and by `-T` — not by this flag.
+		/// terminals, and by `-T`, not by this flag.
 		#[arg(short, long)]
 		interactive: bool,
 		/// Disable pseudo-TTY allocation. `run` allocates one when stdin and
@@ -420,7 +420,7 @@ pub(crate) enum Commands {
 		///
 		/// Takes an optional value so both spellings parse. Other Compose tools
 		/// declare it as a bare flag, and demanding a value turned a script
-		/// copied from one of them into a usage error — inside the very set of
+		/// copied from one of them into a usage error, inside the very set of
 		/// flags whose purpose is that such a script runs unchanged.
 		#[arg(
 			long,

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -21,19 +21,19 @@ pub(crate) use types::{
 /// (bold, underline, dim) and no explicit foreground colour, which means
 /// nothing elsewhere.
 ///
-/// No slot sets an explicit `AnsiColor`, `error`/`invalid` excepted — those are
+/// No slot sets an explicit `AnsiColor`, `error`/`invalid` excepted: those are
 /// status colours (red), not identity, and stay. An explicit `White` was tried
 /// first, on the reasoning that *some* colour should mark headings; measured
 /// against the same reference palette this branch's tests pin
-/// (`ui::palette_tests`), it read 1.82:1 on a white terminal background — worse
-/// than the green/cyan it replaced — and bold commonly promotes `White` to the
+/// (`ui::palette_tests`), it read 1.82:1 on a white terminal background, worse
+/// than the green/cyan it replaced, and bold commonly promotes `White` to the
 /// terminal's bright-white ANSI code, which measured 1.00:1 on white, i.e.
 /// invisible. Leaving the foreground unset uses the terminal's own default
 /// text colour instead, which is readable on both themes by construction: it
 /// is what the terminal owner already chose for their body text.
 ///
 /// All eight slots are still explicitly set, even where that means an empty
-/// style — clap's own `plain()` already leaves `error:` unstyled while podup
+/// style: clap's own `plain()` already leaves `error:` unstyled while podup
 /// printed it bold red, so nothing here may silently fall back to a starting
 /// point that disagreed with the rest of the binary.
 const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
@@ -49,7 +49,7 @@ const HELP_STYLES: clap::builder::Styles = clap::builder::Styles::plain()
 /// Read `--ansi` straight off argv, before clap parses anything.
 ///
 /// clap renders `--help` inside the parse call, and the colour choice was only
-/// applied after it returned — so `podup --ansi never --help` came out coloured
+/// applied after it returned, so `podup --ansi never --help` came out coloured
 /// while `NO_COLOR=1 podup --help` did not. One flag, two answers.
 ///
 /// Accepts both spellings clap does (`--ansi never`, `--ansi=never`) and is
@@ -92,7 +92,7 @@ pub(crate) fn ansi_from_argv<I: Iterator<Item = String>>(args: I) -> Option<Ansi
 #[command(
 	name = "podup",
 	// clap renders `--version` as `{name} {version}`, so the derived default gave
-	// `podup 3.3.0` while the `version` subcommand gave `podup version v3.3.0` —
+	// `podup 3.3.0` while the `version` subcommand gave `podup version v3.3.0`,
 	// two answers to the same question, and neither caller can tell which one it
 	// is going to get. Measured on docker-compose v5.1.3: `version` and
 	// `--version` are byte-identical (`Docker Compose version v5.1.3`) and only
@@ -165,7 +165,7 @@ pub(crate) struct Cli {
 	/// emits during `up`/`create`/`run`/`exec` (e.g. `network_mode: host`,
 	/// `privileged: true`, `pid: host`, `container:<id>` namespace sharing).
 	/// Operators who wrote the compose file deliberately use this to silence
-	/// the per-run warning. `podup config` still surfaces the active modes —
+	/// the per-run warning. `podup config` still surfaces the active modes, since
 	/// that command is the "show me what will happen" path, where the
 	/// warning is the whole point.
 	// `global` so it works on every subcommand that may build a container spec

--- a/internal/cli/mod_tests.rs
+++ b/internal/cli/mod_tests.rs
@@ -9,7 +9,7 @@ fn argv(args: &[&str]) -> impl Iterator<Item = String> + use<> {
 
 /// clap renders help before the parsed `--ansi` is applied, so the flag has
 /// to be read straight off argv or `podup --ansi never --help` comes out
-/// coloured — which it did, while `NO_COLOR=1 podup --help` did not.
+/// coloured, which it did, while `NO_COLOR=1 podup --help` did not.
 #[test]
 fn ansi_is_found_before_the_subcommand() {
 	assert_eq!(

--- a/internal/cli/parse.rs
+++ b/internal/cli/parse.rs
@@ -49,7 +49,7 @@ pub(crate) fn parse_pull_policy(value: &str) -> Result<String, String> {
 }
 
 /// The progress styles the Compose Spec defines. podup renders build
-/// output one way, so the flag is inert — but an unknown value must still be
+/// output one way, so the flag is inert, but an unknown value must still be
 /// rejected rather than accepted and ignored, or a typo silently changes nothing
 /// and reports success.
 const PROGRESS_STYLES: [&str; 3] = ["auto", "plain", "tty"];

--- a/internal/cli/types.rs
+++ b/internal/cli/types.rs
@@ -14,14 +14,14 @@ pub(crate) enum OutputFormat {
 
 /// Output rendering for `events`. Distinct from [`OutputFormat`] because the
 /// event stream is NDJSON (one object per line), not a JSON array, and the table
-/// form is a plain summary line with no header — so the help text must not claim
+/// form is a plain summary line with no header, so the help text must not claim
 /// "JSON array" / "aligned columns".
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum EventsFormat {
 	/// A plain `TYPE ACTION NAME` summary, one event per line (no header/alignment).
 	#[default]
 	Table,
-	/// One JSON object per line (NDJSON) — not a JSON array.
+	/// One JSON object per line (NDJSON), not a JSON array.
 	Json,
 }
 

--- a/internal/compose/anchor.rs
+++ b/internal/compose/anchor.rs
@@ -3,7 +3,7 @@
 //! A service pulled in via `include:` or an external `extends: { file: ... }`
 //! carries paths (build context, env_file, bind-mount sources, secret/config
 //! files) that the compose spec resolves relative to the directory of the file
-//! that defined them — not the top-level project directory. The engine resolves
+//! that defined them, not the top-level project directory. The engine resolves
 //! every relative path against a single project base directory, so before such
 //! content is merged we rewrite its relative paths to absolute paths anchored at
 //! the imported file's directory. Absolute paths then pass through the engine's

--- a/internal/compose/diagnostics/ignored_fields.rs
+++ b/internal/compose/diagnostics/ignored_fields.rs
@@ -56,7 +56,7 @@ pub(super) fn ignored_service_fields(file: &ComposeFile, out: &mut Vec<String>) 
 	}
 }
 
-/// Top-level `models:` (Compose v2.38) — podup runs no model runner, so any
+/// Top-level `models:` (Compose v2.38): podup runs no model runner, so any
 /// declared model is parsed for fidelity but not honored.
 pub(super) fn ignored_models(file: &ComposeFile, out: &mut Vec<String>) {
 	for name in file.models.keys() {
@@ -85,8 +85,8 @@ pub(super) fn ignored_port_fields(file: &ComposeFile, out: &mut Vec<String>) {
 /// compose-spec short form (`"5432:5432"`) and the long form with no
 /// `host_ip` both bind on all interfaces, which exposes services the
 /// operator thought were local-only (databases, admin UIs) to anything
-/// reachable on the host's network. An explicit `host_ip` — including
-/// `0.0.0.0` — is a decision taken and is not flagged, so flagging it
+/// reachable on the host's network. An explicit `host_ip`, including
+/// `0.0.0.0`, is a decision taken and is not flagged, so flagging it
 /// would only train the reader to ignore the warning.
 pub(super) fn port_published_on_all_interfaces(file: &ComposeFile, out: &mut Vec<String>) {
 	for (service, def) in &file.services {
@@ -269,9 +269,9 @@ pub(super) fn ignored_service_network_fields(file: &ComposeFile, out: &mut Vec<S
 }
 
 /// Top-level secret/config driver fields. An external secret-store driver
-/// (Vault, AWS SM, etc.) on a non-`external` definition is not honored — podup
+/// (Vault, AWS SM, etc.) on a non-`external` definition is not honored: podup
 /// only stages `file`/`content`/`environment` sources and routes `external:
-/// true` to Podman-native secrets — so warn rather than mount nothing silently.
+/// true` to Podman-native secrets, so warn rather than mount nothing silently.
 pub(super) fn ignored_secret_config_drivers(file: &ComposeFile, out: &mut Vec<String>) {
 	for (name, cfg) in &file.secrets {
 		if cfg.external != Some(true) {

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -5,7 +5,7 @@
 //! The cost of that leniency is silent drops: a typo or an unmapped compose
 //! feature would just vanish. This pass closes that gap by reporting every key
 //! or field podup parses but cannot translate, so nothing is ignored without
-//! the operator hearing about it — the same guarantee that lets podup absorb
+//! the operator hearing about it, the same guarantee that lets podup absorb
 //! future Docker/Podman compose additions gracefully.
 
 use super::types::ComposeFile;
@@ -128,8 +128,8 @@ fn unknown_top_level_keys(file: &ComposeFile, out: &mut Vec<String>) {
 	}
 }
 
-/// Service keys that matched no known field. A likely typo — e.g.
-/// `enviroment:` — is easy to miss when it just vanishes, so surface it.
+/// Service keys that matched no known field. A likely typo, e.g.
+/// `enviroment:`, is easy to miss when it just vanishes, so surface it.
 fn unknown_service_keys(file: &ComposeFile, out: &mut Vec<String>) {
 	for (service, def) in &file.services {
 		for key in def.unknown.keys() {

--- a/internal/compose/diagnostics/nested_raw.rs
+++ b/internal/compose/diagnostics/nested_raw.rs
@@ -1,7 +1,7 @@
 //! Unknown-key warnings for nested compose *option blocks*.
 //!
 //! The typed [`ComposeFile`](crate::compose::types::ComposeFile) silently drops
-//! any key it does not model inside seven nested option blocks — a `bind`,
+//! any key it does not model inside seven nested option blocks: a `bind`,
 //! `volume`, or `tmpfs` mount block, a long-form service `networks.<net>` map,
 //! and the `deploy.resources.{limits,reservations}` specs (plus their
 //! `driver_config` / `devices[]` children). Unlike the service- and top-level
@@ -18,7 +18,7 @@
 //! (serialize-the-parsed-struct) would drop any modeled key whose value is
 //! `None`/empty (every field carries `skip_serializing_if`), so `propagation:`
 //! null, `link_local_ips: []`, `driver_opts: {}`, or `devices: []` would be
-//! mis-flagged as unknown — the forbidden "warn on a modeled key" case. A guard
+//! mis-flagged as unknown, the forbidden "warn on a modeled key" case. A guard
 //! test per type (see `tests`) serializes a fully-populated, exhaustive struct
 //! literal and asserts its key set equals the allowlist, so adding a field to
 //! any of the seven structs fails to compile until both the literal and the
@@ -68,7 +68,7 @@ const DEVICE_RESERVATION_KEYS: &[&str] =
 /// interpolated, merge-resolved compose document.
 ///
 /// Pure (no I/O, no logging) so it is unit-testable; the caller emits each
-/// message via `tracing::warn!`. An unparseable document yields no warnings — it
+/// message via `tracing::warn!`. An unparseable document yields no warnings; it
 /// is the parser proper's job to report that.
 pub(crate) fn raw_nested_unknown_warnings(interpolated_yaml: &str) -> Vec<String> {
 	let mut out = Vec::new();
@@ -136,7 +136,7 @@ fn walk_volumes(service: &str, svc: &serde_yaml::Mapping, out: &mut Vec<String>)
 	}
 }
 
-/// `services.<svc>.networks.<net>` — only the long-form mapping carries options;
+/// `services.<svc>.networks.<net>`: only the long-form mapping carries options;
 /// a bare list or a `null` attachment has nothing to diff.
 fn walk_networks(service: &str, svc: &serde_yaml::Mapping, out: &mut Vec<String>) {
 	let Some(nets) = svc.get("networks").and_then(|v| v.as_mapping()) else {

--- a/internal/compose/diagnostics/nested_raw_tests.rs
+++ b/internal/compose/diagnostics/nested_raw_tests.rs
@@ -7,7 +7,7 @@ use crate::compose::types::{
 };
 
 /// Interpolate + merge-resolve `yaml` exactly as the parser does, then diff
-/// the nested blocks — mirrors the production caller, which feeds the pure
+/// the nested blocks, mirroring the production caller, which feeds the pure
 /// entry the interpolated document text.
 fn warnings_for(yaml: &str) -> Vec<String> {
 	let value = crate::compose::merge::interpolated_value(yaml, None).unwrap();
@@ -170,7 +170,7 @@ fn warns_on_unknown_tmpfs_key() {
 #[test]
 fn warns_on_unknown_driver_config_key_via_recursion() {
 	// The unknown key lives one level below `volume`, which the parent
-	// allowlist cannot reach — only the recursion into `driver_config` finds it.
+	// allowlist cannot reach; only the recursion into `driver_config` finds it.
 	let msgs = warnings_for(
 		"services:\n  web:\n    image: nginx\n    volumes:\n      - type: volume\n        source: data\n        target: /data\n        volume:\n          driver_config:\n            name: local\n            optoins: {}\n",
 	);
@@ -255,8 +255,8 @@ fn modeled_key_with_null_value_does_not_warn() {
 
 #[test]
 fn modeled_keys_with_empty_collections_do_not_warn() {
-	// Empty modeled collections — `link_local_ips: []`, `driver_opts: {}` on a
-	// service network and `devices: []` on a reservation — would all be dropped
+	// Empty modeled collections (`link_local_ips: []`, `driver_opts: {}` on a
+	// service network and `devices: []` on a reservation) would all be dropped
 	// by a round-trip; none may warn.
 	let msgs = warnings_for(
 		"services:\n  web:\n    image: nginx\n    networks:\n      frontend:\n        aliases: []\n        link_local_ips: []\n        driver_opts: {}\n    deploy:\n      resources:\n        reservations:\n          devices: []\nnetworks:\n  frontend:\n",
@@ -285,7 +285,7 @@ fn clean_file_produces_no_warning() {
 
 #[test]
 fn null_network_attachment_is_not_a_block() {
-	// `networks: { frontend: }` is a null attachment, not an options map — there
+	// `networks: { frontend: }` is a null attachment, not an options map: there
 	// is nothing to diff and it must not warn.
 	let msgs = warnings_for(
 		"services:\n  web:\n    image: nginx\n    networks:\n      frontend:\nnetworks:\n  frontend:\n",

--- a/internal/compose/diagnostics/port_exposure_tests.rs
+++ b/internal/compose/diagnostics/port_exposure_tests.rs
@@ -41,8 +41,8 @@ fn does_not_warn_on_short_port_with_loopback_ip() {
 	);
 }
 
-/// `0.0.0.0:5432:5432` does the same bind as the IP-less short form — every
-/// interface — but the operator typed it explicitly. Warning here would
+/// `0.0.0.0:5432:5432` does the same bind as the IP-less short form, every
+/// interface, but the operator typed it explicitly. Warning here would
 /// train the reader to ignore this warning, so this is the case that looks
 /// wrong but is deliberate.
 #[test]
@@ -68,7 +68,7 @@ fn does_not_warn_when_service_has_no_ports() {
 }
 
 /// A service with only `expose:` (no `ports:`) is reachable to peers on the
-/// same compose network but not on the host — same case as no ports at all.
+/// same compose network but not on the host, the same case as no ports at all.
 #[test]
 fn does_not_warn_on_expose_only() {
 	let msgs =
@@ -173,7 +173,7 @@ fn does_not_warn_on_ipv6_short_port() {
 	);
 }
 
-/// Two ports on the same service: one with IP, one without — only the
+/// Two ports on the same service: one with IP, one without; only the
 /// IP-less one warns.
 #[test]
 fn warns_only_for_ip_less_port_in_mixed_list() {

--- a/internal/compose/diagnostics/tests.rs
+++ b/internal/compose/diagnostics/tests.rs
@@ -247,7 +247,7 @@ fn warns_on_remaining_unmapped_build_fields() {
 		);
 	}
 	// `build.ulimits` was on this list, wrongly: the libpod build endpoint takes
-	// a `ulimits` parameter and applies it. Measured on podman 5.7.0 — the same
+	// a `ulimits` parameter and applies it. Measured on podman 5.7.0: the same
 	// build saw `ulimit -n` of 524288 without it and 1234 with it. Reporting it
 	// as unmapped now would send the reader looking for a workaround that is not
 	// needed.

--- a/internal/compose/extends/merge.rs
+++ b/internal/compose/extends/merge.rs
@@ -4,7 +4,7 @@
 //! fields (env vars, labels, maps) are merged with the override winning on
 //! overlapping keys. Sequence fields are combined per the Compose
 //! Specification's `extends` rules: referenced (base) items first, then the
-//! extending service's items, with duplicates removed — not replaced wholesale.
+//! extending service's items, with duplicates removed, not replaced wholesale.
 
 use super::super::types::{
 	DependsOn, DependsOnCondition, EnvFile, EnvVars, Labels, Service, ServiceCondition,
@@ -16,7 +16,7 @@ use super::super::types::{
 /// A key tagged `!override` takes the overriding value whole, skipping whatever
 /// combine rule would normally apply; `!reset` drops the key entirely, leaving
 /// the type's default. Both were accepted and silently ignored before, so a file
-/// asking for replacement got an append instead — the opposite of what it said.
+/// asking for replacement got an append instead, the opposite of what it said.
 ///
 /// Implemented by pre-shaping the two sides and then running the ordinary merge,
 /// rather than by branching inside it: `!reset` empties both sides so the result
@@ -43,7 +43,7 @@ pub(in crate::compose) fn merge_service_tagged(
 	merge_service(base, over)
 }
 
-/// Reset one service key to its default, by name — the primitive both tags are
+/// Reset one service key to its default, by name: the primitive both tags are
 /// built from.
 ///
 /// A key podup does not model is ignored: a tag cannot change a merge that never
@@ -230,7 +230,7 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		secrets: merge_vec(base.secrets, override_svc.secrets),
 		// Union, not replace. A service on `backend` in the base and `monitoring`
 		// in the override silently lost `backend`, dropped off the network, and
-		// service discovery failed at run time — far from the config that caused
+		// service discovery failed at run time, far from the config that caused
 		// it. docker compose unions them; the override's per-network config wins
 		// for a network both declare.
 		networks: merge_networks(base.networks, override_svc.networks),
@@ -303,7 +303,7 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 		oom_score_adj: override_svc.oom_score_adj.or(base.oom_score_adj),
 		blkio_config: override_svc.blkio_config.or(base.blkio_config),
 		logging: override_svc.logging.or(base.logging),
-		// Merged per key, like `environment` and `labels` — not replaced.
+		// Merged per key, like `environment` and `labels`, not replaced.
 		sysctls: merge_sysctls(base.sysctls, override_svc.sysctls),
 		ulimits: {
 			let mut m = base.ulimits;
@@ -336,7 +336,7 @@ pub(in crate::compose) fn merge_service(base: Service, override_svc: Service) ->
 /// Merge `volumes:` by **container-side target**, with the override winning.
 ///
 /// `merge_vec` dedups by serialized form, so a base mounting `./a:/data` and an
-/// override remapping it to `./b:/data` produced both entries — and
+/// override remapping it to `./b:/data` produced both entries, and
 /// `podman create` refused the container with `duplicate mount destination`.
 /// docker compose replaces the mount at a target it already has, which is what
 /// remapping a path in an override is *for*.
@@ -393,7 +393,7 @@ fn merge_networks(base: ServiceNetworks, over: ServiceNetworks) -> ServiceNetwor
 		}
 	}
 	// Stay in the short form when nothing carries per-network config. That is the
-	// form the user wrote and the one docker keeps — and a map of all-`None`
+	// form the user wrote and the one docker keeps, and a map of all-`None`
 	// values is pruned as empty by the `config` renderer's null-stripping, which
 	// would drop the networks from the rendered file entirely.
 	if out.values().all(Option::is_none) {
@@ -402,7 +402,7 @@ fn merge_networks(base: ServiceNetworks, over: ServiceNetworks) -> ServiceNetwor
 	ServiceNetworks::Map(out)
 }
 
-/// Merge `sysctls:` per key, the way `environment` and `labels` already merge —
+/// Merge `sysctls:` per key, the way `environment` and `labels` already merge:
 /// the override wins for a key both set, and the base keeps the rest.
 fn merge_sysctls(base: Sysctls, over: Sysctls) -> Sysctls {
 	if matches!(over, Sysctls::Empty) {

--- a/internal/compose/extends/merge/tests.rs
+++ b/internal/compose/extends/merge/tests.rs
@@ -190,7 +190,7 @@ services:
 	);
 }
 
-/// #1078: `env_file` is appended too — the base's files are still read, in
+/// #1078: `env_file` is appended too: the base's files are still read, in
 /// order, followed by the override's.
 #[test]
 fn env_file_override_appends_to_base() {
@@ -267,7 +267,7 @@ networks:
 }
 
 /// A bare name in the override must not erase per-network config the base
-/// set — the union keeps the config unless the override supplies its own.
+/// set: the union keeps the config unless the override supplies its own.
 #[test]
 fn network_union_keeps_base_config_for_a_bare_override_entry() {
 	let yaml = r#"
@@ -389,7 +389,7 @@ services:
 
 /// #1078: `!override` takes the overriding value whole instead of appending.
 /// Both tags were accepted and silently ignored, so a file asking for
-/// replacement got a merge — the opposite of what it said.
+/// replacement got a merge, the opposite of what it said.
 #[test]
 fn override_tag_replaces_instead_of_appending() {
 	let base =
@@ -433,7 +433,7 @@ fn reset_tag_clears_the_base_value() {
 	);
 }
 
-/// Without a tag the ordinary merge rule still applies — the tags must not
+/// Without a tag the ordinary merge rule still applies; the tags must not
 /// change the default behaviour of anything they are not on.
 #[test]
 fn an_untagged_key_still_merges_normally() {

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -1,4 +1,4 @@
-//! `extends:` directive — inheritance and field merging between service definitions.
+//! `extends:` directive: inheritance and field merging between service definitions.
 //!
 //! Services can extend another service within the same file or from an external
 //! compose file referenced by path. Resolution is recursive (chains are supported)

--- a/internal/compose/extends/mod_tests.rs
+++ b/internal/compose/extends/mod_tests.rs
@@ -9,7 +9,7 @@ fn svc(image: &str) -> Service {
 	}
 }
 
-// merge_service — scalar fields
+// merge_service: scalar fields
 
 #[test]
 fn merge_override_image_wins() {
@@ -27,7 +27,7 @@ fn merge_base_image_used_when_override_missing() {
 	assert_eq!(merged.image.as_deref(), Some("nginx:1.24"));
 }
 
-// merge_service — env vars (override wins per key)
+// merge_service: env vars (override wins per key)
 
 #[test]
 fn merge_env_vars_override_wins_on_conflict() {
@@ -73,7 +73,7 @@ fn merge_env_vars_base_key_preserved_when_not_overridden() {
 	assert_eq!(env.get("BASE_ONLY").and_then(|v| v.as_deref()), Some("yes"));
 }
 
-// merge_service — labels (merged, override wins on conflict)
+// merge_service: labels (merged, override wins on conflict)
 
 #[test]
 fn merge_labels_both_preserved() {
@@ -97,7 +97,7 @@ fn merge_labels_both_preserved() {
 	assert_eq!(lm.get("env").map(|s| s.as_str()), Some("prod"));
 }
 
-// resolve_extends_same_file — cycle detection
+// resolve_extends_same_file: cycle detection
 
 #[test]
 fn cycle_detection_returns_error() {

--- a/internal/compose/include.rs
+++ b/internal/compose/include.rs
@@ -1,4 +1,4 @@
-//! `include:` directive — merging externally included compose files.
+//! `include:` directive: merging externally included compose files.
 //!
 //! Included files are merged into the parent: services, volumes, networks,
 //! secrets, configs, and models from the included file are added only if the
@@ -13,7 +13,7 @@ use crate::error::{ComposeError, Result};
 /// [`ComposeError::Include`] so a consumer matching on the variant can tell the
 /// failure originated from an included file rather than the top-level compose
 /// file. A missing included file is not the same as a missing main file, and
-/// an invalid-YAML included file is not the same as a malformed main file —
+/// an invalid-YAML included file is not the same as a malformed main file:
 /// the variant lets a handler branch on the difference, and the message names
 /// the included path so the operator can find it.
 pub(super) fn parse_included_file(

--- a/internal/compose/include_tests.rs
+++ b/internal/compose/include_tests.rs
@@ -124,7 +124,7 @@ fn merge_empty_other_is_noop() {
 	assert_eq!(target.services.len(), 1);
 }
 
-// parse_included_file — wraps every failure in ComposeError::Include (#1500).
+// parse_included_file wraps every failure in ComposeError::Include (#1500).
 //
 // Each rejection test asserts the variant with `matches!` so the assertion
 // cannot be satisfied by a different failure mode. Every rejection is paired
@@ -201,7 +201,7 @@ fn included_file_invalid_yaml_becomes_include_variant() {
 	);
 	// Acceptance shape: the same main file with a well-formed include
 	// succeeds, so the rejection above is the malformed-include path
-	// firing — not a YAML error in the main file itself.
+	// firing, not a YAML error in the main file itself.
 	let good = dir.path().join("good.yml");
 	write_file(&good, "services:\n  helper:\n    image: alpine\n");
 	let main_ok = dir.path().join("ok.yml");
@@ -235,7 +235,7 @@ fn included_path_is_directory_becomes_include_variant() {
 	// Pointing `include:` at a directory provokes a non-NotFound io error
 	// from the file reader (open-fails with IsADirectory on Unix, an
 	// access error on Windows). The wrapping must convert it to
-	// `Include`, not let `Io` leak out — that's the catch-all arm.
+	// `Include`, not let `Io` leak out; that's the catch-all arm.
 	let dir = tempfile::tempdir().expect("tempdir");
 	let not_a_file = dir.path().join("a-directory");
 	std::fs::create_dir(&not_a_file).expect("mkdir");

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -2,7 +2,7 @@
 //!
 //! serde's tolerance of a merge key depends on the type behind it, so the tags
 //! are resolved on the raw `Value` first and the merged document is what gets
-//! deserialized — the type never sees a `<<:` key.
+//! deserialized; the type never sees a `<<:` key.
 
 use std::collections::HashMap;
 
@@ -13,7 +13,7 @@ use crate::error::{ComposeError, Result};
 /// the size of such a document. serde_yaml_ng already aborts deeply *nested*
 /// alias expansion (its repetition limit), but a flat document with many alias
 /// references to a non-trivial anchor expands *linearly* while the `Value` tree
-/// is built and can exhaust memory — a ~46 KB file can allocate gigabytes. Real
+/// is built and can exhaust memory: a ~46 KB file can allocate gigabytes. Real
 /// compose files use a handful of anchors, so these caps never trigger in
 /// practice; the worst-case expansion they allow (refs × doc size) stays bounded.
 const MAX_ALIAS_REFS: usize = 100;
@@ -55,7 +55,7 @@ pub(super) fn deserialize_with_merge_interp(
 	Ok(file)
 }
 
-/// Produce the interpolated, merge-key-resolved YAML `Value` for `content` — the
+/// Produce the interpolated, merge-key-resolved YAML `Value` for `content`, the
 /// exact transformation [`deserialize_with_merge_interp`] applies before it
 /// deserializes into a [`ComposeFile`], stopping one step short.
 ///
@@ -102,7 +102,7 @@ fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, Strin
 			// Pre-check: only rebuild the mapping when something inside actually
 			// carries a `$`. Without this gate every mapping allocates a fresh
 			// `serde_yaml::Mapping` and re-inserts every key/value on every parse
-			// — for a 100-service file with ~10 fields each that is ~10k key/value
+			// For a 100-service file with ~10 fields each that is ~10k key/value
 			// pairs moved for free (#1364). Scalar strings are already gated on
 			// `s.contains('$')`; this mirrors that gate for the parent node.
 			if !mapping_needs_interp(map) {
@@ -195,14 +195,14 @@ fn guard_alias_expansion(content: &str) -> Result<()> {
 	if content.len() > MAX_ALIAS_DOC_BYTES {
 		return Err(ComposeError::Unsupported(format!(
 			"compose document uses YAML aliases and is {} bytes; documents using anchors/aliases \
-			 must be at most {MAX_ALIAS_DOC_BYTES} bytes — inline the repeated content instead",
+			 must be at most {MAX_ALIAS_DOC_BYTES} bytes; inline the repeated content instead",
 			content.len()
 		)));
 	}
 	if refs > MAX_ALIAS_REFS {
 		return Err(ComposeError::Unsupported(format!(
 			"compose document uses {refs} YAML alias references; at most {MAX_ALIAS_REFS} are \
-			 allowed — inline the repeated content instead"
+			 allowed; inline the repeated content instead"
 		)));
 	}
 	Ok(())
@@ -240,7 +240,7 @@ fn guard_flow_depth(content: &str) -> Result<()> {
 
 /// Count YAML alias references (`*anchor`) outside quoted scalars and comments.
 ///
-/// A heuristic — it does not fully parse YAML — but it only needs to bound a
+/// A heuristic (it does not fully parse YAML) but it only needs to bound a
 /// DoS and it is conservative: `*` inside single/double quotes or after `#` is
 /// ignored, and an alias is counted only when `*` sits at a node position and is
 /// followed by an anchor-name character.
@@ -274,7 +274,7 @@ fn count_alias_refs(content: &str) -> usize {
 
 /// Recursively resolve YAML merge keys (`<<: *anchor`) in a `Value` tree.
 ///
-/// serde_yaml_ng does not expose `apply_merge()` — this replaces it.
+/// serde_yaml_ng does not expose `apply_merge()`, so this replaces it.
 /// Merge semantics: keys from the anchor fill in only where the child has no value.
 fn apply_merge_keys(value: &mut serde_yaml::Value) {
 	match value {

--- a/internal/compose/merge_tests.rs
+++ b/internal/compose/merge_tests.rs
@@ -88,7 +88,7 @@ fn guard_allows_normal_anchored_file() {
 
 #[test]
 fn guard_rejects_linear_alias_amplification() {
-	// Many references to one anchor — the OOM vector serde_yaml_ng does not bound.
+	// Many references to one anchor: the OOM vector serde_yaml_ng does not bound.
 	let mut yaml = String::from("anchor: &a [x, y, z]\nlist:\n");
 	for _ in 0..(MAX_ALIAS_REFS + 50) {
 		yaml.push_str("  - *a\n");
@@ -140,7 +140,7 @@ fn needs_interp(yaml: &str) -> bool {
 
 #[test]
 fn needs_interp_detects_scalar_key_or_value() {
-	// A `$` in any leaf — including a key — flips the gate to true.
+	// A `$` in any leaf, including a key, flips the gate to true.
 	assert!(!needs_interp("foo: bar"));
 	assert!(needs_interp("foo: $bar"));
 	assert!(needs_interp("$foo: bar"));
@@ -165,7 +165,7 @@ fn needs_interp_ignores_non_string_leaves() {
 /// round-trips through `deserialize_with_merge_interp` with the same
 /// content, and the parent mapping is not rebuilt (no allocations beyond
 /// the original parse). Asserted by counting scalar-string equality
-/// post-interpolation — a rebuild that mutated the document would still
+/// post-interpolation: a rebuild that mutated the document would still
 /// pass equality, so this also pins the no-mutation invariant.
 #[test]
 fn mapping_rebuild_is_skipped_when_nothing_needs_interpolation() {

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -37,7 +37,7 @@ pub fn parse_file(path: &Path) -> Result<ComposeFile> {
 /// effect for the top-level file and any included files.
 ///
 /// They **replace** a project `.env` rather than adding to it: when `env_files`
-/// is non-empty, `.env` is not read. That is docker-correct — and the opposite
+/// is non-empty, `.env` is not read. That is docker-correct, and the opposite
 /// of what this comment used to claim, which also reached docs.rs readers. The
 /// process environment still takes precedence over both.
 pub fn parse_file_with_env_files(path: &Path, env_files: &[String]) -> Result<ComposeFile> {
@@ -85,7 +85,7 @@ pub fn parse_file_with_env_files_interp(
 			// including file and treats `../` as canonical (monorepos routinely use
 			// `include: ../shared/compose.yaml`). An absolute path is used as given.
 			// This matches docker-compose and the trusted-input policy already
-			// applied to `extends.file` and `env_file` — the compose file is
+			// applied to `extends.file` and `env_file`: the compose file is
 			// trusted input, like a Makefile.
 			let inc_path = if rel_path.is_absolute() {
 				rel_path.to_path_buf()
@@ -187,7 +187,7 @@ pub fn parse_files_with_env_files_interp(
 	Ok(merged)
 }
 
-/// Re-read `path` and return the interpolated, merge-resolved YAML as text — the
+/// Re-read `path` and return the interpolated, merge-resolved YAML as text, the
 /// same document shape the parser builds before deserializing into a
 /// `ComposeFile`. Used only by the raw nested-key diagnostic, which needs the
 /// pre-typed document to spot keys the model drops. `interpolate = false` (the
@@ -218,7 +218,7 @@ fn interpolated_yaml_text(path: &Path, env_files: &[String], interpolate: bool) 
 /// Synthesize the implicit `default` network, matching docker-compose: any
 /// service that declares neither `networks:` nor `network_mode` is attached to
 /// a project `default` network. Without this, such services are created with no
-/// network namespace at all — they get no IP and cannot resolve each other by
+/// network namespace at all: they get no IP and cannot resolve each other by
 /// name, silently breaking the common no-`networks:`-block compose file.
 ///
 /// The `default` network is created as `{project}_default` (see
@@ -272,7 +272,7 @@ fn merge_override(target: &mut ComposeFile, other: ComposeFile, directives: &tag
 /// Parse a compose YAML string (no file I/O).
 ///
 /// Variable substitution is applied using only the process environment.
-/// `extends: { file: ... }` and `include:` directives are not resolved —
+/// `extends: { file: ... }` and `include:` directives are not resolved;
 /// use [`parse_file`] for that.
 pub fn parse_str(content: &str) -> Result<ComposeFile> {
 	let vars = substitute::build_vars(Path::new("."));

--- a/internal/compose/order.rs
+++ b/internal/compose/order.rs
@@ -43,7 +43,7 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 	// deterministic: the in-degree map is a `HashMap`, so seeding/extending the
 	// frontier from its iteration order would otherwise be per-run random. This
 	// mirrors the per-level `sort_unstable` in `resolve_levels`, so independent
-	// (in-degree-0) services resolve in a stable order — which `wait` relies on
+	// (in-degree-0) services resolve in a stable order, which `wait` relies on
 	// for a reproducible exit code and output ordering.
 	let mut queue: BinaryHeap<Reverse<&str>> = in_degree
 		.iter()
@@ -73,7 +73,7 @@ pub fn resolve_order(file: &ComposeFile) -> Result<Vec<String>> {
 }
 
 /// Build the user-facing circular-dependency message naming the services still
-/// holding a nonzero in-degree after Kahn's algorithm — exactly the nodes that
+/// holding a nonzero in-degree after Kahn's algorithm: exactly the nodes that
 /// form (or feed into) the cycle. Sorted for a deterministic message.
 fn cycle_message(in_degree: &HashMap<&str, usize>) -> String {
 	let mut involved: Vec<&str> = in_degree

--- a/internal/compose/order_tests.rs
+++ b/internal/compose/order_tests.rs
@@ -131,7 +131,7 @@ fn resolve_levels_missing_required_dep_is_error() {
 #[test]
 fn resolve_order_optional_missing_dep_is_ignored() {
 	// A `required: false` dependency that is not defined is skipped, not an
-	// error — the dependent still resolves.
+	// error; the dependent still resolves.
 	let yaml = "services:\n  web:\n    image: nginx\n    depends_on:\n      ghost:\n        condition: service_started\n        required: false\n";
 	let file = parse_str_raw(yaml).unwrap();
 	let order = resolve_order(&file).unwrap();

--- a/internal/compose/tags.rs
+++ b/internal/compose/tags.rs
@@ -11,7 +11,7 @@
 //!     dns:   !reset []               # drop the base's dns entirely
 //! ```
 //!
-//! podup accepted both and then **ignored them silently** — `!override` still
+//! podup accepted both and then **ignored them silently**: `!override` still
 //! appended and `!reset` still kept the base. Silently doing the opposite of
 //! what a key asks for is worse than refusing it, and the tags exist precisely
 //! for the cases where the default merge is wrong.
@@ -28,10 +28,10 @@ use serde_yaml::Value;
 /// What a tag asks the merge to do with one key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MergeTag {
-	/// `!override` — take the overriding file's value whole, skipping the
+	/// `!override`: take the overriding file's value whole, skipping the
 	/// combine rule that would otherwise apply.
 	Override,
-	/// `!reset` — drop the key entirely, leaving the type's default.
+	/// `!reset`: drop the key entirely, leaving the type's default.
 	Reset,
 }
 
@@ -40,7 +40,7 @@ pub(crate) type Directives = HashMap<String, HashMap<String, MergeTag>>;
 
 /// Collect the merge tags in a raw compose document.
 ///
-/// Reads the document only for its structure, so interpolation is irrelevant —
+/// Reads the document only for its structure, so interpolation is irrelevant:
 /// a tag is attached to a key, never to a value's contents.
 ///
 /// An unrecognized tag is ignored rather than rejected: the compose spec lets a
@@ -80,7 +80,7 @@ pub(crate) fn collect(raw: &Value) -> Directives {
 /// This has to run before the document is deserialized into typed structs.
 /// Whether a tag is tolerated otherwise depends entirely on the field's Rust
 /// type: `ports` is a `Vec`, which quietly ignores it, but `dns` is an untagged
-/// enum, and serde refuses those outright — so `dns: !reset []` failed the whole
+/// enum, and serde refuses those outright, so `dns: !reset []` failed the whole
 /// file with "failed to parse compose file" while `ports: !reset []` parsed and
 /// did nothing. Two different wrong behaviours for the same tag, decided by an
 /// implementation detail the user cannot see.

--- a/internal/compose/tags_tests.rs
+++ b/internal/compose/tags_tests.rs
@@ -20,7 +20,7 @@ fn untagged_document_yields_nothing() {
 	assert!(parse("services:\n  web:\n    ports: [\"80:80\"]\n").is_empty());
 }
 
-/// A tag this tool does not define is ignored, not rejected — the document
+/// A tag this tool does not define is ignored, not rejected; the document
 /// may be valid for something else.
 #[test]
 fn unknown_tag_is_ignored() {
@@ -46,7 +46,7 @@ fn strip_removes_tags_at_any_depth() {
 	let out = serde_yaml::to_string(&v).unwrap();
 	assert!(!out.contains("!override"), "{out}");
 	assert!(!out.contains("!reset"), "{out}");
-	// The wrapped value survives — stripping removes the tag, not the data.
+	// The wrapped value survives: stripping removes the tag, not the data.
 	assert!(out.contains("9090:80"), "{out}");
 }
 

--- a/internal/compose/types/build.rs
+++ b/internal/compose/types/build.rs
@@ -1,6 +1,6 @@
 //! Build, include, and extends configuration types.
 //!
-//! [`BuildConfig`] represents the `build:` key — either a bare context string
+//! [`BuildConfig`] represents the `build:` key: either a bare context string
 //! or a full long-form config. [`IncludeConfig`] and [`ExtendsConfig`] handle
 //! the `include:` and `extends:` top-level / per-service directives respectively.
 
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use super::{EnvVars, Labels, StringOrList, UlimitConfig};
 
-/// Compose `include:` directive — either a bare file path or a long-form block.
+/// Compose `include:` directive: either a bare file path or a long-form block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum IncludeConfig {
@@ -39,7 +39,7 @@ impl IncludeConfig {
 	}
 }
 
-/// Compose `extends:` directive — either a bare service name or a long-form `{service, file}` block.
+/// Compose `extends:` directive: either a bare service name or a long-form `{service, file}` block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ExtendsConfig {
@@ -73,7 +73,7 @@ impl ExtendsConfig {
 	}
 }
 
-/// Compose `build:` directive — either a bare context path or a full build-config block.
+/// Compose `build:` directive: either a bare context path or a full build-config block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
@@ -266,7 +266,7 @@ impl BuildConfig {
 		}
 	}
 
-	/// `build.cache_to` — cache export targets (image references).
+	/// `build.cache_to`: cache export targets (image references).
 	pub fn cache_to(&self) -> &[String] {
 		match self {
 			BuildConfig::Context(_) => &[],
@@ -274,7 +274,7 @@ impl BuildConfig {
 		}
 	}
 
-	/// `build.ssh` — SSH agent sockets/keys for the build.
+	/// `build.ssh`: SSH agent sockets/keys for the build.
 	pub fn ssh(&self) -> &[String] {
 		match self {
 			BuildConfig::Context(_) => &[],
@@ -282,7 +282,7 @@ impl BuildConfig {
 		}
 	}
 
-	/// `build.secrets` — names of top-level secrets exposed to the build.
+	/// `build.secrets`: names of top-level secrets exposed to the build.
 	pub fn secrets(&self) -> &[String] {
 		match self {
 			BuildConfig::Context(_) => &[],
@@ -290,7 +290,7 @@ impl BuildConfig {
 		}
 	}
 
-	/// `build.additional_contexts` — named extra build contexts (`name -> source`).
+	/// `build.additional_contexts`: named extra build contexts (`name -> source`).
 	pub fn additional_contexts(&self) -> Vec<(String, String)> {
 		match self {
 			BuildConfig::Context(_) => Vec::new(),

--- a/internal/compose/types/build_tests.rs
+++ b/internal/compose/types/build_tests.rs
@@ -85,7 +85,7 @@ fn build_config_long_form_context() {
 #[test]
 fn build_with_only_dockerfile_inline_defaults_context_to_dot() {
 	// Compose Spec (v2.22+): `build:` may carry only `dockerfile_inline:` with
-	// no `context:` — the context then defaults to the project directory `.`.
+	// no `context:`, so the context then defaults to the project directory `.`.
 	let b: BuildConfig = serde_yaml::from_str("dockerfile_inline: |\n  FROM alpine\n").unwrap();
 	assert!(matches!(b, BuildConfig::Config { .. }));
 	assert_eq!(b.context(), ".");

--- a/internal/compose/types/deploy.rs
+++ b/internal/compose/types/deploy.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Labels;
 
-/// `deploy:` service key — resource limits, replica count, restart policies, and labels.
+/// `deploy:` service key: resource limits, replica count, restart policies, and labels.
 ///
 /// The engine uses `replicas`, `resources`, `restart_policy`, and `labels`.
 /// Fields inherited from Docker Swarm (`mode`, `placement`, `update_config`,
@@ -52,7 +52,7 @@ pub struct DeployConfig {
 	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
-/// Resource constraints under `deploy.resources:` — holds `limits` and `reservations`.
+/// Resource constraints under `deploy.resources:`, holding `limits` and `reservations`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct ResourcesConfig {
 	/// Hard upper bounds on resource usage.
@@ -89,7 +89,7 @@ pub struct ResourceSpec {
 // Device reservations (GPU / accelerators)
 // ---------------------------------------------------------------------------
 
-/// `deploy.resources.reservations.devices` — generic device reservation.
+/// `deploy.resources.reservations.devices`: generic device reservation.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeviceReservation {
 	/// Required device capabilities (e.g. `gpu`, `compute`).
@@ -133,7 +133,7 @@ impl CountOrAll {
 #[path = "deploy_tests.rs"]
 mod tests;
 
-/// Restart policy under `deploy.restart_policy:` — distinct from the service-level `restart:` string.
+/// Restart policy under `deploy.restart_policy:`, distinct from the service-level `restart:` string.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployRestartPolicy {
 	/// When to restart, e.g. `on-failure` or `any`.
@@ -150,7 +150,7 @@ pub struct DeployRestartPolicy {
 	pub window: Option<String>,
 }
 
-/// Update (and rollback) configuration — reused for both `deploy.update_config` and `deploy.rollback_config`.
+/// Update (and rollback) configuration, reused for both `deploy.update_config` and `deploy.rollback_config`.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DeployUpdateConfig {
 	/// Number of containers updated at once.

--- a/internal/compose/types/develop.rs
+++ b/internal/compose/types/develop.rs
@@ -7,7 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// `develop:` service key — holds file-watch rules for the `watch` command.
+/// `develop:` service key: holds file-watch rules for the `watch` command.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct DevelopConfig {
 	/// The rules in declaration order. `watch` evaluates them in order and the
@@ -48,16 +48,16 @@ pub struct WatchRule {
 /// Action triggered by a `develop.watch` rule: `sync`, `rebuild`, `restart`, `sync+restart`, or `sync+exec`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum WatchAction {
-	/// `sync` — copy changed files from `path` into the container at `target`.
+	/// `sync`: copy changed files from `path` into the container at `target`.
 	#[default]
 	Sync,
-	/// `rebuild` — rebuild the service image and recreate the container.
+	/// `rebuild`: rebuild the service image and recreate the container.
 	Rebuild,
-	/// `restart` — restart the running container without rebuilding.
+	/// `restart`: restart the running container without rebuilding.
 	Restart,
-	/// `sync+restart` — sync changed files, then restart the container.
+	/// `sync+restart`: sync changed files, then restart the container.
 	SyncAndRestart,
-	/// `sync+exec` — sync changed files, then run the rule's `exec` command in the container.
+	/// `sync+exec`: sync changed files, then run the rule's `exec` command in the container.
 	SyncAndExec,
 }
 

--- a/internal/compose/types/env.rs
+++ b/internal/compose/types/env.rs
@@ -60,7 +60,7 @@ impl EnvVars {
 	}
 }
 
-/// One entry in an `env_file:` list — either a bare path or a long-form object.
+/// One entry in an `env_file:` list: either a bare path or a long-form object.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum EnvFileEntry {
@@ -88,7 +88,7 @@ impl EnvFileEntry {
 		}
 	}
 
-	/// `true` by default — missing file is an error unless `required: false`.
+	/// `true` by default: a missing file is an error unless `required: false`.
 	pub fn required(&self) -> bool {
 		match self {
 			EnvFileEntry::Path(_) => true,
@@ -97,7 +97,7 @@ impl EnvFileEntry {
 	}
 }
 
-/// `env_file:` field — single path, list of paths, or list of long-form objects.
+/// `env_file:` field: single path, list of paths, or list of long-form objects.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum EnvFile {

--- a/internal/compose/types/lifecycle.rs
+++ b/internal/compose/types/lifecycle.rs
@@ -1,6 +1,6 @@
 //! Lifecycle and dependency types: `depends_on:`, `healthcheck:`, `restart:`, and lifecycle hooks.
 //!
-//! [`DependsOn`] models the service dependency graph — either a simple name list
+//! [`DependsOn`] models the service dependency graph: either a simple name list
 //! or a map with per-dependency [`ServiceCondition`] semantics. [`HealthCheck`]
 //! covers the inline healthcheck definition. [`RestartPolicy`] parses the
 //! `restart:` string field. [`LifecycleHook`] is used for `post_start:` and
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::env::EnvVars;
 use super::primitives::Command;
 
-/// `depends_on:` value — absent, a bare list of service names, or a map of service name to condition.
+/// `depends_on:` value: absent, a bare list of service names, or a map of service name to condition.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum DependsOn {
@@ -63,7 +63,7 @@ impl DependsOn {
 	}
 }
 
-/// Long-form per-dependency entry in `depends_on:` — holds the condition and restart flag.
+/// Long-form per-dependency entry in `depends_on:`, holding the condition and restart flag.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DependsOnCondition {
 	/// Condition the dependency must reach before the dependent starts.
@@ -122,7 +122,7 @@ pub struct HealthCheck {
 ///
 /// `x-` is the spec's reserved prefix for extensions: docker compose ignores an
 /// unknown `x-` key rather than erroring, so a file using this stays a valid
-/// compose file and still runs under docker — it just does not act on a sick
+/// compose file and still runs under docker; it just does not act on a sick
 /// container there. That is the whole reason for the prefix rather than a bare
 /// `on_failure`, which would make the file podup-only.
 pub const X_PODMAN_ON_FAILURE: &str = "x-podman-on-failure";
@@ -130,8 +130,8 @@ pub const X_PODMAN_ON_FAILURE: &str = "x-podman-on-failure";
 /// What Podman does when a container's healthcheck flips to unhealthy.
 ///
 /// The Compose Spec has no equivalent: a compose healthcheck detects a sick
-/// container and does nothing about it. A restart policy does not cover this —
-/// it reacts to the process exiting, not to the container being unhealthy — so
+/// container and does nothing about it. A restart policy does not cover this:
+/// it reacts to the process exiting, not to the container being unhealthy, so
 /// an app that hangs without dying stays in rotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HealthOnFailure {
@@ -178,7 +178,7 @@ impl HealthCheck {
 	///
 	/// Spec-defined keys are typed fields on this struct; a Podman extension
 	/// lives in `unknown` (where `#[serde(flatten)]` already preserves it for
-	/// round-tripping) and is read through here. That split is deliberate — it
+	/// round-tripping) and is read through here. That split is deliberate: it
 	/// keeps the type honest about which keys are portable.
 	///
 	/// `Err` for a value that is not one of Podman's four actions, so a typo is
@@ -223,7 +223,7 @@ pub struct LifecycleHook {
 	pub environment: EnvVars,
 }
 
-/// Service-level `restart:` policy — `no`, `always`, `unless-stopped`, or `on-failure` (with optional max-retries).
+/// Service-level `restart:` policy: `no`, `always`, `unless-stopped`, or `on-failure` (with optional max-retries).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestartPolicy {
 	/// Never restart the container.

--- a/internal/compose/types/lifecycle_tests.rs
+++ b/internal/compose/types/lifecycle_tests.rs
@@ -202,7 +202,7 @@ fn podman_on_failure_parses_each_action() {
 }
 
 /// A typo is rejected rather than silently leaving a sick container in
-/// rotation — the failure this key exists to prevent.
+/// rotation, the failure this key exists to prevent.
 #[test]
 fn podman_on_failure_rejects_an_unknown_action() {
 	let yaml = format!("test: [\"CMD\", \"true\"]\n{X_PODMAN_ON_FAILURE}: bogus\n");

--- a/internal/compose/types/mod.rs
+++ b/internal/compose/types/mod.rs
@@ -28,7 +28,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Top-level `secrets:` entry — defines a named secret available to services.
+/// Top-level `secrets:` entry: defines a named secret available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct SecretConfig {
@@ -61,7 +61,7 @@ pub struct SecretConfig {
 	pub template_driver: Option<String>,
 }
 
-/// Top-level `configs:` entry — defines a named config available to services.
+/// Top-level `configs:` entry: defines a named config available to services.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ConfigConfig {
@@ -94,7 +94,7 @@ pub struct ConfigConfig {
 	pub template_driver: Option<String>,
 }
 
-/// Top-level `models:` entry (Compose v2.38) — declares an AI model the
+/// Top-level `models:` entry (Compose v2.38) declares an AI model the
 /// project depends on. podup runs no model runner, so the diagnostics pass
 /// reports any declared model as not honored; the fields are parsed for
 /// fidelity and round-tripped by `config`.
@@ -154,7 +154,7 @@ pub struct ComposeFile {
 	/// not honored.
 	#[serde(default)]
 	pub models: IndexMap<String, ModelConfig>,
-	/// Top-level `x-*` extension fields — preserved and round-tripped via `config` subcommand.
+	/// Top-level `x-*` extension fields, preserved and round-tripped via `config` subcommand.
 	#[serde(flatten, default, skip_serializing_if = "IndexMap::is_empty")]
 	pub extensions: IndexMap<String, serde_yaml::Value>,
 }
@@ -175,7 +175,7 @@ impl ComposeFile {
 	/// Replace every inline `content:` value under `secrets:` and `configs:`
 	/// with [`REDACTED_PLACEHOLDER`], so rendering the file for display (the
 	/// `config` subcommand) never writes secret material to stdout. References
-	/// to a `file:` or `environment:` source are left untouched — they name a
+	/// to a `file:` or `environment:` source are left untouched: they name a
 	/// source, they do not embed the value.
 	pub fn redact_inline_content(&mut self) {
 		for secret in self.secrets.values_mut() {
@@ -192,8 +192,8 @@ impl ComposeFile {
 
 	/// Drop every captured unknown key that the diagnostics pass reports as
 	/// "ignored", so a rendered `config` reflects only what podup actually
-	/// applies. Compose-spec `x-*` extension keys are kept — they are valid and
-	/// round-tripped — but a typo or an unmapped key is removed rather than
+	/// applies. Compose-spec `x-*` extension keys are kept (they are valid and
+	/// round-tripped) but a typo or an unmapped key is removed rather than
 	/// echoed back, which is what makes re-feeding the output stop re-triggering
 	/// the same warning. Mirrors the levels walked by the diagnostics collector.
 	pub fn strip_ignored_unknown_keys(&mut self) {

--- a/internal/compose/types/mod_tests.rs
+++ b/internal/compose/types/mod_tests.rs
@@ -58,7 +58,7 @@ secrets:
 fn strip_ignored_unknown_keys_drops_non_extension_at_every_level() {
 	// Unknown keys at the top level, in a service, a service sub-object
 	// (deploy), a network, and a volume are all dropped, while `x-*` extension
-	// keys at any level survive — so the rendered config agrees with the
+	// keys at any level survive, so the rendered config agrees with the
 	// diagnostics that flagged the rest as ignored.
 	let yaml = r#"
 bogus_top: 1

--- a/internal/compose/types/network.rs
+++ b/internal/compose/types/network.rs
@@ -1,7 +1,7 @@
 //! Network configuration types for both top-level networks and per-service attachments.
 //!
 //! [`NetworkConfig`] describes a named network in the `networks:` top-level block.
-//! [`ServiceNetworks`] is the per-service attachment — either a bare list of names
+//! [`ServiceNetworks`] is the per-service attachment: either a bare list of names
 //! or a map with [`ServiceNetworkConfig`] options (aliases, IP, priority, etc.).
 
 use indexmap::IndexMap;
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use super::Labels;
 
-/// `networks:` value at service level — absent, a bare list of network names, or a detailed map.
+/// `networks:` value at service level: absent, a bare list of network names, or a detailed map.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum ServiceNetworks {

--- a/internal/compose/types/primitives.rs
+++ b/internal/compose/types/primitives.rs
@@ -1,10 +1,10 @@
 //! Primitive compose field types shared across multiple service keys.
 //!
-//! [`Command`] — shell string or exec list for `command:`/`entrypoint:`.
-//! [`StringOrList`] — single string or list of strings (used in `dns:`, `cap_add:`, etc.).
-//! [`Labels`] — list or map form for `labels:`.
-//! [`LoggingConfig`] — `logging:` driver and options.
-//! [`Sysctls`] — list or map form for `sysctls:`.
+//! [`Command`] is a shell string or exec list for `command:`/`entrypoint:`.
+//! [`StringOrList`] is a single string or list of strings (used in `dns:`, `cap_add:`, etc.).
+//! [`Labels`] is the list or map form for `labels:`.
+//! [`LoggingConfig`] is the `logging:` driver and options.
+//! [`Sysctls`] is the list or map form for `sysctls:`.
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -54,7 +54,7 @@ where
 	}))
 }
 
-/// Container entrypoint / command — either a shell string or exec list.
+/// Container entrypoint / command: either a shell string or exec list.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Command {
@@ -115,7 +115,7 @@ impl StringOrList {
 	}
 }
 
-/// Labels — list or map form.
+/// Labels: list or map form.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum Labels {
@@ -157,7 +157,7 @@ impl Labels {
 	}
 }
 
-/// `logging:` configuration — driver name and driver-specific options.
+/// `logging:` configuration: driver name and driver-specific options.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct LoggingConfig {
 	/// Logging driver name; the runtime default is used if absent.
@@ -168,7 +168,7 @@ pub struct LoggingConfig {
 	pub options: HashMap<String, String>,
 }
 
-/// Kernel parameters — list (`["net.ipv4.ip_forward=1"]`) or map form.
+/// Kernel parameters: list (`["net.ipv4.ip_forward=1"]`) or map form.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(untagged)]
 pub enum Sysctls {

--- a/internal/compose/types/resources.rs
+++ b/internal/compose/types/resources.rs
@@ -1,12 +1,12 @@
 //! Resource limit and device types shared across service and deploy configuration.
 //!
-//! [`UlimitConfig`] maps to the `ulimits:` map — either a single value (soft==hard)
+//! [`UlimitConfig`] maps to the `ulimits:` map: either a single value (soft==hard)
 //! or an explicit soft/hard pair. [`BlkioConfig`] covers block I/O weight and rate
 //! limits. [`GpuSpec`] handles the `gpus:` shorthand (`"all"` or a count).
 
 use serde::{Deserialize, Serialize};
 
-/// `ulimits:` entry — either a single integer (soft == hard) or an explicit `{soft, hard}` pair.
+/// `ulimits:` entry: either a single integer (soft == hard) or an explicit `{soft, hard}` pair.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum UlimitConfig {
@@ -39,7 +39,7 @@ impl UlimitConfig {
 	}
 }
 
-/// `blkio_config:` service field — controls I/O weight and per-device rate limits.
+/// `blkio_config:` service field: controls I/O weight and per-device rate limits.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct BlkioConfig {
 	/// Default block I/O weight for the service (10-1000).
@@ -71,7 +71,7 @@ pub struct BlkioWeightDevice {
 	pub weight: u16,
 }
 
-/// Per-device rate limit under `blkio_config` — used for both bps and iops limits.
+/// Per-device rate limit under `blkio_config`, used for both bps and iops limits.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioRateDevice {
 	/// Host device path the limit applies to.

--- a/internal/compose/types/service.rs
+++ b/internal/compose/types/service.rs
@@ -1,4 +1,4 @@
-//! [`Service`] struct — the central type representing a single compose service.
+//! [`Service`] struct, the central type representing a single compose service.
 //!
 //! Fields map 1-to-1 to the Docker Compose specification. Optional fields use
 //! `Option<T>` so that absent keys are distinguishable from explicit nulls
@@ -22,90 +22,90 @@ use super::{
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct Service {
-	/// `image:` — container image reference (`name[:tag|@digest]`) to run; if
+	/// `image:` is the container image reference (`name[:tag|@digest]`) to run; if
 	/// absent, `build:` must supply one.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub image: Option<String>,
-	/// `build:` — build the image from source instead of (or in addition to)
+	/// `build:` builds the image from source instead of (or in addition to)
 	/// pulling `image:`; a string shorthand is the build context path.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub build: Option<BuildConfig>,
-	/// `extends:` — inherit configuration from another service (optionally in
+	/// `extends:` inherits configuration from another service (optionally in
 	/// another file); merged before this service's own keys are applied.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub extends: Option<ExtendsConfig>,
-	/// `command:` — overrides the image `CMD`; string (shell-parsed) or list (exec
+	/// `command:` overrides the image `CMD`; string (shell-parsed) or list (exec
 	/// form, no shell).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub command: Option<Command>,
-	/// `entrypoint:` — overrides the image `ENTRYPOINT` and resets any image
+	/// `entrypoint:` overrides the image `ENTRYPOINT` and resets any image
 	/// `CMD`; string (shell form) or list (exec form).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub entrypoint: Option<Command>,
 
-	/// `ports:` — published host↔container port mappings (`[host:]container[/proto]`
+	/// `ports:` lists published host↔container port mappings (`[host:]container[/proto]`
 	/// or long form); exposes the port outside the container network.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub ports: Vec<PortMapping>,
-	/// `expose:` — ports made reachable to linked services only, without
+	/// `expose:` lists ports made reachable to linked services only, without
 	/// publishing them on the host.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub expose: Vec<String>,
 
-	/// `environment:` — environment variables set in the container; map or
+	/// `environment:` holds environment variables set in the container; map or
 	/// `KEY=VALUE` list. Takes precedence over `env_file:`.
 	#[serde(default)]
 	pub environment: EnvVars,
-	/// `env_file:` — file(s) of `KEY=VALUE` lines loaded into the environment;
+	/// `env_file:` names file(s) of `KEY=VALUE` lines loaded into the environment;
 	/// overridden by `environment:` on key collision.
 	#[serde(default)]
 	pub env_file: EnvFile,
-	/// `volumes:` — bind mounts, named volumes, and anonymous volumes (short
+	/// `volumes:` lists bind mounts, named volumes, and anonymous volumes (short
 	/// `src:dst[:opts]` or long form).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub volumes: Vec<VolumeMount>,
-	/// `tmpfs:` — paths mounted as an in-memory tmpfs inside the container; single
+	/// `tmpfs:` lists paths mounted as an in-memory tmpfs inside the container; single
 	/// path or list.
 	#[serde(default)]
 	pub tmpfs: StringOrList,
-	/// `volumes_from:` — mount all volumes from another service or container
+	/// `volumes_from:` mounts all volumes from another service or container
 	/// (`name[:ro|rw]`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub volumes_from: Vec<String>,
-	/// `configs:` — top-level configs granted to this service, mounted as files
+	/// `configs:` lists top-level configs granted to this service, mounted as files
 	/// (default `/<config-name>`) or exposed per the long form.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub configs: Vec<ServiceConfigRef>,
-	/// `secrets:` — top-level secrets granted to this service, mounted under
+	/// `secrets:` lists top-level secrets granted to this service, mounted under
 	/// `/run/secrets/` (or the long-form target).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub secrets: Vec<ServiceSecretRef>,
 
-	/// `networks:` — networks this service joins, with optional per-network
+	/// `networks:` lists the networks this service joins, with optional per-network
 	/// aliases/IPs; absent means the project's default network.
 	#[serde(default)]
 	pub networks: ServiceNetworks,
-	/// `hostname:` — the container's own hostname (its `/etc/hostname` and
+	/// `hostname:` is the container's own hostname (its `/etc/hostname` and
 	/// in-container `uname -n`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub hostname: Option<String>,
-	/// `domainname:` — the container's NIS/DNS domain (fully-qualified
+	/// `domainname:` is the container's NIS/DNS domain (fully-qualified
 	/// hostname suffix).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub domainname: Option<String>,
-	/// `mac_address:` — fixed MAC for the container's primary interface; a
+	/// `mac_address:` is a fixed MAC for the container's primary interface; a
 	/// documented divergence under rootless Podman where it may be ignored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mac_address: Option<String>,
-	/// `links:` — legacy service links (`service[:alias]`) adding hostname
+	/// `links:` declares legacy service links (`service[:alias]`) adding hostname
 	/// entries; superseded by shared networks.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub links: Vec<String>,
-	/// `external_links:` — link to containers outside this compose project
+	/// `external_links:` links to containers outside this compose project
 	/// (`container[:alias]`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub external_links: Vec<String>,
-	/// `extra_hosts:` — extra `/etc/hosts` entries (`hostname:ip`); accepts the
+	/// `extra_hosts:` adds `/etc/hosts` entries (`hostname:ip`); accepts the
 	/// list or mapping YAML forms.
 	#[serde(
 		default,
@@ -113,186 +113,186 @@ pub struct Service {
 		skip_serializing_if = "Vec::is_empty"
 	)]
 	pub extra_hosts: Vec<String>,
-	/// `dns:` — custom DNS server IP(s) for name resolution; single value or list.
+	/// `dns:` sets custom DNS server IP(s) for name resolution; single value or list.
 	#[serde(default)]
 	pub dns: StringOrList,
-	/// `dns_search:` — DNS search domains appended to unqualified names; single
+	/// `dns_search:` sets DNS search domains appended to unqualified names; single
 	/// value or list.
 	#[serde(default)]
 	pub dns_search: StringOrList,
-	/// `dns_opt:` — resolver options written to `/etc/resolv.conf` (e.g.
+	/// `dns_opt:` sets resolver options written to `/etc/resolv.conf` (e.g.
 	/// `ndots:2`); single value or list.
 	#[serde(default)]
 	pub dns_opt: StringOrList,
-	/// `network_mode:` — networking namespace mode (`bridge`, `host`, `none`,
+	/// `network_mode:` is the networking namespace mode (`bridge`, `host`, `none`,
 	/// `service:NAME`, `container:NAME`); mutually exclusive with `networks:`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub network_mode: Option<String>,
 
-	/// `depends_on:` — start/stop ordering and optional `condition:`
+	/// `depends_on:` declares start/stop ordering and an optional `condition:`
 	/// (`service_started`/`service_healthy`/`service_completed_successfully`)
 	/// dependencies on other services.
 	#[serde(default)]
 	pub depends_on: DependsOn,
-	/// `healthcheck:` — command and timing that determine container health;
+	/// `healthcheck:` is the command and timing that determine container health;
 	/// `disable: true` turns off any image-defined check.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub healthcheck: Option<HealthCheck>,
 
-	/// `restart:` — restart policy (`no`/`always`/`on-failure[:max]`/
+	/// `restart:` is the restart policy (`no`/`always`/`on-failure[:max]`/
 	/// `unless-stopped`). Takes precedence over `deploy.restart_policy` when both
 	/// are set.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub restart: Option<RestartPolicy>,
-	/// `stop_signal:` — signal sent to stop the container (e.g. `SIGTERM`,
+	/// `stop_signal:` is the signal sent to stop the container (e.g. `SIGTERM`,
 	/// `SIGINT`); default `SIGTERM`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_signal: Option<String>,
-	/// `stop_grace_period:` — duration string (e.g. `10s`, `1m30s`) to wait after
+	/// `stop_grace_period:` is the duration string (e.g. `10s`, `1m30s`) to wait after
 	/// `stop_signal` before `SIGKILL`; default `10s`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stop_grace_period: Option<String>,
-	/// `profiles:` — activation profiles; the service starts only when one of
+	/// `profiles:` lists activation profiles; the service starts only when one of
 	/// these profiles is enabled (no profiles = always enabled).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub profiles: Vec<String>,
-	/// `post_start:` — lifecycle hook commands run inside the container right
+	/// `post_start:` holds lifecycle hook commands run inside the container right
 	/// after it starts (Compose v2.30+).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub post_start: Vec<LifecycleHook>,
-	/// `pre_stop:` — lifecycle hook commands run inside the container just before
+	/// `pre_stop:` holds lifecycle hook commands run inside the container just before
 	/// it is stopped (Compose v2.30+).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub pre_stop: Vec<LifecycleHook>,
 
-	/// `labels:` — metadata labels applied to the container; map or `key=value`
+	/// `labels:` holds metadata labels applied to the container; map or `key=value`
 	/// list.
 	#[serde(default)]
 	pub labels: Labels,
-	/// `annotations:` — OCI annotations on the container; distinct from `labels:`,
+	/// `annotations:` holds OCI annotations on the container; distinct from `labels:`,
 	/// passed through to the runtime.
 	#[serde(default)]
 	pub annotations: Labels,
-	/// `container_name:` — explicit container name overriding the generated
+	/// `container_name:` is an explicit container name overriding the generated
 	/// `<project>_<service>_<n>`; forbids scaling above 1 replica.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub container_name: Option<String>,
-	/// `user:` — user (and optional `:group`) the process runs as, by name or
+	/// `user:` is the user (and optional `:group`) the process runs as, by name or
 	/// numeric `UID[:GID]`; overrides the image `USER`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub user: Option<String>,
-	/// `working_dir:` — working directory for the process; overrides the image
+	/// `working_dir:` is the working directory for the process; overrides the image
 	/// `WORKDIR`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub working_dir: Option<String>,
-	/// `group_add:` — additional groups (name or GID) the process joins, beyond
+	/// `group_add:` lists additional groups (name or GID) the process joins, beyond
 	/// its primary group.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub group_add: Vec<String>,
-	/// `platform:` — target platform for the image (`os[/arch[/variant]]`, e.g.
+	/// `platform:` is the target platform for the image (`os[/arch[/variant]]`, e.g.
 	/// `linux/amd64`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub platform: Option<String>,
 
-	/// `cap_add:` — Linux capabilities to grant on top of the runtime default set
+	/// `cap_add:` lists Linux capabilities to grant on top of the runtime default set
 	/// (e.g. `NET_ADMIN`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_add: Vec<String>,
-	/// `cap_drop:` — Linux capabilities to drop from the default set (`ALL` drops
+	/// `cap_drop:` lists Linux capabilities to drop from the default set (`ALL` drops
 	/// every capability).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub cap_drop: Vec<String>,
-	/// `security_opt:` — runtime security options (e.g. `label:...`, `seccomp=...`,
+	/// `security_opt:` lists runtime security options (e.g. `label:...`, `seccomp=...`,
 	/// `no-new-privileges:true`, `apparmor=...`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub security_opt: Vec<String>,
-	/// `read_only:` — when `true`, mounts the container's root filesystem
+	/// `read_only:`, when `true`, mounts the container's root filesystem
 	/// read-only (writes only via volumes/tmpfs). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub read_only: Option<bool>,
-	/// `privileged:` — when `true`, grants extended host privileges; has reduced
+	/// `privileged:`, when `true`, grants extended host privileges; has reduced
 	/// effect under rootless Podman. Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub privileged: Option<bool>,
-	/// `init:` — when `true`, runs an init process (PID 1) that reaps zombies and
+	/// `init:`, when `true`, runs an init process (PID 1) that reaps zombies and
 	/// forwards signals. Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub init: Option<bool>,
-	/// `tty:` — when `true`, allocates a pseudo-TTY for the container (akin to
+	/// `tty:`, when `true`, allocates a pseudo-TTY for the container (akin to
 	/// `docker run -t`). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub tty: Option<bool>,
-	/// `stdin_open:` — when `true`, keeps stdin open for the container (akin to
+	/// `stdin_open:`, when `true`, keeps stdin open for the container (akin to
 	/// `docker run -i`). Default `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stdin_open: Option<bool>,
 
-	/// `runtime:` — OCI runtime to execute the container (e.g. `runc`, `crun`);
+	/// `runtime:` is the OCI runtime to execute the container (e.g. `runc`, `crun`);
 	/// default is the engine's configured runtime.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub runtime: Option<String>,
-	/// `shm_size:` — size of `/dev/shm` as a size string (e.g. `512m`, `1g`);
+	/// `shm_size:` is the size of `/dev/shm` as a size string (e.g. `512m`, `1g`);
 	/// bytes if unitless.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub shm_size: Option<String>,
-	/// `userns_mode:` — user-namespace mode (e.g. `host`, `keep-id`) controlling
+	/// `userns_mode:` is the user-namespace mode (e.g. `host`, `keep-id`) controlling
 	/// UID/GID mapping into the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub userns_mode: Option<String>,
-	/// `pid:` — PID namespace to share (e.g. `host`, `container:NAME`,
+	/// `pid:` is the PID namespace to share (e.g. `host`, `container:NAME`,
 	/// `service:NAME`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pid: Option<String>,
-	/// `ipc:` — IPC namespace mode (e.g. `host`, `shareable`, `service:NAME`,
+	/// `ipc:` is the IPC namespace mode (e.g. `host`, `shareable`, `service:NAME`,
 	/// `container:NAME`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub ipc: Option<String>,
-	/// `uts:` — UTS namespace mode; `host` shares the host's hostname/domain
+	/// `uts:` is the UTS namespace mode; `host` shares the host's hostname/domain
 	/// namespace.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub uts: Option<String>,
-	/// `cgroup_parent:` — optional parent cgroup under which the container's
+	/// `cgroup_parent:` is the optional parent cgroup under which the container's
 	/// cgroup is created.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup_parent: Option<String>,
-	/// `cgroup:` — cgroup namespace mode (`host` or `private`) for the container.
+	/// `cgroup:` is the cgroup namespace mode (`host` or `private`) for the container.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cgroup: Option<String>,
 
-	/// `devices:` — host devices exposed to the container
+	/// `devices:` lists host devices exposed to the container
 	/// (`host[:container[:perms]]`, perms a subset of `rwm`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub devices: Vec<String>,
-	/// `device_cgroup_rules:` — explicit device cgroup allow/deny rules (e.g.
+	/// `device_cgroup_rules:` lists explicit device cgroup allow/deny rules (e.g.
 	/// `c 1:3 mr`).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub device_cgroup_rules: Vec<String>,
-	/// `storage_opt:` — per-container storage driver options (e.g. `size`) passed
+	/// `storage_opt:` holds per-container storage driver options (e.g. `size`) passed
 	/// to the graph driver.
 	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
 	pub storage_opt: HashMap<String, String>,
 
-	/// `scale:` — number of replica containers to run. Takes precedence over
+	/// `scale:` is the number of replica containers to run. Takes precedence over
 	/// `deploy.replicas`; a CLI `--scale` override wins over both.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub scale: Option<u32>,
-	/// `cpu_shares:` — relative CPU weight under contention (default `1024`);
+	/// `cpu_shares:` is the relative CPU weight under contention (default `1024`);
 	/// proportional share, not a hard cap like `cpus:`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_shares: Option<u64>,
-	/// `cpu_quota:` — CFS hard cap in microseconds of CPU time per `cpu_period`;
+	/// `cpu_quota:` is the CFS hard cap in microseconds of CPU time per `cpu_period`;
 	/// `cpus:` is the higher-level equivalent.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_quota: Option<i64>,
-	/// `cpu_period:` — CFS scheduler period in microseconds against which
+	/// `cpu_period:` is the CFS scheduler period in microseconds against which
 	/// `cpu_quota` is measured (default `100000`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_period: Option<u64>,
-	/// `cpuset:` — explicit CPUs/cores the container may run on (e.g. `0-3`,
+	/// `cpuset:` names the explicit CPUs/cores the container may run on (e.g. `0-3`,
 	/// `0,2`).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpuset: Option<String>,
-	/// `cpus:` — fractional number of CPUs to allow (e.g. `0.5`); a hard cap
+	/// `cpus:` is the fractional number of CPUs to allow (e.g. `0.5`); a hard cap
 	/// converted to a CFS quota. Top-level value wins over `deploy.resources`.
 	/// Accepts both the unquoted number (`cpus: 0.5`) and the quoted string form.
 	#[serde(
@@ -301,115 +301,115 @@ pub struct Service {
 		skip_serializing_if = "Option::is_none"
 	)]
 	pub cpus: Option<String>,
-	/// `cpu_count:` — number of usable CPUs (Windows containers); not honored on
+	/// `cpu_count:` is the number of usable CPUs (Windows containers); not honored on
 	/// Linux/Podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_count: Option<i64>,
-	/// `cpu_percent:` — usable percentage of available CPU (Windows containers);
+	/// `cpu_percent:` is the usable percentage of available CPU (Windows containers);
 	/// not honored on Linux/Podman.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_percent: Option<i64>,
-	/// `cpu_rt_runtime:` — real-time CPU runtime per period in microseconds for
+	/// `cpu_rt_runtime:` is the real-time CPU runtime per period in microseconds for
 	/// real-time scheduling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_rt_runtime: Option<i64>,
-	/// `cpu_rt_period:` — real-time scheduler period in microseconds for
+	/// `cpu_rt_period:` is the real-time scheduler period in microseconds for
 	/// real-time scheduling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cpu_rt_period: Option<i64>,
-	/// `mem_limit:` — hard memory cap as a size string (e.g. `512m`, `1g`); bytes
+	/// `mem_limit:` is the hard memory cap as a size string (e.g. `512m`, `1g`); bytes
 	/// if unitless. Top-level value wins over `deploy.resources.limits.memory`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_limit: Option<String>,
-	/// `memswap_limit:` — total memory + swap limit as a size string; `-1` allows
+	/// `memswap_limit:` is the total memory + swap limit as a size string; `-1` allows
 	/// unlimited swap.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub memswap_limit: Option<String>,
-	/// `mem_reservation:` — soft memory limit (size string, e.g. `256m`) enforced
+	/// `mem_reservation:` is the soft memory limit (size string, e.g. `256m`) enforced
 	/// under host memory pressure; must be below `mem_limit`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_reservation: Option<String>,
-	/// `mem_swappiness:` — swap tendency for the container's memory, `0`–`100`.
+	/// `mem_swappiness:` is the swap tendency for the container's memory, `0`–`100`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub mem_swappiness: Option<i64>,
-	/// `pids_limit:` — maximum number of PIDs the container may create; `-1` for
+	/// `pids_limit:` is the maximum number of PIDs the container may create; `-1` for
 	/// unlimited. Top-level value wins over `deploy.resources.limits.pids`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pids_limit: Option<i64>,
-	/// `oom_kill_disable:` — when `true`, disables the OOM killer for the
+	/// `oom_kill_disable:`, when `true`, disables the OOM killer for the
 	/// container; not supported on cgroups v2.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_kill_disable: Option<bool>,
-	/// `oom_score_adj:` — OOM-killer preference (`-1000`..`1000`); higher makes
+	/// `oom_score_adj:` is the OOM-killer preference (`-1000`..`1000`); higher makes
 	/// the container likelier to be killed first.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub oom_score_adj: Option<i64>,
-	/// `blkio_config:` — block-IO weights and per-device read/write bandwidth and
+	/// `blkio_config:` holds block-IO weights and per-device read/write bandwidth and
 	/// IOPS limits.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub blkio_config: Option<BlkioConfig>,
 
-	/// `logging:` — log driver and its options for the container's stdout/stderr.
+	/// `logging:` is the log driver and its options for the container's stdout/stderr.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub logging: Option<LoggingConfig>,
-	/// `sysctls:` — kernel parameters set in the container's namespace (e.g.
+	/// `sysctls:` sets kernel parameters in the container's namespace (e.g.
 	/// `net.core.somaxconn`); map or list form.
 	#[serde(default)]
 	pub sysctls: Sysctls,
-	/// `ulimits:` — per-resource process limits (e.g. `nofile`) as a single
+	/// `ulimits:` sets per-resource process limits (e.g. `nofile`) as a single
 	/// value or `{soft, hard}` pair, keyed by limit name.
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub ulimits: IndexMap<String, UlimitConfig>,
 
-	/// `label_file:` — file(s) of `key=value` lines loaded as container labels;
+	/// `label_file:` names file(s) of `key=value` lines loaded as container labels;
 	/// single path or list (Compose v2.32+).
 	#[serde(default)]
 	pub label_file: StringOrList,
 
-	/// `attach:` — when `false`, `up` does not stream this service's logs to the
+	/// `attach:`, when `false`, stops `up` streaming this service's logs to the
 	/// console. Default `true`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attach: Option<bool>,
 
-	/// `pull_policy:` — when to pull the image: `always`, `never`, `missing` (the
+	/// `pull_policy:` decides when to pull the image: `always`, `never`, `missing` (the
 	/// default; alias `if_not_present`), `build`, or `newer`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub pull_policy: Option<String>,
 
-	/// `deploy:` — deployment config (replicas, resource limits/reservations,
+	/// `deploy:` is the deployment config (replicas, resource limits/reservations,
 	/// restart policy); a fallback for top-level `scale`/`cpus`/`mem_limit`/
 	/// `restart` and the source of Swarm-only fields.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub deploy: Option<DeployConfig>,
 
-	/// `develop:` — `watch` rules driving file-sync/rebuild during development.
+	/// `develop:` holds the `watch` rules driving file-sync/rebuild during development.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub develop: Option<DevelopConfig>,
 
-	/// `gpus:` — GPU devices to expose (`all` or a capability/count spec),
+	/// `gpus:` lists GPU devices to expose (`all` or a capability/count spec),
 	/// forwarded as CDI device reservations.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub gpus: Option<GpuSpec>,
 
-	/// `credential_spec:` — Windows managed-service-account credential source
+	/// `credential_spec:` is the Windows managed-service-account credential source
 	/// (`config`/`file`/`registry`). Parsed for fidelity; podup has no rootless
 	/// Podman equivalent, so the diagnostics pass reports it as not honored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub credential_spec: Option<CredentialSpec>,
 
-	/// `isolation:` — container isolation technology (e.g. `default`, `process`,
+	/// `isolation:` is the container isolation technology (e.g. `default`, `process`,
 	/// `hyperv`). Distinct from `build.isolation`. Parsed for fidelity; podup has
 	/// no rootless Podman equivalent, so it is reported as not honored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub isolation: Option<String>,
 
-	/// `provider:` (Compose v2.36) — delegates the service lifecycle to an
+	/// `provider:` (Compose v2.36) delegates the service lifecycle to an
 	/// external provider plugin. Parsed for fidelity; podup invokes no provider
 	/// plugins, so it is reported as not honored.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub provider: Option<ProviderConfig>,
 
-	/// `use_api_socket:` (Compose v2.37.1) — bind-mount the Docker API socket and
+	/// `use_api_socket:` (Compose v2.37.1) bind-mounts the Docker API socket and
 	/// forward credentials into the container. Parsed for fidelity; podup has no
 	/// equivalent, so it is reported as not honored.
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -492,20 +492,20 @@ impl Service {
 	}
 }
 
-/// `credential_spec:` — source of a Windows managed-service-account credential
+/// `credential_spec:` is the source of a Windows managed-service-account credential
 /// spec. Exactly one of `config`/`file`/`registry` is expected per the Compose
 /// Spec; podup parses all three for fidelity but honors none.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct CredentialSpec {
-	/// `config:` — ID of a Compose config object holding the credential spec.
+	/// `config:` is the ID of a Compose config object holding the credential spec.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub config: Option<String>,
-	/// `file:` — path to a credential-spec file, relative to the Docker data
+	/// `file:` is the path to a credential-spec file, relative to the Docker data
 	/// directory.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub file: Option<String>,
-	/// `registry:` — Windows registry value name holding the credential spec.
+	/// `registry:` is the Windows registry value name holding the credential spec.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub registry: Option<String>,
 	/// Forward-compatible keys captured so a typo is surfaced rather than dropped.
@@ -513,16 +513,16 @@ pub struct CredentialSpec {
 	pub unknown: IndexMap<String, serde_yaml::Value>,
 }
 
-/// `provider:` (Compose v2.36) — names an external provider plugin (`type`) and
+/// `provider:` (Compose v2.36) names an external provider plugin (`type`) and
 /// its free-form `options`. Parsed for fidelity; podup invokes no providers.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[non_exhaustive]
 pub struct ProviderConfig {
-	/// `type:` — name of the external provider plugin to delegate the service
+	/// `type:` is the name of the external provider plugin to delegate the service
 	/// lifecycle to.
 	#[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
 	pub provider_type: Option<String>,
-	/// `options:` — free-form provider-specific parameters passed through to the
+	/// `options:` holds free-form provider-specific parameters passed through to the
 	/// plugin.
 	#[serde(default, skip_serializing_if = "IndexMap::is_empty")]
 	pub options: IndexMap<String, serde_yaml::Value>,

--- a/internal/compose/types/volume.rs
+++ b/internal/compose/types/volume.rs
@@ -46,7 +46,7 @@ pub struct BindOptions {
 	pub selinux: Option<String>,
 }
 
-/// Sub-options for a `volume`-type mount — nocopy flag and optional driver config.
+/// Sub-options for a `volume`-type mount: nocopy flag and optional driver config.
 ///
 /// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
 #[non_exhaustive]
@@ -69,7 +69,7 @@ pub struct VolumeOptions {
 	/// A podup extension, like its two siblings below: the Compose
 	/// Specification defines no per-mount hardening flags on the long form,
 	/// while the short form has always carried them as raw mount options
-	/// (`cache:/app/cache:noexec`). The long form deserved the same reach —
+	/// (`cache:/app/cache:noexec`). The long form deserved the same reach:
 	/// these are the standard mount-hardening trio, and a compose file that
 	/// spells a mount out longhand should not lose them (#1160).
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -96,7 +96,7 @@ pub struct DriverConfig {
 	pub options: HashMap<String, String>,
 }
 
-/// Sub-options for a `tmpfs`-type mount — size and mode.
+/// Sub-options for a `tmpfs`-type mount: size and mode.
 ///
 /// `#[non_exhaustive]` (3.0.0): see [`BindOptions`].
 #[non_exhaustive]
@@ -172,7 +172,7 @@ fn int_mode_bits(n: u32) -> u32 {
 	u32::from_str_radix(&n.to_string(), 8).unwrap_or(n)
 }
 
-/// A volume mount entry — either a short-form string or a long-form typed block.
+/// A volume mount entry: either a short-form string or a long-form typed block.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
@@ -184,7 +184,7 @@ pub enum VolumeMount {
 		/// Mount type selecting which options block applies.
 		#[serde(rename = "type")]
 		volume_type: VolumeType,
-		/// Mount source — host path, volume name, or omitted for anonymous/tmpfs.
+		/// Mount source: host path, volume name, or omitted for anonymous/tmpfs.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		source: Option<String>,
 		/// Mount target path inside the container.
@@ -248,7 +248,7 @@ pub struct VolumeConfig {
 	pub unknown: indexmap::IndexMap<String, serde_yaml::Value>,
 }
 
-/// Reference to a named config from a service — short form (name only) or long form with mount target.
+/// Reference to a named config from a service: short form (name only) or long form with mount target.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceConfigRef {
@@ -297,7 +297,7 @@ impl ServiceConfigRef {
 	}
 }
 
-/// Reference to a named secret from a service — short form (name only) or long form with mount target.
+/// Reference to a named secret from a service: short form (name only) or long form with mount target.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum ServiceSecretRef {

--- a/internal/compose/validate.rs
+++ b/internal/compose/validate.rs
@@ -31,7 +31,7 @@ use crate::ports::parse_ports;
 /// required dependency. Returns the first violation found.
 pub fn validate_config(file: &ComposeFile) -> Result<()> {
 	// An empty file, a missing `services:` key, or `services: {}` is not a valid
-	// project — `docker compose config` errors with "no service selected".
+	// project; `docker compose config` errors with "no service selected".
 	if file.services.is_empty() {
 		return Err(ComposeError::Unsupported(
 			"no services defined in compose file".to_string(),

--- a/internal/dispatch.rs
+++ b/internal/dispatch.rs
@@ -14,7 +14,7 @@ use crate::cli::*;
 /// Clone the compose file keeping only services in an active profile, plus any
 /// named on the command line (which activates their profile). Used by the
 /// per-service subcommands so they target exactly the set `up`/`create` would
-/// bring up — never a service hidden behind an inactive profile.
+/// bring up, never a service hidden behind an inactive profile.
 fn profile_filtered(
 	file: &podup::compose::types::ComposeFile,
 	profile: &[String],
@@ -107,7 +107,7 @@ pub(crate) async fn dispatch(
 			// means "return once the services are up", so attaching afterwards
 			// would block forever on a command whose whole point is to finish.
 			// Measured against v5.1.3 on the same socket: `docker compose up
-			// --wait` exits 0, and `podup up --wait` hung until killed — which is
+			// --wait` exits 0, and `podup up --wait` hung until killed, which is
 			// the canonical health-gated CI idiom, so it hung the job.
 			if watch {
 				engine.watch(file).await?;
@@ -149,7 +149,7 @@ pub(crate) async fn dispatch(
 				// Same ordering rule as the abort above: reported after the
 				// teardown, never instead of it. docker compose exits 1 when an
 				// attached stream dies with the container still running, and we
-				// exited 0 — measured on 5.4.2 by restarting the libpod socket
+				// exited 0, measured on 5.4.2 by restarting the libpod socket
 				// underneath an attached `up`.
 				match outcome {
 					podup::AttachOutcome::Aborted => {}
@@ -276,7 +276,7 @@ pub(crate) async fn dispatch(
 			// `-s/--stop` gracefully stops the targets first so they can be
 			// removed without `--force`.
 			// A paused container cannot be stopped (Podman rejects it with a raw
-			// state error), so resume it first — matching `docker compose rm
+			// state error), so resume it first, matching `docker compose rm
 			// -s`. `unpause` is idempotent, so this is a no-op when not paused.
 			if stop {
 				engine.unpause_paused(file, &services).await?;

--- a/internal/dispatch/rest_tests.rs
+++ b/internal/dispatch/rest_tests.rs
@@ -2,7 +2,7 @@ use super::cli_logs_tail_default;
 
 /// The CLI default is bounded. Without `--tail`, the dispatch substitutes
 /// the constant so the wire query carries `&tail=100`. Library callers that
-/// build `LogsOptions` directly keep `None` (= all) — see the issue.
+/// build `LogsOptions` directly keep `None` (= all); see the issue.
 #[test]
 fn cli_logs_tail_default_substitutes_the_bounded_default_when_missing() {
 	assert_eq!(cli_logs_tail_default(None).as_deref(), Some("100"));

--- a/internal/dotenv.rs
+++ b/internal/dotenv.rs
@@ -22,7 +22,7 @@ pub fn parse(content: &str) -> Vec<(String, String)> {
 ///
 /// Used for explicitly requested env files (`--env-file`, a service `env_file:`)
 /// where a typo'd or truncated file must fail loudly rather than silently drop
-/// variables — matching docker compose, which hard-errors on an unterminated
+/// variables, matching docker compose, which hard-errors on an unterminated
 /// quoted value.
 pub fn parse_strict(content: &str) -> crate::error::Result<Vec<(String, String)>> {
 	parse_inner(content, true)

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -27,8 +27,8 @@ fn append_context<W: std::io::Write>(
 	force_include: &[&str],
 ) -> Result<()> {
 	// Do not dereference symlinks: a symlink in the context would otherwise pack
-	// the bytes of its (possibly out-of-context) target — e.g. `/etc/hostname` or
-	// an SSH key — into the image. Store the link itself instead, matching the
+	// the bytes of its (possibly out-of-context) target, e.g. `/etc/hostname` or
+	// an SSH key, into the image. Store the link itself instead, matching the
 	// watch-sync and cp paths.
 	tar.follow_symlinks(false);
 	for abs in walk::walk_dir(context).map_err(ComposeError::Io)? {
@@ -41,7 +41,7 @@ fn append_context<W: std::io::Write>(
 		}
 		// The active Dockerfile is always sent to the builder even when
 		// `.dockerignore` would match it: Docker keeps the Dockerfile (and
-		// `.dockerignore`) available for the build itself — they just can't be
+		// `.dockerignore`) available for the build itself; they just can't be
 		// COPY'd into the image. Without this, a `.dockerignore` listing
 		// `Dockerfile` (or a blanket `*`) drops it from the context tar and the
 		// build fails with "stat .../Dockerfile: no such file or directory".
@@ -266,7 +266,7 @@ pub(super) fn map_additional_context(base_dir: &Path, value: &str) -> String {
 /// the context directory, podman build reads its contents. […] if both are in
 /// the context directory, podman build only uses `.containerignore`."
 ///
-/// So exactly one file applies — never the union. Applying both client-side
+/// So exactly one file applies, never the union. Applying both client-side
 /// produced an image missing content that `podman build` puts in, because we
 /// filtered by `.dockerignore` (a file podman would have ignored entirely) and
 /// the server then filtered by `.containerignore`.
@@ -348,7 +348,7 @@ fn glob_rec(pat: &[u8], s: &[u8]) -> bool {
 	if pat.is_empty() {
 		return s.is_empty();
 	}
-	// `**` — matches across `/` boundaries.
+	// `**` matches across `/` boundaries.
 	if pat.starts_with(b"**") {
 		let mut rest = &pat[2..];
 		// `**/` may also match zero directories, so `**/foo` matches top-level `foo`.

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -111,7 +111,7 @@ fn inline_tar_excludes_build_secrets_via_dockerignore() {
 	for entry in archive.entries().unwrap() {
 		let mut entry = entry.unwrap();
 		// No user ignore file in this context, so the synthesized one is
-		// written as `.containerignore` — the name podman prefers, so a
+		// written as `.containerignore`, the name podman prefers, so a
 		// stray `.dockerignore` cannot shadow our exclusions.
 		if entry.path().unwrap().to_string_lossy() == ".containerignore" {
 			entry.read_to_string(&mut di).unwrap();
@@ -133,7 +133,7 @@ fn dockerfile_is_force_included_despite_dockerignore() {
 	use std::io::Read;
 
 	// A `.dockerignore` that matches the Dockerfile (here a blanket `*`) must
-	// not drop it from the context tar — Docker keeps the active Dockerfile
+	// not drop it from the context tar; Docker keeps the active Dockerfile
 	// available to the builder regardless. Without the force-include the build
 	// fails with "stat .../Dockerfile: no such file or directory".
 	let dir = tempdir().unwrap();
@@ -377,7 +377,7 @@ fn inline_dockerfile_excluded_via_dockerignore() {
 	for entry in archive.entries().unwrap() {
 		let mut entry = entry.unwrap();
 		// No user ignore file in this context, so the synthesized one is
-		// written as `.containerignore` — the name podman prefers, so a
+		// written as `.containerignore`, the name podman prefers, so a
 		// stray `.dockerignore` cannot shadow our exclusions.
 		if entry.path().unwrap().to_string_lossy() == ".containerignore" {
 			entry.read_to_string(&mut di).unwrap();
@@ -502,7 +502,7 @@ fn glob_match_question_mark_matches_single_non_slash_char() {
 /// #1096: with both ignore files present, only `.containerignore` may filter the
 /// context tar. Applying both client-side is what made podup ship an image
 /// missing content that `podman build` includes: we dropped `b.txt` per
-/// `.dockerignore` — a file podman ignores entirely here — and the server then
+/// `.dockerignore` (a file podman ignores entirely here) and the server then
 /// dropped `a.txt` per `.containerignore`, so the union of both applied.
 #[test]
 fn context_tar_filters_by_containerignore_only_when_both_exist() {

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -3,7 +3,7 @@
 //! [`Engine::pull_image`] fetches a pre-built image from a registry.
 //! [`Engine::build_service`] compiles a build context tar, passes it to the
 //! Podman libpod API, and applies any extra tags. Multi-stage targets are
-//! passed as the `target=` query parameter — the full Dockerfile is always sent.
+//! passed as the `target=` query parameter; the full Dockerfile is always sent.
 
 mod context;
 mod pull;
@@ -37,7 +37,7 @@ type ResolvedBuildSecrets = (Vec<(String, Vec<u8>)>, Vec<String>);
 
 /// How `build_service` sends the context to the libpod build endpoint.
 enum BodyPlan {
-	/// A Git/URL context — Podman clones it server-side, so the body is empty.
+	/// A Git/URL context: Podman clones it server-side, so the body is empty.
 	Empty,
 	/// A local context, streamed to the socket from a `spawn_blocking` tar writer
 	/// so its size never drives the process's RSS.
@@ -122,7 +122,7 @@ impl BuildOptions {
 /// build saw 524288, with `ulimits=["nofile=1234:1234"]` it saw 1234.
 ///
 /// An unrecognised name is dropped rather than forwarded. The value reaches a
-/// query string, so an unknown name is either a typo or an injection attempt —
+/// query string, so an unknown name is either a typo or an injection attempt,
 /// the same reasoning the container-side `build_ulimits` applies.
 fn render_build_ulimits(build: &BuildConfig) -> Vec<String> {
 	build

--- a/internal/engine/build/pull.rs
+++ b/internal/engine/build/pull.rs
@@ -104,8 +104,8 @@ impl Engine {
 	/// the engine's pull-policy override (see [`Engine::with_up_overrides`]).
 	///
 	/// Services that agree on every field that shapes the actual pull
-	/// request — the image reference, the *resolved* pull policy (override
-	/// applied), and the platform — pull it once, not once per service. Two
+	/// request (the image reference, the *resolved* pull policy with the
+	/// override applied, and the platform) pull it once, not once per service. Two
 	/// services naming the same image but differing on the resolved policy
 	/// or the platform each get their own pull, so per-service intent (e.g.
 	/// one `never`, one `always`) is never silently collapsed onto whichever
@@ -135,8 +135,8 @@ impl Engine {
 			(false, false) => Some(services.iter().cloned().collect()),
 		};
 
-		// Every service this pull pass covers, in file order — kept so the
-		// per-service reporting loop below stays deterministic — paired with
+		// Every service this pull pass covers, in file order, kept so the
+		// per-service reporting loop below stays deterministic, paired with
 		// the key that determines its actual pull request: the image
 		// reference, the *resolved* pull policy (the `--pull` override
 		// applied ahead of the service's own `pull_policy:`, see
@@ -206,14 +206,14 @@ impl Engine {
 		// Dedup by that key: 50 services agreeing on image, resolved policy
 		// and platform must issue one pull, not 50. Two services naming the
 		// same image with a different resolved policy or platform get their
-		// own key, and so their own pull — one representative service per
+		// own key, and so their own pull; one representative service per
 		// unique key is enough to issue it.
 		let mut representative: HashMap<PullKey<'a>, &'a Service> = HashMap::new();
 		for (_, service, key) in candidates {
 			representative.entry(*key).or_insert(service);
 		}
 
-		// Pull each unique key once, bounded, and record its outcome — the
+		// Pull each unique key once, bounded, and record its outcome: the
 		// same present/error pair the per-service loop used to compute for
 		// itself, now shared by every service that agrees on image, resolved
 		// policy and platform.
@@ -247,7 +247,7 @@ impl Engine {
 			// Presence alone is not success. A stale copy of the image already in
 			// local storage makes the probe pass while the pull actually failed,
 			// so `pull` against an unreachable registry exited 0 and reported
-			// nothing — the same way `up --pull always` did (#1076). The pull
+			// nothing, the same way `up --pull always` did (#1076). The pull
 			// having reported an error is decisive; the probe only covers the
 			// case where it reported nothing and the image still is not there.
 			if present && pull_err.is_none() {
@@ -255,8 +255,8 @@ impl Engine {
 			}
 			if opts.ignore_failures {
 				match &pull_err {
-					Some(e) => tracing::warn!("pull {name} ({image}) failed — ignored: {e}"),
-					None => tracing::warn!("pull {name} ({image}) failed — ignored"),
+					Some(e) => tracing::warn!("pull {name} ({image}) failed, ignored: {e}"),
+					None => tracing::warn!("pull {name} ({image}) failed, ignored"),
 				}
 			} else {
 				let detail = pull_err.map(|e| format!(": {e}")).unwrap_or_default();
@@ -301,7 +301,7 @@ impl Engine {
 	/// value is rejected via [`pull_policy_checked`]. Shared by
 	/// [`Self::pull_image`] and by the standalone-pull fan-out's dedup key
 	/// ([`Self::pull_services_with_options`]), so both agree on exactly the
-	/// same resolved value — an override collapses the dedup (every service
+	/// same resolved value: an override collapses the dedup (every service
 	/// resolves to the same policy), while differing per-service policies
 	/// (no override set) keep it split.
 	///
@@ -323,8 +323,8 @@ impl Engine {
 
 	/// Issue the actual pull request for `service` against an
 	/// already-resolved `pull_policy` (see [`Self::resolved_pull_policy`]).
-	/// Split out of [`Self::pull_image`] so the standalone-pull fan-out —
-	/// which must resolve the policy anyway to compute its dedup key — can
+	/// Split out of [`Self::pull_image`] so the standalone-pull fan-out,
+	/// which must resolve the policy anyway to compute its dedup key, can
 	/// reuse that value instead of resolving (and potentially re-warning
 	/// about an unrecognized one) a second time.
 	async fn pull_image_with_policy(
@@ -341,7 +341,7 @@ impl Engine {
 		// Through the progress layer, not a bare `eprintln!`. This was the one
 		// user-facing line in the binary that bypassed `ui` entirely, so it
 		// ignored `PROGRESS_ENABLED` and an embedder that asked podup to stay
-		// silent got it anyway — and there was never a matching `Pulled`, so a
+		// silent got it anyway, and there was never a matching `Pulled`, so a
 		// pull that finished looked exactly like one that hung.
 		if quiet {
 			debug!("pulling {image}");
@@ -580,7 +580,7 @@ pub(in crate::engine) fn libpod_pull_policy(policy: Option<&str>) -> Option<&'st
 /// `--pull` override (no service context). The rejected value lands in the
 /// error so a typo'd `pull_policy: alaways` on a specific service is reported
 /// as `service.<name>: pull_policy: unknown pull policy "alaways" (value:
-/// alaways)` — the actionable bit is which service and which value, not the
+/// alaways)`: the actionable bit is which service and which value, not the
 /// abstract policy name.
 pub(in crate::engine) fn pull_policy_checked(
 	policy: Option<&str>,

--- a/internal/engine/build/pull_tests.rs
+++ b/internal/engine/build/pull_tests.rs
@@ -231,7 +231,7 @@ async fn pull_dedupes_a_shared_image_into_a_single_pull() {
 
 /// Two services sharing an image but with *different* resolved pull
 /// policies (no `--pull` override) must each get their own pull request,
-/// not collapse into one — the dedup key must include the resolved
+/// not collapse into one: the dedup key must include the resolved
 /// policy, not just the image reference.
 #[tokio::test]
 #[cfg(unix)]
@@ -276,7 +276,7 @@ async fn pull_issues_separate_requests_for_same_image_different_policy() {
 }
 
 /// A shared image that fails to pull must still be reported for *every*
-/// service that names it — derived from the one shared outcome, not from
+/// service that names it, derived from the one shared outcome, not from
 /// a redundant pull per service. `ignore_failures` lets both warnings
 /// through instead of aborting on the first.
 #[tokio::test]
@@ -313,7 +313,7 @@ async fn pull_failure_on_a_shared_image_is_still_only_pulled_once() {
 }
 
 /// Without `ignore_failures`, a shared image that never lands must still
-/// abort the whole pull — the per-service error report is derived from
+/// abort the whole pull: the per-service error report is derived from
 /// the image's single shared outcome, so the failure is not silently
 /// dropped for services 2..N once service 1 already reported it.
 #[tokio::test]
@@ -347,7 +347,7 @@ async fn pull_failure_on_a_shared_image_aborts_without_ignore_failures() {
 // fan-out's `join_bounded` uses (see `parallel::tests::
 // join_bounded_preserves_input_order`), and a synchronous fake responder
 // cannot observe real concurrency without a multi-thread runtime and a
-// blocking rendezvous — exactly the flakiness the testing standard rules
+// blocking rendezvous, exactly the flakiness the testing standard rules
 // out. The dedup tests above already pin the dispatch contract (every
 // unique image is attempted, exactly once).
 
@@ -355,7 +355,7 @@ async fn pull_failure_on_a_shared_image_aborts_without_ignore_failures() {
 /// response. That line used to be warned about and dropped, so every caller
 /// believed the pull had succeeded.
 ///
-/// The image is present here — a stale copy from an earlier pull — which is
+/// The image is present here (a stale copy from an earlier pull) which is
 /// exactly the case a presence probe cannot catch: it passes while the pull
 /// failed. `up --pull always` against an unreachable registry therefore
 /// started yesterday's image and exited 0.

--- a/internal/engine/build/pull_typo_tests.rs
+++ b/internal/engine/build/pull_typo_tests.rs
@@ -1,11 +1,11 @@
-//! Targeted regression for #1450 — the standalone `pull` path used to panic
+//! Targeted regression for #1450: the standalone `pull` path used to panic
 //! on a typo'd `pull_policy:` because the dedup pass unwrapped
 //! `resolved_pull_policy` with an `.expect` whose invariant only held for
 //! `up`. Split out so adding this test does not push `build/pull.rs` over the
 //! source-line limit; the production fix lives there.
 
 /// Standalone `pull` must surface a typo'd `pull_policy:` as a structured
-/// `PodmanError::Field` carrying the offending service and value — the same
+/// `PodmanError::Field` carrying the offending service and value, the same
 /// shape `up` uses after #1443. Before the fix the dedup pass unwrapped
 /// `resolved_pull_policy` with `.expect`, so the binary panicked on every
 /// typo and the worker-thread death produced a second `internal error` from

--- a/internal/engine/build/push.rs
+++ b/internal/engine/build/push.rs
@@ -168,7 +168,7 @@ impl Engine {
 				failed += 1;
 			}
 			// `build.tags` is locally retagged by `apply_extra_tags` after the
-			// build. Push each one too — the registry would otherwise end up
+			// build. Push each one too; the registry would otherwise end up
 			// with only the primary `image`, and the other refs a user expects
 			// to deploy would never be published (#1476).
 			if let Some(build) = &service.build {
@@ -218,7 +218,7 @@ impl Engine {
 	///
 	/// The two user-facing lines go through `ui::progress_line`, not `tracing`.
 	/// They were `info!` until #1248, and the CLI floors tracing at `warn`
-	/// everywhere except `watch` — so a successful `podup push` wrote **zero
+	/// everywhere except `watch`, so a successful `podup push` wrote **zero
 	/// bytes** to stdout and stderr while the image really did land in the
 	/// registry, and `--quiet` suppressed output that never appeared. Routing
 	/// through the progress layer also honours `PROGRESS_ENABLED`, which is the

--- a/internal/engine/build/push_tests.rs
+++ b/internal/engine/build/push_tests.rs
@@ -33,7 +33,7 @@ async fn drain_surfaces_mid_stream_error_line() {
 #[tokio::test]
 async fn drain_times_out_on_an_unresponsive_stream() {
 	// A stream that yields one line then never another stands in for a registry
-	// that accepts the request then stalls — the per-line deadline must fire.
+	// that accepts the request then stalls; the per-line deadline must fire.
 	let first = futures_util::stream::iter(vec![Ok(progress("pushing", ""))]);
 	let stream = first.chain(futures_util::stream::pending::<
 		std::result::Result<ImagePullProgress, PodmanError>,

--- a/internal/engine/build/secrets.rs
+++ b/internal/engine/build/secrets.rs
@@ -48,7 +48,7 @@ impl Engine {
 					})?
 					.into_bytes()
 			} else if config.external == Some(true) {
-				warn!("build secret '{name}' is external; cannot forward over the libpod build API — skipping");
+				warn!("build secret '{name}' is external; cannot forward over the libpod build API; skipping");
 				continue;
 			} else {
 				continue;

--- a/internal/engine/build/service.rs
+++ b/internal/engine/build/service.rs
@@ -56,7 +56,7 @@ impl Engine {
 		);
 
 		// A Git/URL context is cloned server-side by Podman via the `remote`
-		// query parameter — there is no local directory to tar. Tar-only features
+		// query parameter; there is no local directory to tar. Tar-only features
 		// (inline Dockerfile, in-tar build secrets) do not apply.
 		let (body_plan, dockerfile_name, secret_specs) = if remote_context {
 			info!("building {tag} from remote context {context_str}");
@@ -151,7 +151,7 @@ impl Engine {
 		}
 
 		// A secret passed as a build arg is recorded in the image history and, if
-		// promoted via `ENV`, the image config — so it can leak. Warn and point at
+		// promoted via `ENV`, the image config, so it can leak. Warn and point at
 		// `build.secrets` (BuildKit `--mount=type=secret`), which does not persist.
 		let mut secretish: Vec<&str> = build_args
 			.keys()
@@ -315,7 +315,7 @@ impl Engine {
 				secrets,
 			} => {
 				// The tar writer runs on a blocking thread feeding the request
-				// body; drain the body first, then join the writer — joining
+				// body; drain the body first, then join the writer, since joining
 				// before the body is drained would deadlock on the bounded
 				// channel. If the request itself failed, that transport error is
 				// the real cause; otherwise surface any context-assembly error.

--- a/internal/engine/build/stream.rs
+++ b/internal/engine/build/stream.rs
@@ -4,7 +4,7 @@
 //! [`context_body`] runs the (blocking) tar+gzip writer on a `spawn_blocking`
 //! thread that feeds a bounded channel, and returns an async body stream that
 //! drains it. Peak memory is roughly `CHANNEL_CAP * CHUNK_BYTES` regardless of
-//! context size — a multi-gigabyte context no longer drives the process's RSS.
+//! context size: a multi-gigabyte context no longer drives the process's RSS.
 
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -82,7 +82,7 @@ impl Write for ChannelWriter {
 /// The producer's `JoinHandle` yields the context-assembly `Result` (a tar/IO
 /// error surfaces here with its descriptive message); the `body` is the stream
 /// the client sends as the request body. Await the body request first, then the
-/// producer — awaiting the producer before draining the body would deadlock on
+/// producer; awaiting the producer before draining the body would deadlock on
 /// the bounded channel.
 pub(super) fn context_body(
 	context: PathBuf,

--- a/internal/engine/container/fields.rs
+++ b/internal/engine/container/fields.rs
@@ -198,9 +198,9 @@ pub(super) enum SanitizeError {
 /// Sanitize a single key/value pair parsed from a `label_file:` line and insert
 /// it into `labels`, enforcing:
 ///
-/// * per-pair constraints on the key — non-empty, no ASCII control characters,
+/// * per-pair constraints on the key: non-empty, no ASCII control characters,
 ///   length ≤ [`MAX_LABEL_KEY_LEN`];
-/// * per-pair constraints on the value — no ASCII control characters, length ≤
+/// * per-pair constraints on the value: no ASCII control characters, length ≤
 ///   [`MAX_LABEL_VALUE_LEN`];
 /// * the per-file entry cap [`MAX_LABEL_FILE_ENTRIES`] on distinct keys.
 ///
@@ -223,7 +223,7 @@ pub(super) fn sanitize_kv_pair(
 	if value.len() > MAX_LABEL_VALUE_LEN || value.chars().any(|c| c.is_control()) {
 		return Err(SanitizeError::InvalidValue);
 	}
-	// Overwrite of an existing key is allowed even at the cap — the cap bounds
+	// Overwrite of an existing key is allowed even at the cap: the cap bounds
 	// the number of distinct keys, not total insertions.
 	if !labels.contains_key(key) && labels.len() >= MAX_LABEL_FILE_ENTRIES {
 		return Err(SanitizeError::TooManyEntries);
@@ -238,7 +238,7 @@ pub(super) fn sanitize_kv_pair(
 /// `podup.config-files` label. A `,` in a path would visually merge with the
 /// next entry when the label is split back on `,`; `%2C` round-trips through
 /// that split unambiguously. Newlines are not produced by `Path::display` on
-/// any supported platform and are left as-is — the libpod JSON encoding would
+/// any supported platform and are left as-is; the libpod JSON encoding would
 /// re-escape them anyway. The underlying `PathBuf` is unaffected: this is a
 /// render-side concern only.
 pub(super) fn encode_path_for_label(path_str: &str) -> String {

--- a/internal/engine/container/fields/tests.rs
+++ b/internal/engine/container/fields/tests.rs
@@ -307,7 +307,7 @@ fn sanitize_kv_pair_rejects_empty_key() {
 #[test]
 fn sanitize_kv_pair_rejects_control_char_in_key() {
 	let mut labels = HashMap::new();
-	// \t in the middle of the key — a downstream consumer that splits on
+	// \t in the middle of the key: a downstream consumer that splits on
 	// whitespace would see two keys.
 	assert_eq!(
 		sanitize_kv_pair(&mut labels, "bad\tkey", "v"),
@@ -319,7 +319,7 @@ fn sanitize_kv_pair_rejects_control_char_in_key() {
 #[test]
 fn sanitize_kv_pair_rejects_control_char_in_value() {
 	let mut labels = HashMap::new();
-	// NUL in the value — meaningless in a label and would corrupt any
+	// NUL in the value: meaningless in a label and would corrupt any
 	// downstream parser that treats the value as a C string.
 	assert_eq!(
 		sanitize_kv_pair(&mut labels, "k", "bad\0val"),
@@ -331,7 +331,7 @@ fn sanitize_kv_pair_rejects_control_char_in_value() {
 #[test]
 fn sanitize_kv_pair_rejects_oversize_key() {
 	let mut labels = HashMap::new();
-	// 254 bytes — one past the podman cap.
+	// 254 bytes, one past the podman cap.
 	let big = "a".repeat(MAX_LABEL_KEY_LEN + 1);
 	assert_eq!(
 		sanitize_kv_pair(&mut labels, &big, "v"),
@@ -352,7 +352,7 @@ fn sanitize_kv_pair_accepts_key_at_cap() {
 #[test]
 fn sanitize_kv_pair_rejects_oversize_value() {
 	let mut labels = HashMap::new();
-	// 4 KiB + 1 — past the value cap.
+	// 4 KiB + 1, past the value cap.
 	let big = "a".repeat(MAX_LABEL_VALUE_LEN + 1);
 	assert_eq!(
 		sanitize_kv_pair(&mut labels, "k", &big),
@@ -372,7 +372,7 @@ fn sanitize_kv_pair_rejects_when_map_is_full() {
 		sanitize_kv_pair(&mut labels, "new-key", "v"),
 		Err(SanitizeError::TooManyEntries)
 	);
-	// ...but overwriting an existing key at the cap is allowed — the cap
+	// ...but overwriting an existing key at the cap is allowed: the cap
 	// bounds the number of distinct keys, not total insertions.
 	assert!(sanitize_kv_pair(&mut labels, "k0", "new-v").is_ok());
 	assert_eq!(labels.get("k0").map(String::as_str), Some("new-v"));
@@ -385,7 +385,7 @@ fn label_file_rejects_control_char_in_value_at_parse() {
 	use crate::compose::types::primitives::StringOrList;
 	let dir = tempfile::tempdir().unwrap();
 	let path = dir.path().join("labels.env");
-	// The value carries an embedded NUL — meaningless as a label and would
+	// The value carries an embedded NUL: meaningless as a label and would
 	// corrupt any downstream consumer that re-parses the value.
 	std::fs::write(&path, "com.example.team=bl\0ue\n").unwrap();
 
@@ -431,7 +431,7 @@ fn label_file_accepts_exactly_max_entries() {
 	use crate::compose::types::primitives::StringOrList;
 	let dir = tempfile::tempdir().unwrap();
 	let path = dir.path().join("labels.env");
-	// Exactly the cap is the inclusive boundary — every entry fits.
+	// Exactly the cap is the inclusive boundary; every entry fits.
 	let mut content = String::new();
 	for i in 0..MAX_LABEL_FILE_ENTRIES {
 		content.push_str(&format!("com.example.k{i}=v\n"));
@@ -450,7 +450,7 @@ fn label_file_overwrite_does_not_count_against_cap() {
 	let dir = tempfile::tempdir().unwrap();
 	let path = dir.path().join("labels.env");
 	// First `MAX_LABEL_FILE_ENTRIES` distinct keys, then repeated overwrites
-	// of the first key — the overwrites are allowed at the cap.
+	// of the first key; the overwrites are allowed at the cap.
 	let mut content = String::new();
 	for i in 0..MAX_LABEL_FILE_ENTRIES {
 		content.push_str(&format!("com.example.k{i}=v{i}\n"));

--- a/internal/engine/container/host_mode.rs
+++ b/internal/engine/container/host_mode.rs
@@ -39,8 +39,8 @@ pub struct ModeWarning {
 /// the compose key used to label each warning; it is rendered into the
 /// message so the call site can emit it verbatim.
 ///
-/// The five compose-native keys — `network_mode`, `privileged`, `pid`, `ipc`,
-/// `uts`, `cgroup`, `userns_mode` — are mirrored to one `Namespace` field
+/// The five compose-native keys (`network_mode`, `privileged`, `pid`, `ipc`,
+/// `uts`, `cgroup`, `userns_mode`) are mirrored to one `Namespace` field
 /// each on the libpod spec, so the same detector covers the live engine and
 /// the Quadlet export. The `container:<id>` prefix on `pid`/`ipc`/`uts`/`cgroup`
 /// is treated as host-binding too: sharing another container's namespace

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -52,7 +52,7 @@ impl Engine {
 		let image: &str = if let Some(img) = service.image.as_deref() {
 			img
 		} else if let Some(build) = service.build.as_ref() {
-			// No `image:` — reference the exact tag the build step produced for this
+			// No `image:`, so reference the exact tag the build step produced for this
 			// build-only service (project-scoped `{project}-{service}:latest`, or
 			// the first `build.tags` entry). Must stay in lockstep with
 			// `primary_build_tag`, or `up --build` creates the container against a
@@ -77,7 +77,7 @@ impl Engine {
 			})
 			.collect();
 
-		// Every secret/config source — inline, `file:` and `external: true` — is
+		// Every secret/config source (inline, `file:` and `external: true`) is
 		// injected as a Podman-native secret, never a bind mount. The ones podup
 		// owns are created up front by `create_project_secrets`; here we only build
 		// the references and preflight external ones for existence.
@@ -206,7 +206,7 @@ impl Engine {
 		// Surface every active host-binding / privilege-escalation mode the
 		// compose file declared. The warning is emitted *before* the spec is
 		// POSTed so a host-mode the operator did not intend never reaches the
-		// daemon — the log line is the only signal they get, and it has to
+		// daemon: the log line is the only signal they get, and it has to
 		// arrive before the API call succeeds. `--no-warn` is the escape
 		// hatch for operators who wrote the compose file deliberately.
 		if !self.no_warn {

--- a/internal/engine/container/resolve.rs
+++ b/internal/engine/container/resolve.rs
@@ -186,7 +186,7 @@ pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> Result<Strin
 	// different bytes for different iteration orders, which would flap the
 	// hash on every parse and trigger spurious recreates. The double
 	// serialisation is therefore load-bearing for the stable-hash invariant
-	// (#1364 deferred the proposed optimisation — see
+	// (#1364 deferred the proposed optimisation; see
 	// `config_hash_stable_despite_map_field_order`). Fail closed if either
 	// step fails (e.g. a non-scalar mapping key in an `x-` extension):
 	// returning an empty/default hash would make distinct services hash
@@ -226,7 +226,7 @@ pub(crate) fn config_hash(service: &Service, file: &ComposeFile) -> Result<Strin
 
 /// Fold an inline secret/config's resolved bytes into the config hasher. Inline
 /// `content:` contributes its literal bytes; `environment:` contributes the
-/// current value of the named variable (empty if unset — `up` errors on a
+/// current value of the named variable (empty if unset; `up` errors on a
 /// genuinely missing var later). `file:`/`external:` sources contribute nothing.
 fn hash_inline_payload(
 	hasher: &mut sha2::Sha256,
@@ -237,7 +237,7 @@ fn hash_inline_payload(
 ) {
 	use sha2::Digest;
 	// The environment-sourced branch holds the resolved `String` in a local so
-	// the `&[u8]` view stays alive across `update()` (#1364 — also E0716
+	// the `&[u8]` view stays alive across `update()` (#1364, and also E0716
 	// otherwise: a temporary `as_bytes()` is freed at end of statement).
 	let env_value;
 	let payload: Option<&[u8]> = match (content, environment) {

--- a/internal/engine/container/rootless.rs
+++ b/internal/engine/container/rootless.rs
@@ -12,7 +12,7 @@ pub(super) fn rootless_caveat_warnings(name: &str, service: &Service) -> Vec<Str
 	let mut out = Vec::new();
 	if service.privileged == Some(true) {
 		out.push(format!(
-			"service \"{name}\": privileged has reduced effect under rootless Podman — a \
+			"service \"{name}\": privileged has reduced effect under rootless Podman: a \
 			container cannot gain more privileges than the user that launched it"
 		));
 	}
@@ -36,13 +36,13 @@ pub(super) fn rootless_caveat_warnings(name: &str, service: &Service) -> Vec<Str
 	}
 	if !service.links.is_empty() {
 		out.push(format!(
-			"service \"{name}\": links has no effect under rootless Podman networking — put the \
+			"service \"{name}\": links has no effect under rootless Podman networking; put the \
 			services on a shared network and reach them by service name instead"
 		));
 	}
 	if !service.external_links.is_empty() {
 		out.push(format!(
-			"service \"{name}\": external_links has no effect under rootless Podman networking — \
+			"service \"{name}\": external_links has no effect under rootless Podman networking; \
 			attach the target container to a shared network and reach it by service name instead"
 		));
 	}

--- a/internal/engine/container/security.rs
+++ b/internal/engine/container/security.rs
@@ -2,7 +2,7 @@
 //! Podman SpecGenerator fields: `security_opt` decomposition, `device_cgroup_rules`
 //! parsing, and CDI device injection. Podman 5.x has no `security_opt` or
 //! `cdi_devices` SpecGenerator field, and `device_cgroup_rule` is structured, not
-//! a string list — sending the compose shapes verbatim silently drops them (or,
+//! a string list, and sending the compose shapes verbatim silently drops them (or,
 //! for cgroup rules, fails the request), so each is converted here.
 
 use tracing::warn;
@@ -29,7 +29,7 @@ pub(crate) fn cdi_device(name: String) -> LinuxDevice {
 }
 
 /// Decomposed `security_opt:` values, matching Podman's SpecGenerator security
-/// fields (it has no single `security_opt` field — see [`parse_security_opts`]).
+/// fields (it has no single `security_opt` field; see [`parse_security_opts`]).
 #[derive(Default)]
 pub(crate) struct SecurityOptions {
 	pub selinux_opts: Vec<String>,

--- a/internal/engine/container_config/log_config_tests.rs
+++ b/internal/engine/container_config/log_config_tests.rs
@@ -1,4 +1,4 @@
-//! Tests for `build_log_config` — the bridge between compose `logging:` and
+//! Tests for `build_log_config`, the bridge between compose `logging:` and
 //! libpod's `LogConfig`. Split from `mod.rs` so the production file stays under
 //! the 500-line cap and each surface (struct vs wire JSON vs malformed input
 //! vs `max-file` drop) gets its own focused case (#1417).
@@ -17,7 +17,7 @@ fn log_config_applies_the_default_when_absent() {
 		.expect("absent -> default, not None");
 	assert_eq!(cfg.driver.as_deref(), Some("k8s-file"));
 	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
-	// `max-size`/`max-file` no longer travel inside options — libpod would
+	// `max-size`/`max-file` no longer travel inside options; libpod would
 	// ignore them there, leaving the container with -1B.
 	assert!(!cfg.options.contains_key("max-size"));
 	assert!(!cfg.options.contains_key("max-file"));
@@ -60,7 +60,7 @@ fn log_config_with_max_size_parses_into_typed_field() {
 	};
 	let cfg = build_log_config("web", Some(&logging)).unwrap().unwrap();
 	assert_eq!(cfg.size, Some(10 * 1024 * 1024));
-	// And on the wire — what libpod actually parses — the key is `size`
+	// And on the wire, what libpod actually parses, the key is `size`
 	// and the value is a number, not the suffixed string under options.
 	let v = serde_json::to_value(&cfg).unwrap();
 	assert_eq!(v["size"], 10 * 1024 * 1024);

--- a/internal/engine/container_config/mod.rs
+++ b/internal/engine/container_config/mod.rs
@@ -38,7 +38,7 @@ pub(super) fn build_restart_policy(service: &Service) -> (Option<String>, Option
 		.and_then(|d| d.restart_policy.as_ref())
 	{
 		// Compose `restart_policy.condition`: `any` (the default) means restart
-		// under any circumstance, which docker-compose maps to `always` — not
+		// under any circumstance, which docker-compose maps to `always`, not
 		// `unless-stopped` (the latter would skip restarts after an explicit
 		// stop, diverging from docker-compose).
 		let name = match drp.condition.as_deref().unwrap_or("any") {
@@ -99,7 +99,7 @@ pub(crate) fn default_log_config() -> LogConfig {
 /// has a rotation policy without the user having to set one. When the user
 /// supplies a block, `max-size` is parsed into the typed [`LogConfig::size`]
 /// field libpod actually reads rotation from (passing it inside `options` is
-/// silently ignored — #1417); `max-file` is dropped with a warning because
+/// silently ignored, #1417); `max-file` is dropped with a warning because
 /// libpod does not implement it. A malformed `max-size` is rejected with a
 /// `PodmanError::Field` so the user gets a compose-flavoured error instead of
 /// a 500 from libpod's JSON unmarshal.
@@ -116,7 +116,7 @@ pub(crate) fn build_log_config(
 /// Translate a user-supplied `logging:` block into libpod's [`LogConfig`].
 ///
 /// `max-size` is moved into the typed `size` field. `max-file` is dropped
-/// with a warning — libpod does not implement it and would silently ignore
+/// with a warning: libpod does not implement it and would silently ignore
 /// it if forwarded. The user-supplied value of `max-size` is parsed with the
 /// same memory parser used elsewhere in the engine (`10m`, `1g`, plain
 /// bytes); a malformed value is rejected with the service field name so the
@@ -175,7 +175,7 @@ pub(super) fn build_healthcheck(hc: &HealthCheck) -> HealthConfig {
 	// API does NOT default these: a missing `Timeout` is taken as 0s, which makes
 	// every probe fail with "exceeded timeout of 0s" so the container is stuck
 	// `starting`; a missing/zero `Interval` disables the periodic check. Match
-	// docker-compose — interval 30s, timeout 30s, retries 3 (start_period 0).
+	// docker-compose: interval 30s, timeout 30s, retries 3 (start_period 0).
 	const DEFAULT_NANOS: i64 = 30 * 1_000_000_000;
 	HealthConfig {
 		test,

--- a/internal/engine/container_config/resources.rs
+++ b/internal/engine/container_config/resources.rs
@@ -194,7 +194,7 @@ fn ulimit_value(value: i64, name: &str, which: &str) -> u64 {
 	}
 }
 
-/// Upper bound on an explicit GPU `count:` — clamps an untrusted compose value
+/// Upper bound on an explicit GPU `count:`, clamping an untrusted compose value
 /// so a huge count cannot allocate billions of device-id strings (OOM). Far
 /// above any real host's GPU count.
 const MAX_GPU_DEVICES: i64 = 64;
@@ -202,7 +202,7 @@ const MAX_GPU_DEVICES: i64 = 64;
 /// Map `deploy.resources.reservations.devices` GPU reservations to Podman CDI
 /// device names (e.g. `nvidia.com/gpu=all`).
 ///
-/// Only NVIDIA GPU reservations are translated — the common case Podman exposes
+/// Only NVIDIA GPU reservations are translated: the common case Podman exposes
 /// through CDI. Reservations for other drivers or capabilities are warned about
 /// and skipped, since there is no portable mapping for them.
 pub(crate) fn cdi_devices(service: &Service) -> Vec<String> {

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -99,7 +99,7 @@ impl Engine {
 
 	/// Copy with `docker compose cp` options: `--index` (target a specific
 	/// replica), `-L/--follow-link` (follow host symlinks when uploading) and
-	/// `-a/--archive` (accepted for compatibility — see [`CpOptions::archive`]).
+	/// `-a/--archive` (accepted for compatibility; see [`CpOptions::archive`]).
 	pub async fn cp_with_options(
 		&self,
 		file: &ComposeFile,
@@ -162,7 +162,7 @@ impl Engine {
 		// Two destination shapes, and only one of them can be streamed.
 		//
 		// An existing directory goes straight to `extract_tar_guarded`, which
-		// walks the archive once — so the body can be piped into it and nothing
+		// walks the archive once, so the body can be piped into it and nothing
 		// accumulates. That is also the shape that moves bulk data (`cp
 		// svc:/var/lib/data ./backup/`), which is why it is the one worth
 		// streaming.
@@ -202,21 +202,21 @@ impl Engine {
 
 	/// Push a host file or directory into a service container.
 	///
-	/// # Concurrency contract — read before touching the two HEAD + PUT sequence
+	/// # Concurrency contract: read before touching the two HEAD + PUT sequence
 	///
 	/// `cp_to_container` issues two `HEAD /archive` requests with the PUT
 	/// between them, so a concurrent mutation in the window could land a
 	/// successful-but-wrong-state PUT. The two callers in the codebase are
 	/// the CLI `cp` subcommand and the `watch` sync path, both of which are
 	/// called only while the per-project lock ([`crate::engine::lock`]) is
-	/// held by the mutating stage — `lock_project` serialises a single
+	/// held by the mutating stage: `lock_project` serialises a single
 	/// `podup` process against any other `podup` process working on the same
 	/// project, closing the **cross-invocation** case.
 	///
-	/// The **within-invocation** case — a foreign actor (a manual
+	/// The **within-invocation** case, a foreign actor (a manual
 	/// `podman exec`, another compose stack on the same machine, the user
 	/// running `podman cp` in another shell) mutating the destination
-	/// between the two HEADs — is closed by libpod itself: the archive PUT
+	/// between the two HEADs, is closed by libpod itself: the archive PUT
 	/// extracts into a directory that we have just confirmed exists and is
 	/// a directory, so a foreign `rm -rf` racing in is rejected by the
 	/// second PUT, not silently succeeded. The `extract_stat_path` HEAD
@@ -312,12 +312,12 @@ impl Engine {
 	}
 
 	/// PUT a gzipped tar to a container's archive endpoint at `dir`, extracting
-	/// it there, and confirm it landed — the upload path shared by `cp` and
+	/// it there, and confirm it landed, the upload path shared by `cp` and
 	/// `watch` sync.
 	///
 	/// #1097: on Podman 6 the archive endpoint applies the tar and then closes
 	/// the connection *without* an HTTP response, which hyper reports as
-	/// `IncompleteMessage` even though the copy landed (the content does appear —
+	/// `IncompleteMessage` even though the copy landed (the content does appear,
 	/// measured on 6.0.1; every raw request to the same endpoint gets a clean
 	/// 200, so the trigger is client-side and could not be stripped out). To tell
 	/// that apply-then-close apart from a *genuine* upload failure (a dropped
@@ -328,7 +328,7 @@ impl Engine {
 	/// This used to compare the entry's mtime before and after and require it to
 	/// move. That signal cannot express the question: Podman 6 reports the mtime
 	/// to whole seconds, so two copies inside one second look identical
-	/// (#1270 — three failures in six back-to-back copies, measured), and
+	/// (#1270: three failures in six back-to-back copies, measured), and
 	/// re-copying an *unchanged* file is undetectable at any resolution because
 	/// the extracted file takes the source's own mtime.
 	///
@@ -363,7 +363,7 @@ impl Engine {
 		// This used to read the entry's mtime *before* the PUT and check that it
 		// moved afterwards. That cannot work: Podman 6 reports the mtime to
 		// whole seconds, so two copies inside one second are indistinguishable
-		// — measured at three failures in six back-to-back copies (#1270) — and
+		// (measured at three failures in six back-to-back copies, #1270), and
 		// copying an unchanged file twice is undetectable at any resolution,
 		// because the extracted file takes the source's own mtime.
 		//
@@ -409,7 +409,7 @@ impl Engine {
 		// The upload finished but its result could not be confirmed. Say so, with
 		// an actionable hint, instead of surfacing the raw transport error.
 		Err(ComposeError::Copy(format!(
-			"the upload to {dir} could not be confirmed — the container runtime closed the \
+			"the upload to {dir} could not be confirmed: the container runtime closed the \
 			 connection without a response and the destination did not change. The copy may \
 			 or may not have landed; check {dir} in the container."
 		)))
@@ -420,7 +420,7 @@ impl Engine {
 /// nothing to compare.
 ///
 /// Only a regular file has a size the archive preserves. A directory upload
-/// stays unverifiable and therefore fail-closed, which is what it was before —
+/// stays unverifiable and therefore fail-closed, which is what it was before:
 /// a directory entry's own size says nothing about whether its children
 /// arrived. A source that cannot be stat'd is `None` for the same reason:
 /// unknown must not become a guess.
@@ -440,7 +440,7 @@ pub(super) fn uploaded_entry_size(src: &std::path::Path) -> Option<u64> {
 /// Only the size for now. The mtime is deliberately not part of it: the archive
 /// sets it from the source, but Podman reports it to whole seconds while the
 /// source's own mtime carries sub-second precision, so comparing the two would
-/// re-introduce a resolution mismatch — this time as a false *negative* on a
+/// re-introduce a resolution mismatch, this time as a false *negative* on a
 /// copy that did land.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ExpectedEntry {
@@ -518,12 +518,12 @@ fn parse_endpoint(s: &str) -> Option<(&str, &str)> {
 	if s == "-" {
 		return None;
 	}
-	// `SERVICE:PATH` — colon must not be the first character and path cannot be empty.
+	// `SERVICE:PATH`: colon must not be the first character and path cannot be empty.
 	let (svc, path) = s.split_once(':')?;
 	if svc.is_empty() || path.is_empty() {
 		return None;
 	}
-	// On Windows, an absolute path like `C:\path` has a single-char drive prefix —
+	// On Windows, an absolute path like `C:\path` has a single-char drive prefix,
 	// treat those as local paths, not service endpoints. This must NOT apply on
 	// Unix, where a one-character service name (`c:/path`) is perfectly valid and
 	// would otherwise be rejected as a bogus "drive".

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -1,7 +1,7 @@
 //! Tar packing and extraction for `cp`.
 //!
 //! The pure, container-free half of `cp`: it moves bytes between the host
-//! filesystem and a tar stream and carries the security hardening — the
+//! filesystem and a tar stream and carries the security hardening: the
 //! zip-slip guard, the extracted-mode sanitization and the docker/podman
 //! destination semantics. Kept synchronous so the guards can be unit-tested
 //! without a container.
@@ -51,7 +51,7 @@ pub(super) fn pack_path(
 /// - `dst` is an existing directory: the archive is extracted into it (a source
 ///   directory lands under its own name).
 /// - `dst` does not exist and the source is a single regular file: its
-///   **content** is written to exactly `dst` — the daemon-supplied entry name is
+///   **content** is written to exactly `dst`; the daemon-supplied entry name is
 ///   ignored, so a hostile image cannot choose the on-host filename (e.g. drop a
 ///   `.bashrc`/`authorized_keys` into the destination directory).
 /// - `dst` does not exist and the source is a directory: `dst` is created and the
@@ -111,7 +111,7 @@ pub(super) fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
 
 /// True when the destination path was written with a trailing path separator
 /// (e.g. `./newdir/`), which `docker cp` treats as an explicit *directory*
-/// destination — it must already exist.
+/// destination; it must already exist.
 fn has_trailing_separator(p: &Path) -> bool {
 	p.as_os_str()
 		.to_string_lossy()
@@ -120,7 +120,7 @@ fn has_trailing_separator(p: &Path) -> bool {
 		.is_some_and(std::path::is_separator)
 }
 
-/// True if any entry in `tar_bytes` is a directory — the signal that the source
+/// True if any entry in `tar_bytes` is a directory, the signal that the source
 /// of a container→host copy was a directory (libpod tars it under its basename),
 /// as opposed to a single file.
 fn archive_contains_dir(tar_bytes: &[u8]) -> Result<bool> {
@@ -164,12 +164,12 @@ fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
 /// Extract a (plain, uncompressed) tar archive into `dst_dir`, refusing any
 /// Rebuild the on-disk path `unpack_in` chose for an entry.
 ///
-/// `unpack_in` keeps only [`Component::Normal`] parts — a leading `/` or a `..`
-/// is dropped rather than honoured — so an entry named `/etc/passwd` lands at
+/// `unpack_in` keeps only [`Component::Normal`] parts (a leading `/` or a `..`
+/// is dropped rather than honoured) so an entry named `/etc/passwd` lands at
 /// `dst_dir/etc/passwd`. Reconstructing that path as `dst_dir.join(rel)` is
 /// wrong in exactly that case: [`Path::join`] with an absolute path **discards
 /// the base**, so the follow-up chmod would leave the destination and land on
-/// the real host file — a hostile image could hand back an entry named
+/// the real host file: a hostile image could hand back an entry named
 /// `/home/user/.ssh/id_ed25519` with mode 0o644 and have the copy loosen it.
 /// Mirroring `unpack_in`'s own rule keeps the two in agreement.
 ///
@@ -220,10 +220,10 @@ pub fn extract_tar_guarded<R: std::io::Read>(src: R, dst_dir: &Path) -> Result<(
 			(Some(rel), Some(mode)) => match unpacked_path(dst_dir, &rel) {
 				Some(path) => sanitize_extracted_mode(&path, mode),
 				None => {
-					tracing::warn!("cp: entry with no usable path component — mode not sanitized")
+					tracing::warn!("cp: entry with no usable path component; mode not sanitized")
 				}
 			},
-			_ => tracing::warn!("cp: unreadable entry path or mode — mode not sanitized"),
+			_ => tracing::warn!("cp: unreadable entry path or mode; mode not sanitized"),
 		}
 	}
 	Ok(())

--- a/internal/engine/copy/archive_tests.rs
+++ b/internal/engine/copy/archive_tests.rs
@@ -312,7 +312,7 @@ fn absolute_entry_name_cannot_chmod_a_file_outside_the_destination() {
 
 	// Build an entry whose stored name is the victim's ABSOLUTE path. The
 	// safe setter refuses absolute paths, but a hostile archive is not built
-	// with the safe setter, so write the header's name field directly — this
+	// with the safe setter, so write the header's name field directly: this
 	// is the shape the guard has to survive.
 	let target = victim.to_str().expect("utf-8");
 	let mut header = tar::Header::new_gnu();

--- a/internal/engine/copy/stream.rs
+++ b/internal/engine/copy/stream.rs
@@ -31,7 +31,7 @@ pub(super) type ChunkItem = io::Result<Bytes>;
 /// Serves the bytes an async producer sends over a bounded channel to a
 /// blocking consumer, refusing to serve more than `cap` in total.
 ///
-/// The cap is no longer a memory bound — nothing accumulates — but it stays
+/// The cap is no longer a memory bound (nothing accumulates) but it stays
 /// meaningful: a compromised container can stream without end, and the bytes
 /// land on the host's disk as they arrive. What it protects changed from RAM to
 /// disk, so it is not redundant.
@@ -65,7 +65,7 @@ impl Read for ChannelReader {
 		while self.current.is_empty() {
 			match self.rx.blocking_recv() {
 				// Channel closed: the producer finished or was dropped. Either
-				// way there are no more bytes, which is a clean end of file —
+				// way there are no more bytes, which is a clean end of file;
 				// a truncated archive surfaces as a tar error, not here.
 				None => return Ok(0),
 				Some(Err(e)) => return Err(e),

--- a/internal/engine/copy/stream_tests.rs
+++ b/internal/engine/copy/stream_tests.rs
@@ -26,7 +26,7 @@ fn chunks_are_reassembled_in_order() {
 }
 
 /// The reader must survive a producer that sends an empty frame. Reporting
-/// end-of-stream there would truncate the archive with no error anywhere —
+/// end-of-stream there would truncate the archive with no error anywhere,
 /// exactly the silent-data-loss shape this file exists to avoid.
 #[test]
 fn an_empty_frame_is_not_end_of_stream() {

--- a/internal/engine/copy_tests.rs
+++ b/internal/engine/copy_tests.rs
@@ -33,7 +33,7 @@ fn copy_landed_asks_whether_the_entry_matches_what_was_uploaded() {
 ///
 /// The old check required the destination's mtime to move. The archive sets
 /// that mtime from the source, so re-copying an unchanged file leaves it
-/// identical by construction — no resolution would have helped — and the
+/// identical by construction (no resolution would have helped) and the
 /// second copy was reported as a failure. Matching against what was uploaded
 /// answers correctly.
 #[test]
@@ -50,7 +50,7 @@ fn copying_an_unchanged_file_twice_is_confirmed() {
 /// and a directory has none.
 ///
 /// A mutation replacing the length with a constant survived every other test
-/// here, because they all build `ExpectedEntry` by hand — this is the only
+/// here, because they all build `ExpectedEntry` by hand; this is the only
 /// one that goes through the filesystem.
 #[test]
 fn the_expected_size_comes_from_the_source_file() {

--- a/internal/engine/events.rs
+++ b/internal/engine/events.rs
@@ -1,4 +1,4 @@
-//! `events` — stream Podman events scoped to the project (`docker compose
+//! `events` streams Podman events scoped to the project (`docker compose
 //! events`). Filters the libpod event stream by the `podup.project` label.
 
 use futures_util::StreamExt;
@@ -71,7 +71,7 @@ impl Engine {
 	///
 	/// The feed is unbounded, so it normally ends only when the caller stops it.
 	/// Returning at all therefore means the stream was lost, and this returns
-	/// `Err` — see [`Engine::stream_events_with_options`] for the bounded case.
+	/// `Err`; see [`Engine::stream_events_with_options`] for the bounded case.
 	pub async fn stream_events(&self, json: bool) -> Result<()> {
 		self.stream_events_with_options(json, &EventsOptions::default())
 			.await
@@ -86,10 +86,10 @@ impl Engine {
 	/// asked for. Beyond that, whether a *clean* ending is an error depends on
 	/// what the caller asked for:
 	///
-	/// - **`since` and `until` both set, both already elapsed** — the window
+	/// - **`since` and `until` both set, both already elapsed**: the window
 	///   closes on its own, so a clean ending is what was asked for. Returns
 	///   `Ok(())`.
-	/// - **anything else** — the feed is unbounded and libpod never ends it, so
+	/// - **anything else**: the feed is unbounded and libpod never ends it, so
 	///   any ending means the stream was lost. Returns
 	///   [`ComposeError::StreamTruncated`](crate::ComposeError::StreamTruncated).
 	///
@@ -194,7 +194,7 @@ impl Engine {
 /// to that key's value array). Pure so the merge is unit-tested.
 ///
 /// A predicate with no `=` is an error rather than a skip. Dropping it scoped
-/// the stream to the whole project instead — `events --filter garbage` printed
+/// the stream to the whole project instead: `events --filter garbage` printed
 /// everything, which a caller reads as "these all matched". docker compose
 /// errors on a malformed filter too.
 fn build_event_filters(project: &str, user_filters: &[String]) -> Result<Value> {
@@ -267,7 +267,7 @@ fn format_event(value: &Value, json: bool) -> String {
 /// that applied at that instant.
 ///
 /// The calendar arithmetic used to live here as its own civil-from-days walk.
-/// It moved to `crate::timestamp`, which already held the inverse for parsing —
+/// It moved to `crate::timestamp`, which already held the inverse for parsing:
 /// the two halves are one thing, and a round-trip test between them only means
 /// something while neither can be edited without the other in view.
 pub(crate) fn format_event_time(unix_secs: i64) -> String {
@@ -279,7 +279,7 @@ pub(crate) fn format_event_time(unix_secs: i64) -> String {
 /// `YYYY-MM-DD HH:MM:SS -05:00` is twenty-six. It was nineteen while the column
 /// rendered UTC and said nothing about it; adding the offset without widening
 /// truncated every row to `...19:00:0…`, which the tests caught. The two belong
-/// in one edit — a width that describes a format it no longer holds is the same
+/// in one edit: a width that describes a format it no longer holds is the same
 /// class of bug as the `stats` header that had drifted off its own columns.
 const TIME_WIDTH: usize = 26;
 
@@ -295,7 +295,7 @@ const ACTION_WIDTH: usize = 14;
 ///
 /// Fixed widths, not content-sized like every other table here: rows arrive over
 /// time, so there is nothing to measure up front. `events` was the only stream
-/// with no header and no padding at all — three fields joined by single spaces,
+/// with no header and no padding at all: three fields joined by single spaces,
 /// so `NAME` sat in a different column on every line and nothing named what the
 /// fields were.
 fn events_header() -> String {
@@ -362,7 +362,7 @@ mod event_json_tests;
 /// Whether an events feed that ended did so because it was asked to.
 ///
 /// The four other streaming commands re-check the container they followed. An
-/// events feed follows none, so the discriminator is intent — which the client
+/// events feed follows none, so the discriminator is intent, which the client
 /// knows without an API call.
 #[cfg(test)]
 #[cfg(unix)]

--- a/internal/engine/events_event_json_tests.rs
+++ b/internal/engine/events_event_json_tests.rs
@@ -20,11 +20,11 @@ fn a_well_formed_value_renders_as_a_compact_json_line() {
 
 /// The fix for #1366: a `Value` that cannot be serialised must not silently
 /// emit `""`. `format_event` returns the empty string (so the NDJSON stream
-/// stays well-formed — a single missing row is recoverable), and the cause is
+/// stays well-formed, and a single missing row is recoverable), and the cause is
 /// logged at `debug` so the operator can find it.
 ///
 /// `serde_json::Value` itself never fails to serialise, so we wrap it in a
-/// custom serialiser that always errors — the shape of the failure is the
+/// custom serialiser that always errors: the shape of the failure is the
 /// contract under test, not the specific payload.
 #[test]
 fn an_unserialisable_value_drops_the_row_and_logs_debug() {

--- a/internal/engine/events_tests.rs
+++ b/internal/engine/events_tests.rs
@@ -29,7 +29,7 @@ fn build_event_filters_merges_user_predicates() {
 }
 
 /// #1081: a predicate with no `=` used to be dropped, so `events --filter
-/// garbage` silently scoped to the whole project and printed everything — a
+/// garbage` silently scoped to the whole project and printed everything, a
 /// caller reads that back as "these all matched".
 #[test]
 fn malformed_filter_is_rejected_not_dropped() {

--- a/internal/engine/fake_podman.rs
+++ b/internal/engine/fake_podman.rs
@@ -4,14 +4,14 @@
 //! lifecycle/scale/query tests can assert exit-code semantics against canned
 //! API responses without a real Podman daemon. [`Client`] opens a fresh
 //! connection per request (see `internal/libpod/client/mod.rs`), so this only
-//! ever needs to answer one HTTP/1.1 request per accepted connection — no
+//! ever needs to answer one HTTP/1.1 request per accepted connection, with no
 //! keep-alive.
 //!
 //! It does frame a chunked body, for one reason: a stream that ends *badly* has
 //! a wire shape, and podup's central open question about streaming (#1104) is
 //! whether it can tell that shape from a stream that ended well. A real Podman
 //! cannot be asked to break a stream on demand, and which shape it produces at a
-//! CLEAN end turns out to differ by version — so the two cases are pinned here,
+//! CLEAN end turns out to differ by version, so the two cases are pinned here,
 //! deterministically, with no daemon and no version in the picture.
 
 #![cfg(unix)]
@@ -39,11 +39,11 @@ pub(super) enum FakeReply {
 	ChunkedTruncated(Vec<String>),
 	/// A 200 with a **chunked** body cut in the middle of a chunk's payload: the
 	/// header promises more bytes than are then written, and the connection
-	/// closes. The other place a severed stream can land, and — measured — hyper
+	/// closes. The other place a severed stream can land and, measured, hyper
 	/// classifies the two differently, which is why both exist here.
 	ChunkedCutMidPayload(String),
 	/// The request is read and accepted, and then the connection closes with **no
-	/// response at all** — not even a status line.
+	/// response at all**, not even a status line.
 	///
 	/// This is the shape `PodmanError::is_incomplete_message` names: hyper's
 	/// `IncompleteMessage` is about the message *head*, so it is the one reply
@@ -65,7 +65,7 @@ type Responder = dyn Fn(&str, &str) -> FakeReply + Send + Sync;
 /// A fake libpod socket driven by a routing closure; see [`Responder`].
 pub(super) struct FakePodman {
 	sock_path: std::path::PathBuf,
-	/// Every request answered so far, as `"METHOD target"` — lets a test assert
+	/// Every request answered so far, as `"METHOD target"`, letting a test assert
 	/// that a best-effort pass attempted every container even after one of them
 	/// failed.
 	pub(super) requests: Arc<Mutex<Vec<String>>>,
@@ -108,7 +108,7 @@ where
 	})
 }
 
-/// As [`start`], but the routing closure chooses the wire shape too — including
+/// As [`start`], but the routing closure chooses the wire shape too, including
 /// a chunked body that ends cleanly or one that is cut off mid-stream.
 pub(super) fn start_replying<F>(respond: F) -> FakePodman
 where

--- a/internal/engine/health.rs
+++ b/internal/engine/health.rs
@@ -35,7 +35,7 @@ enum HealthVerdict {
 	/// the service failed to start, so the wait must fail rather than report the
 	/// dependency satisfied. Carries the exit code.
 	Failed(i64),
-	/// Not healthy yet — keep polling.
+	/// Not healthy yet; keep polling.
 	Pending,
 }
 
@@ -77,14 +77,14 @@ fn classify_health(info: &ContainerInspect) -> HealthVerdict {
 /// Reading is a plain inspect: it does not execute the healthcheck, so it costs
 /// a request and nothing inside the container. Podman runs the check on its own
 /// schedule where systemd is available, and this is what notices promptly when
-/// it does — previously the status was only ever looked at once per `interval`,
+/// it does: previously the status was only ever looked at once per `interval`,
 /// so a container that turned healthy just after a probe went unnoticed for the
 /// rest of the window.
 const STATUS_READ_INTERVAL: Duration = Duration::from_millis(150);
 
 /// Lower bound on how often podup will *run* a healthcheck.
 ///
-/// Running is not free — it executes the command inside the container — so an
+/// Running is not free (it executes the command inside the container) so an
 /// `interval` of `10ms` must not turn into a hundred executions a second.
 const MIN_RUN_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -95,7 +95,7 @@ const MIN_RUN_INTERVAL: Duration = Duration::from_millis(100);
 /// how long it keeps trying. Sub-second intervals are honoured down to
 /// [`MIN_RUN_INTERVAL`]: they used to be discarded and replaced by the 2s
 /// default, so asking for `500ms` polling produced *slower* polling than asking
-/// for `1s` — the opposite of the request. Pure so the timing is unit-testable.
+/// for `1s`, the opposite of the request. Pure so the timing is unit-testable.
 fn health_poll_plan(
 	interval: Option<&str>,
 	start_period: Option<&str>,
@@ -124,7 +124,7 @@ fn health_poll_plan(
 /// healthcheck with a short `interval × retries` budget would otherwise time
 /// out long before a generous `--wait-timeout` elapsed. So when a wait-timeout
 /// is given we run at least enough iterations to cover it (plus a small margin),
-/// letting the outer `--wait-timeout` deadline — not the poll plan — decide when
+/// letting the outer `--wait-timeout` deadline, not the poll plan, decide when
 /// to give up. Without a wait-timeout the poll plan governs unchanged. Pure so
 /// the budget arithmetic is unit-tested without a live socket.
 fn effective_budget(
@@ -189,7 +189,7 @@ impl Engine {
 	/// `healthcheck.start_period` so a slow-starting service is not timed out early.
 	///
 	/// The wait is driven by the container's *effective* healthcheck reported by
-	/// the runtime, so healthchecks inherited from the image count too — not just
+	/// the runtime, so healthchecks inherited from the image count too, not just
 	/// those declared in compose. If the container has no effective healthcheck at
 	/// all (none in the image or compose), it can never report `healthy`, so the
 	/// wait short-circuits as satisfied rather than blocking until timeout.
@@ -210,7 +210,7 @@ impl Engine {
 		let budget = effective_budget(run_interval, plan_budget, wait_timeout);
 
 		// One inspect decides the short-circuits: already healthy, or no effective
-		// healthcheck at all (image or compose) — in which case a server-side
+		// healthcheck at all (image or compose), in which case a server-side
 		// `wait?condition=healthy` would block forever, so treat it as satisfied.
 		let info = self
 			.client
@@ -240,7 +240,7 @@ impl Engine {
 		// Actively drive the healthcheck on demand. A server-side
 		// `wait?condition=healthy` only returns once the health *status* flips to
 		// `healthy`, but Podman updates that status only when the healthcheck runs
-		// — and it schedules those runs via systemd transient timers. Without
+		// and it schedules those runs via systemd transient timers. Without
 		// systemd (containers, minimal hosts) the timer never fires and the status
 		// stays `starting`, so the wait would block until the whole budget elapsed.
 		//
@@ -255,7 +255,7 @@ impl Engine {
 		// Two cadences, because running a check and observing its result are not
 		// the same cost. Running executes a command inside the container, so it
 		// happens at the interval the compose file asked for and no faster.
-		// Observing is a plain inspect, so it happens often — Podman runs the
+		// Observing is a plain inspect, so it happens often: Podman runs the
 		// check on its own systemd schedule where one exists, and this is what
 		// notices promptly when it does.
 		//
@@ -275,7 +275,7 @@ impl Engine {
 					Ok(run) if run.status.as_deref() == Some("healthy") => return Ok(()),
 					Ok(_) => {}
 					// A transient error (container not yet running, 409, 500, …)
-					// just means "not healthy yet" — keep going rather than
+					// just means "not healthy yet", so keep going rather than
 					// failing hard.
 					Err(e) => tracing::debug!("{container_name} healthcheck run failed: {e}"),
 				}

--- a/internal/engine/health_tests.rs
+++ b/internal/engine/health_tests.rs
@@ -28,7 +28,7 @@ fn poll_plan_uses_interval_and_honors_start_period() {
 
 /// A sub-second interval used to be discarded and replaced by the 2s
 /// default, so asking for 500ms polling produced *slower* polling than
-/// asking for 1s — the opposite of the request (#1147). It is honoured now,
+/// asking for 1s, the opposite of the request (#1147). It is honoured now,
 /// with a floor so `10ms` cannot become a hundred check executions a second.
 #[test]
 fn poll_plan_honours_a_sub_second_interval() {

--- a/internal/engine/image/digests.rs
+++ b/internal/engine/image/digests.rs
@@ -1,8 +1,8 @@
 //! `config --resolve-image-digests`: pin each service image to its registry
 //! digest.
 //!
-//! Like `ls`, this is project-agnostic — it needs only a [`Client`] to inspect
-//! images, not a full [`Engine`](crate::engine::Engine) — so it lives as a free function.
+//! Like `ls`, this is project-agnostic: it needs only a [`Client`] to inspect
+//! images, not a full [`Engine`](crate::engine::Engine), so it lives as a free function.
 
 use futures_util::StreamExt;
 
@@ -19,7 +19,7 @@ use crate::libpod::{urlencoded, Client, PodmanError, API_PREFIX};
 /// **different problems**, and the suite's threshold does not transfer. On the
 /// same plain-KVM guest that produced the suite's `IncompleteMessage`
 /// dose-response table, a single `up` was driven through 2/5/10/20 services in
-/// one dependency level over three rounds with **zero drops** — recorded in
+/// one dependency level over three rounds with **zero drops**, recorded in
 /// `ai-context/context/podup/index.md` as the reason the suite's threshold
 /// "is not the path at risk". Twenty concurrent is the measured-clean
 /// ceiling; this cap sits a comfortable margin below it, conservative with

--- a/internal/engine/image/digests_tests.rs
+++ b/internal/engine/image/digests_tests.rs
@@ -93,7 +93,7 @@ async fn service_without_image_is_not_inspected() {
 async fn image_without_digest_warns_and_leaves_image_unchanged() {
 	let file = file_with(&[("local", Some("built-locally"))]);
 	// The fake responds with an inspect body that carries no
-	// `RepoDigests` — the "locally built image" case.
+	// `RepoDigests`: the "locally built image" case.
 	let fake = fake_podman::start(|_, _| {
 		(
 			200,
@@ -136,7 +136,7 @@ async fn first_inspect_failure_aborts_with_the_offending_service_named() {
 	let client = fake.client();
 
 	let err = resolve_image_digests(&client, &file).await.unwrap_err();
-	// `matches!` on a distinctive fragment, not `is_err()` — the test
+	// `matches!` on a distinctive fragment, not `is_err()`: the test
 	// has to fail when the wrong service is named.
 	let msg = match err {
 		ComposeError::Build(m) => m,
@@ -194,7 +194,7 @@ async fn missing_image_404_is_a_hard_error_naming_the_service() {
 /// A two-failure fixture driven through `buffer_unordered` does **not**
 /// discriminate: the in-process fake answers fast enough that completion
 /// order coincides with submission order, so the assertion passes with the
-/// sort removed. Measured — three runs, three passes, with the sort
+/// sort removed. Measured: three runs, three passes, with the sort
 /// commented out. That is the vacuous shape this file must not carry, so
 /// the property is pinned directly instead.
 #[test]

--- a/internal/engine/image/export.rs
+++ b/internal/engine/image/export.rs
@@ -268,7 +268,7 @@ impl Engine {
 	}
 }
 
-/// Whether a write error is a broken pipe on the stdout sink — a downstream
+/// Whether a write error is a broken pipe on the stdout sink, meaning a downstream
 /// reader closed early. A broken pipe never applies to a `-o FILE` sink, so it
 /// only short-circuits to a clean exit when streaming to stdout. Pure so it is
 /// unit-tested.
@@ -300,7 +300,7 @@ mod tests;
 
 /// End-to-end check that the destination path actually surfaces as
 /// [`ComposeError::IoPath`] when the operator passes an output the file
-/// system refuses to create — i.e. the production wiring from `Engine::export`
+/// system refuses to create, i.e. the production wiring from `Engine::export`
 /// through `std::fs::File::create` into `IoPath`, not just the helper that
 /// shapes the error. The bare `io_to_err` unit test above pins the wrapper;
 /// this one pins the call site that triggers it.

--- a/internal/engine/image/export_iopath_tests.rs
+++ b/internal/engine/image/export_iopath_tests.rs
@@ -19,14 +19,14 @@ async fn export_to_an_unwritable_destination_surfaces_iopath() {
 	);
 
 	// The fake answers the streaming GET the same way it would for a
-	// healthy container — podup never has to read a real byte from us,
+	// healthy container; podup never has to read a real byte from us,
 	// because the destination file fails to open before the body is
 	// consumed. The chunked body is what `get_stream` accepts. The
 	// target carries the `http://localhost` prefix the client builds,
 	// so the matcher looks for the trailing `/export` route instead.
 	let fake = fake_podman::start_replying(|method, target| {
 		if method == "GET" && target.contains("/export") {
-			// One empty chunk is enough — the test errors before the
+			// One empty chunk is enough; the test errors before the
 			// body is fully drained.
 			return FakeReply::ChunkedEnd(vec![String::new()]);
 		}

--- a/internal/engine/image/export_tests.rs
+++ b/internal/engine/image/export_tests.rs
@@ -78,7 +78,7 @@ fn io_to_err_with_output_path_wraps_as_iopath() {
 	let e = Error::new(ErrorKind::PermissionDenied, "denied");
 	let mapped = io_to_err(&Some(p.clone()), e);
 
-	// The variant must be IoPath with the path attached — a bare
+	// The variant must be IoPath with the path attached; a bare
 	// `ComposeError::Io(_)` would drop the destination the user just
 	// asked us to write to, and is the regression this variant exists to
 	// prevent.

--- a/internal/engine/interactive.rs
+++ b/internal/engine/interactive.rs
@@ -4,7 +4,7 @@
 //! hard cap enforced by the org's `line-limit` reusable. The decision is
 //! small but tightly constrained: it has to match `docker compose run` exactly
 //! (an interactive `run` only allocates a pty when stdin AND stdout are both
-//! terminals — the famous redirect-test case, where the user pipes the
+//! terminals: the famous redirect-test case, where the user pipes the
 //! output to a file but leaves the keyboard attached), and the wrong answer
 //! silently corrupts every script that already calls `podup run`.
 

--- a/internal/engine/interactive_tests.rs
+++ b/internal/engine/interactive_tests.rs
@@ -1,6 +1,6 @@
 use super::{wants_interactive_run, wants_interactive_with};
 
-/// `-T` opts out, matching `docker compose run` — which has no `-i` because
+/// `-T` opts out, matching `docker compose run`, which has no `-i` because
 /// a TTY on both ends is the default.
 #[test]
 fn no_tty_disables_the_pty() {
@@ -13,8 +13,8 @@ fn detach_disables_the_pty() {
 	assert!(!wants_interactive_run(false, true));
 }
 
-/// The decisive one for existing users: in a test harness — as in any script
-/// or pipeline — stdin is not a terminal, so `run` stays on the unchanged
+/// The decisive one for existing users: in a test harness, as in any script
+/// or pipeline, stdin is not a terminal, so `run` stays on the unchanged
 /// streaming path. Allocating a pty there would change output framing for
 /// every script that already calls `podup run`.
 #[test]
@@ -25,7 +25,7 @@ fn a_non_terminal_stdin_stays_on_the_streaming_path() {
 /// Both ends are required, and this is the case that made it necessary:
 /// `podup run app cmd > out.txt` typed at a shell leaves stdin a terminal
 /// while stdout is a file. Checking stdin alone allocated a pty, and a pty
-/// merges stdout with stderr and writes CRLF — so the redirect silently
+/// merges stdout with stderr and writes CRLF, so the redirect silently
 /// changed the bytes the file received. Verified against `docker compose`,
 /// which keeps it clean.
 #[test]

--- a/internal/engine/lifecycle/commands.rs
+++ b/internal/engine/lifecycle/commands.rs
@@ -28,7 +28,7 @@ fn wait_header() -> String {
 /// One `wait` result line: the container, then its exit code coloured by whether
 /// it is a failure.
 ///
-/// The name goes through `fit_cell`, so it is escaped as well as padded — a
+/// The name goes through `fit_cell`, so it is escaped as well as padded: a
 /// container name is not podup's own string.
 fn wait_row(container: &str, code: i64) -> String {
 	let cell = crate::ui::fit_cell(container, WAIT_NAME_WIDTH);
@@ -47,7 +47,7 @@ fn wait_row(container: &str, code: i64) -> String {
 
 /// Say so when a command finished having done nothing.
 ///
-/// `start` already did this — *"no containers to start (project not created)"* —
+/// `start` already did this (*"no containers to start (project not created)"*)
 /// and the other six lifecycle commands did not: `rm`, `stop`, `restart`, `kill`,
 /// `pause` and `unpause` all exited 0 in complete silence on a project that was
 /// never created, which reads exactly like success. Measured before the fix, all
@@ -116,7 +116,7 @@ impl Engine {
 			// The server closed before completing the response. That is not an
 			// answer: the operation may have run to completion and lost only its
 			// reply. Measured on Podman 6 under concurrency, where the drops land
-			// on exactly these state-changing POSTs and follow a slow one — a
+			// on exactly these state-changing POSTs and follow a slow one: a
 			// restart that burned its full stop grace, then a drop on the next
 			// (#1339). It is not a client deadline (READ_TIMEOUT is 120s) and not
 			// a pooled-connection race (there is no pool; every request gets a
@@ -173,7 +173,7 @@ impl Engine {
 	/// state was re-confirmed via the drop-recheck path) and `Ok(false)` when
 	/// libpod said it was already stopped/gone. The bool lets
 	/// [`Self::stop_one_service`] keep its `acted` flag accurate now that it no
-	/// longer filters by per-container state itself — the bulk container-list
+	/// longer filters by per-container state itself; the bulk container-list
 	/// helper returns names without states, so the transition bit has to come
 	/// from the response (#1363).
 	pub(super) async fn stop_container(&self, container: &str, grace: i32) -> Result<bool> {
@@ -257,8 +257,8 @@ impl Engine {
 		// label cascade-restarts distinctly in the logs.
 		let (restart_set, targets) = restart_service_set(file, target_services, no_deps);
 
-		// Walk dependency levels in order — a dependency restarts before its
-		// dependents — but restart every service *within* a level concurrently.
+		// Walk dependency levels in order (a dependency restarts before its
+		// dependents) but restart every service *within* a level concurrently.
 		let levels = retain_levels(crate::compose::resolve_levels(file)?, |n| {
 			restart_set.contains(n)
 		});
@@ -360,14 +360,14 @@ impl Engine {
 		};
 
 		// One line per container, which is the granularity the reference reports
-		// at — measured against docker compose v5.1.3 with a service scaled to 3
+		// at, measured against docker compose v5.1.3 with a service scaled to 3
 		// replicas, it printed three lines, one per container id. The comment this
 		// replaces asserted the opposite ("a single exit code for each service"),
 		// and a bare `0` per service was built on it: with more than one container
 		// nothing said which code belonged to which.
 		//
 		// What is deliberately *not* copied is the rendering. The reference prints
-		// `container "<64-char hex id>" exited with status code 0` — an id nobody
+		// `container "<64-char hex id>" exited with status code 0`: an id nobody
 		// can map back to a service, the same sentence repeated on every line, and
 		// no machine path at all. Same information, said better: the container
 		// name podup already has, aligned columns, and the code coloured by
@@ -438,7 +438,7 @@ impl Engine {
 		// running/paused client-side.
 		let live_by_service = self.live_project_replicas().await?;
 
-		// Report "stopped" solely for containers actually running/paused —
+		// Report "stopped" solely for containers actually running/paused:
 		// stopping a Created/Exited one is a harmless no-op and must not claim
 		// it stopped (#876), matching docker compose. `stop_container` returns
 		// `Ok(false)` for libpod's 304/404 idempotent no-ops, which is how this
@@ -482,7 +482,7 @@ impl Engine {
 
 		// Prefetch every project container once and group by service, instead of
 		// one container-list round-trip per service (S+1 → 1 for the level walk;
-		// #1363). Only act on containers Podman actually has — acting on the
+		// #1363). Only act on containers Podman actually has; acting on the
 		// static fallback names would POST `/start` to containers that were never
 		// created, 404 (swallowed as a no-op), and exit 0 silently, masking that
 		// the project was never created. Attempt every live container and
@@ -515,8 +515,8 @@ impl Engine {
 		.await;
 		crate::ui::progress::end();
 		outcome?;
-		// `start`'s flag answers a narrower question than the others' — whether any
-		// container existed at all, not whether anything changed — so it can name
+		// `start`'s flag answers a narrower question than the others': whether any
+		// container existed at all, not whether anything changed, so it can name
 		// the cause, and the extra clause rides in the verb.
 		note_if_idle(&any_live, "start (project not created)");
 		Ok(())
@@ -532,7 +532,7 @@ impl Engine {
 		signal: &str,
 	) -> Result<()> {
 		// Reject an empty/whitespace-only or otherwise invalid signal before
-		// issuing any request — libpod would silently treat `signal=` as SIGKILL.
+		// issuing any request; libpod would silently treat `signal=` as SIGKILL.
 		super::signal::validate_signal(signal)?;
 
 		let levels = crate::compose::resolve_levels(file)?;

--- a/internal/engine/lifecycle/down_label.rs
+++ b/internal/engine/lifecycle/down_label.rs
@@ -33,27 +33,27 @@ impl Engine {
 	/// Best-effort across every container/network/volume so one failure never
 	/// leaves the rest of the teardown undone, but the first real REMOVAL
 	/// failure is remembered and returned at the end instead of being swallowed
-	/// into a warning — mirroring the fix applied to [`Engine::down_with_options`]
+	/// into a warning, mirroring the fix applied to [`Engine::down_with_options`]
 	/// (#598). A stalled or failed `stop` does NOT count towards this: the
 	/// force-remove that follows SIGKILLs the container regardless (the
 	/// container-removal path forces removal), so only a genuine removal failure
 	/// aggregates. A 404 (already gone) stays an idempotent no-op throughout.
 	///
-	/// With no compose file there is no dependency graph to level, so — unlike
-	/// [`Engine::down_with_options`]'s level walk — every labelled container is
+	/// With no compose file there is no dependency graph to level, so, unlike
+	/// [`Engine::down_with_options`]'s level walk, every labelled container is
 	/// independent from podup's point of view and all of them tear down in one
 	/// bounded concurrent batch instead of strictly sequentially.
 	pub async fn down_by_label(&self, remove_volumes: bool) -> Result<()> {
 		let grace = self.stop_timeout.unwrap_or(DEFAULT_STOP_GRACE_SECS);
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
-		// With no compose file, the service names are not known statically — but
+		// With no compose file, the service names are not known statically, but
 		// the labelled containers we are about to tear down carry `podup.service`,
 		// so list them grouped by service instead of the flat name list, and
 		// register the result before any teardown progress line is printed.
 		// Without this every container here fell back to the per-label hash
 		// instead of the sequential identity colour `ps` and the compose-file
-		// `down` path use — the same class of defect fixed for `logs` (#1082).
+		// `down` path use, the same class of defect fixed for `logs` (#1082).
 		//
 		// `set_services` registers under the project's name in the process-wide
 		// identity-colour registry. Two `Engine` values alive in one process
@@ -101,13 +101,13 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Remove every network carrying this project's `podup.project` label — the
+	/// Remove every network carrying this project's `podup.project` label: the
 	/// implicit `<project>_default`, a network whose compose key changed, or any
 	/// project network when no file is present. Only podup-labelled networks
 	/// match, so a user's external network is never touched. Best-effort across
 	/// every network: a list failure leaves networks in place rather than
 	/// aborting teardown, and one network's removal failure never blocks the
-	/// rest — but the first genuine removal failure is returned to the caller
+	/// rest, but the first genuine removal failure is returned to the caller
 	/// (a 404 stays an idempotent no-op) so it can decide whether to aggregate
 	/// it, matching [`Engine::down_by_label`]'s exit-code contract for the same
 	/// class of failure (#598).
@@ -150,9 +150,9 @@ impl Engine {
 	/// Remove every named volume carrying this project's `podup.project` label.
 	/// libpod's `/volumes/json` is fetched in full and filtered client-side by
 	/// the label (mirroring the secret sweep) so only podup-created volumes are
-	/// deleted — a user's hand-made or external volume is never touched.
+	/// deleted: a user's hand-made or external volume is never touched.
 	/// Best-effort across every volume: a list failure leaves volumes in place,
-	/// and one volume's removal failure never blocks the rest — but the first
+	/// and one volume's removal failure never blocks the rest, but the first
 	/// genuine removal failure is returned to the caller (a 404 stays an
 	/// idempotent no-op), matching [`Engine::remove_project_networks_by_label`].
 	pub(super) async fn remove_project_volumes_by_label(

--- a/internal/engine/lifecycle/down_label_tests.rs
+++ b/internal/engine/lifecycle/down_label_tests.rs
@@ -29,7 +29,7 @@ fn volume_owned_by_matches_project_label() {
 
 /// #598 (unfixed on this path until now): `down -p PROJECT` with no compose
 /// file only ever warned on a removal failure and unconditionally returned
-/// `Ok`. Two labelled containers, one whose force-remove genuinely fails —
+/// `Ok`. Two labelled containers, one whose force-remove genuinely fails:
 /// `down_by_label` must still attempt (and complete) the other before
 /// exiting non-zero for the first.
 #[tokio::test]
@@ -74,7 +74,7 @@ async fn down_by_label_propagates_a_real_removal_failure_after_completing_the_re
 }
 
 /// A `down -p PROJECT` on an already torn-down project (no live containers,
-/// nothing left to sweep by label) must still exit 0 — idempotency is
+/// nothing left to sweep by label) must still exit 0; idempotency is
 /// preserved on the label-only path exactly as on `Engine::down`.
 #[tokio::test]
 #[cfg(unix)]

--- a/internal/engine/lifecycle/drop_recheck.rs
+++ b/internal/engine/lifecycle/drop_recheck.rs
@@ -3,7 +3,7 @@
 //! The transport cannot answer it. A libpod call that is severed before its
 //! response completes looks identical whether the operation ran or not (#1104),
 //! and on Podman 6 under concurrency that happens on exactly the state-changing
-//! calls — `exec`, `restart`, `stop`, container `DELETE` — after a slow one
+//! calls (`exec`, `restart`, `stop`, container `DELETE`) after a slow one
 //! (#1339). It is not a client deadline and not a pooled-connection race; both
 //! were ruled out by measurement.
 //!
@@ -18,15 +18,15 @@ use crate::libpod::API_PREFIX;
 /// What a lifecycle operation was trying to achieve.
 ///
 /// The transport cannot say whether a dropped response means the operation
-/// failed or completed and lost only its reply — the two are indistinguishable
+/// failed or completed and lost only its reply; the two are indistinguishable
 /// at HTTP (#1104). This names the observable that answers it out of band.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum LifecycleGoal {
-	/// `start`, `restart` — the container should be running afterwards.
+	/// `start`, `restart`: the container should be running afterwards.
 	Running,
-	/// `kill`, `stop` — the container should not be running afterwards.
+	/// `kill`, `stop`: the container should not be running afterwards.
 	NotRunning,
-	/// `rm` — the container should not exist afterwards. Distinct from
+	/// `rm`: the container should not exist afterwards. Distinct from
 	/// [`Self::NotRunning`]: a stopped-but-present container satisfies that one
 	/// and would read a failed removal as a success.
 	Gone,
@@ -34,11 +34,11 @@ pub(super) enum LifecycleGoal {
 
 impl LifecycleGoal {
 	/// Whether libpod's `State` satisfies this goal. `None` means the container
-	/// no longer exists — which reaches `NotRunning` and `Gone`, and fails
+	/// no longer exists, which reaches `NotRunning` and `Gone`, and fails
 	/// `Running`.
 	///
 	/// The state field is currently always lowercase (validated against
-	/// `libpod/define/containerstate.go::ContainerStatus.String()` — returns
+	/// `libpod/define/containerstate.go::ContainerStatus.String()`, which returns
 	/// `"unknown"|"created"|...|"stopping"`) but the test is case-insensitive so
 	/// a future libpod returning `Running` or `RUNNING` does not produce a
 	/// false negative (#1369).
@@ -56,7 +56,7 @@ impl Engine {
 	/// Decide whether an operation whose response was dropped actually landed.
 	///
 	/// Shared by every state-changing call that can lose its reply, so they
-	/// cannot drift into different answers to the same question — the way the
+	/// cannot drift into different answers to the same question, the way the
 	/// lane's retry list and its flake counter drifted apart in #1104.
 	///
 	/// Success requires the container to have reached `goal`. Both other shapes

--- a/internal/engine/lifecycle/drop_recheck_tests.rs
+++ b/internal/engine/lifecycle/drop_recheck_tests.rs
@@ -1,7 +1,7 @@
 //! A lifecycle POST whose response is dropped is resolved out of band (#1339).
 //!
 //! Measured on Podman 6 under concurrency: the drops land on state-changing
-//! POSTs — `exec`, `restart`, `stop`, container `DELETE` — and follow a slow
+//! POSTs (`exec`, `restart`, `stop`, container `DELETE`) and follow a slow
 //! one, a restart that burned its full stop grace before the next request lost
 //! its response. It is not a client deadline (`READ_TIMEOUT` is 120s) and not a
 //! pooled-connection race (there is no pool; every request opens a fresh
@@ -18,7 +18,7 @@ fn a_goal_is_reached_only_by_the_state_that_satisfies_it() {
 	assert!(!LifecycleGoal::Running.reached(Some("exited")));
 	assert!(!LifecycleGoal::Running.reached(Some("paused")));
 	// A container that no longer exists never satisfies `Running`, and always
-	// satisfies `NotRunning` — `rm` and a lost `kill` response both land here.
+	// satisfies `NotRunning`: `rm` and a lost `kill` response both land here.
 	assert!(!LifecycleGoal::Running.reached(None));
 	assert!(LifecycleGoal::NotRunning.reached(None));
 	assert!(LifecycleGoal::NotRunning.reached(Some("exited")));
@@ -46,7 +46,7 @@ mod over_the_wire {
 			// which is a test that measures nothing.
 			let touches_it = target.contains("/proj-web-1");
 			if touches_it && (method == "POST" || method == "DELETE") {
-				// Accept, then hang up without a response — the one shape that
+				// Accept, then hang up without a response: the one shape that
 				// produces hyper's `IncompleteMessage`.
 				return FakeReply::ClosedWithoutResponse;
 			}
@@ -99,7 +99,7 @@ mod over_the_wire {
 		// Pin the variant: a dropped response that re-checks to a non-running
 		// state must surface as the underlying libpod error, not as some
 		// other variant a future refactor might swap in. `confirm_lost_response`
-		// is the one place that does this — a regression here would otherwise
+		// is the one place that does this, and a regression here would otherwise
 		// be invisible because the test would still see *some* Err.
 		assert!(
 			matches!(err, crate::error::ComposeError::Podman(_)),
@@ -156,7 +156,7 @@ mod over_the_wire {
 }
 
 /// `Gone` is not `NotRunning`. A removal that lost its response must not be read
-/// as success just because the container stopped — it has to be absent.
+/// as success just because the container stopped; it has to be absent.
 #[test]
 fn gone_needs_absence_not_merely_a_stopped_container() {
 	assert!(LifecycleGoal::Gone.reached(None));
@@ -192,7 +192,7 @@ mod stop_and_remove {
 			.expect_err("still running is not a stop");
 		// The dropped-stop branch in `stop_container` falls through to
 		// `confirm_lost_response` with `LifecycleGoal::NotRunning`, which
-		// builds `ComposeError::Podman` on a state mismatch — pin the
+		// builds `ComposeError::Podman` on a state mismatch, so pin the
 		// variant so a regression that swaps in `StreamTruncated` (the
 		// other "ended unexpectedly" variant) cannot silently satisfy this
 		// test.
@@ -202,7 +202,7 @@ mod stop_and_remove {
 		);
 	}
 
-	/// And removal, which needs the container **absent** — a stopped-but-present
+	/// And removal, which needs the container **absent**: a stopped-but-present
 	/// container would satisfy `NotRunning` and read a failed removal as success.
 	#[tokio::test]
 	async fn a_lost_removal_response_fails_when_the_container_is_merely_stopped() {
@@ -215,7 +215,7 @@ mod stop_and_remove {
 		// Same pattern as the stop test: `teardown_one_container`'s dropped
 		// arm goes through `confirm_lost_response` with `LifecycleGoal::Gone`,
 		// and a stopped-but-present container fails `Gone`. The variant is
-		// the contract — anything else would be a regression in the
+		// the contract; anything else would be a regression in the
 		// fail-closed shape this whole file pins.
 		assert!(
 			matches!(err, crate::error::ComposeError::Podman(_)),

--- a/internal/engine/lifecycle/images.rs
+++ b/internal/engine/lifecycle/images.rs
@@ -13,7 +13,7 @@ impl Engine {
 	/// project-scoped `{project}-{service}:latest`).
 	///
 	/// This is the name `up` checks for presence and the name `down --rmi local`
-	/// removes, so both must agree on it — they used to compute it separately.
+	/// removes, so both must agree on it; they used to compute it separately.
 	pub(super) fn service_image_tag(&self, name: &str, service: &Service) -> String {
 		match &service.image {
 			Some(image) => image.clone(),
@@ -38,7 +38,7 @@ impl Engine {
 		// suppresses building even for services with a `build:` section (they fall
 		// back to pulling/using an existing image). Validated through
 		// [`crate::engine::build::pull_policy_checked`] so a typo'd
-		// `pull_policy:` cannot be silently treated as `missing` here — the
+		// `pull_policy:` cannot be silently treated as `missing` here: the
 		// skip-only-when-missing arm below would otherwise hide the bad value
 		// from `up` entirely (#1443).
 		let raw_policy = self
@@ -52,7 +52,7 @@ impl Engine {
 		//
 		// Building unconditionally was worse than redundant. The rebuild runs
 		// *with* the cache, so it can resolve to an older layer chain and retag
-		// the image backwards — silently undoing a `podup build --no-cache` that
+		// the image backwards, silently undoing a `podup build --no-cache` that
 		// just ran. `build --no-cache && up -d`, the ordinary deploy shape, would
 		// start the previous image. It also made `--build` look like a no-op,
 		// since the default already always built.
@@ -75,7 +75,7 @@ impl Engine {
 					.await?
 			}
 			// A service with a `build:` whose image is already present needs no
-			// pull either — the local tag is the declared state.
+			// pull either; the local tag is the declared state.
 			(false, _) if service.build.is_some() => {}
 			(false, "never") => {}
 			// Under `missing`, an image the prefetch stage already saw on this
@@ -93,7 +93,7 @@ impl Engine {
 	///
 	/// False for anything but a normalized `missing` policy: `always` and
 	/// `newer` mean go to the registry, and widening this to them would bring
-	/// back #1076, where a pull that failed was reported as success — libpod
+	/// back #1076, where a pull that failed was reported as success: libpod
 	/// sends that failure as an in-band line on a 200, so no pull means no line
 	/// to miss.
 	///
@@ -128,7 +128,7 @@ impl Engine {
 /// Tests for the pull decision above.
 ///
 /// They drive a whole `up`, so they would sit as naturally in the lifecycle
-/// suite — but that file was already at 487 of its 500 code lines, and adding
+/// suite, but that file was already at 487 of its 500 code lines, and adding
 /// them there put it over. They belong next to the decision they pin anyway,
 /// the same way `prefetch.rs` keeps its own.
 #[cfg(test)]

--- a/internal/engine/lifecycle/images_tests.rs
+++ b/internal/engine/lifecycle/images_tests.rs
@@ -6,7 +6,7 @@ fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
 }
 
-/// A libpod stand-in for a host that already has every image asked about — the
+/// A libpod stand-in for a host that already has every image asked about: the
 /// warm state the pull-skip decision turns on. Shared by the three tests that
 /// exercise that decision, so they cannot drift apart on what "already here"
 /// means.
@@ -30,7 +30,7 @@ fn present_image_engine(method: &str, target: &str) -> (u16, String) {
 ///
 /// The prefetch stage checks presence once and returns without pulling, and then
 /// `acquire_service_image` pulled anyway, per service, under the effective
-/// `missing` policy — 42 of the 88 requests a 42-service warm `up` issued, and a
+/// `missing` policy: 42 of the 88 requests a 42-service warm `up` issued, and a
 /// `Pulling` line on the user's terminal for each. docker compose against the
 /// same engine prints none.
 ///
@@ -66,7 +66,7 @@ async fn warm_up_does_not_pull_an_image_the_host_already_has() {
 /// The two services share one image on purpose, with different policies. With
 /// `always` alone the prefetch stage never records the image as present, so the
 /// skip could not fire whatever the policy check said, and the test would pass
-/// for the wrong reason — it did, until a mutation run showed it surviving the
+/// for the wrong reason; it did, until a mutation run showed it surviving the
 /// removal of the very guard it is named for. The `missing` service is what
 /// records the observation, which is the only state where that guard is the one
 /// thing standing between `always` and a skipped registry visit.
@@ -120,7 +120,7 @@ async fn a_platform_pinned_service_still_pulls_an_image_the_host_already_has() {
 /// be silently treated as `missing` and skip the only pull that would have
 /// surfaced the bad value. The host stands in for one that already has the
 /// image (so the skip branch *would* fire), and the assertion is that the
-/// error fires instead — without the fix the call returned `true` and the
+/// error fires instead: without the fix the call returned `true` and the
 /// pull was skipped, leaving `up` to exit 0 with the wrong image.
 #[tokio::test]
 async fn image_already_seen_present_rejects_an_unknown_pull_policy() {
@@ -128,8 +128,8 @@ async fn image_already_seen_present_rejects_an_unknown_pull_policy() {
 	// Pre-populate the prefetch's seen-present set as if a previous
 	// `prefetch_images` had confirmed the image on this host. Without the
 	// fix `image_already_seen_present` would then return `true` for any
-	// service whose effective policy it read as `missing` — including a
-	// typo'd `pull_policy:` — and the only pull that could have surfaced
+	// service whose effective policy it read as `missing`, including a
+	// typo'd `pull_policy:`, and the only pull that could have surfaced
 	// the bad value would be skipped.
 	e.images_seen_present
 		.lock()

--- a/internal/engine/lifecycle/parallel.rs
+++ b/internal/engine/lifecycle/parallel.rs
@@ -5,7 +5,7 @@
 //! `depends_on` satisfied by an earlier level, so services *within* a level have
 //! no ordering between them and can be acted on concurrently. The whole-project
 //! lifecycle commands (stop/start/restart/kill/rm/pause/unpause/down) walk the
-//! levels in order — preserving the cross-level dependency ordering — but
+//! levels in order, preserving the cross-level dependency ordering, but
 //! dispatch each level's per-service (or, for teardown, per-container)
 //! operations in parallel instead of strictly serially, so a restart/stop/down
 //! of many independent services no longer serializes every grace period (#757).
@@ -111,7 +111,7 @@ pub(super) fn retain_levels(
 /// target subset (used only to label cascade-restarts distinctly in the logs).
 ///
 /// With no targets every service is restarted. With targets, the set is the
-/// targets plus — unless `no_deps` — every service whose `depends_on` carries a
+/// targets plus, unless `no_deps`, every service whose `depends_on` carries a
 /// `restart: true` condition pointing at one of the targets (one hop, matching
 /// the previous serial implementation).
 pub(super) fn restart_service_set(
@@ -161,7 +161,7 @@ impl Engine {
 			match self.stop_container(&container_name, grace).await {
 				Ok(true) => acted.store(true, std::sync::atomic::Ordering::Relaxed),
 				Ok(false) => {
-					tracing::debug!("{container_name}: not running — stop is a no-op");
+					tracing::debug!("{container_name}: not running, stop is a no-op");
 				}
 				Err(e) => {
 					first_err.get_or_insert(e);
@@ -279,7 +279,7 @@ impl Engine {
 			// `Removing` would be flushed as such by the plain sink.
 			crate::ui::progress::start("Container", &container_name, "Removing");
 			match self.client.delete_existed(&path).await {
-				// Only report a removal that actually happened — a phantom
+				// Only report a removal that actually happened: a phantom
 				// (never-created) container 404s and must not be logged as
 				// "removed".
 				Ok(true) => {
@@ -293,7 +293,7 @@ impl Engine {
 				Err(e) if !force && e.is_status(409) => {
 					crate::ui::progress_line("Container", &container_name, "Skipped");
 					tracing::warn!(
-						"{container_name} is running — skipping (pass -f to force removal)"
+						"{container_name} is running; skipping (pass -f to force removal)"
 					);
 				}
 				Err(e) => {
@@ -336,12 +336,12 @@ impl Engine {
 
 	/// Tear down one already-known-live container: run its `pre_stop` hooks (if
 	/// any), a best-effort stop bounded by `grace`, then a forced removal. One
-	/// unit of work in a concurrent teardown level/batch — shared by
+	/// unit of work in a concurrent teardown level/batch, shared by
 	/// [`super::Engine::down_with_options`] (per dependency level) and
 	/// [`super::Engine::down_by_label`] (one label-scoped batch, no dependency
 	/// graph to level).
 	///
-	/// A stalled or failed `stop` is never surfaced as an error here — the
+	/// A stalled or failed `stop` is never surfaced as an error here: the
 	/// forced removal that follows SIGKILLs the container regardless of how
 	/// `stop` went (`container_rm_path` always passes `force=true`), so only a
 	/// genuine removal failure propagates. A 404 (container already gone) is an
@@ -372,10 +372,10 @@ impl Engine {
 		);
 		// A 404 (container already gone, or a profile-gated service that was
 		// never created) is an idempotent no-op here, exactly as the network and
-		// volume removal arms treat it — not a warning. A stalled or failed stop
+		// volume removal arms treat it, not a warning. A stalled or failed stop
 		// is not fatal either: the force-remove just below SIGKILLs the
 		// container regardless, so its outcome is logged but never returned as
-		// an error — only a genuine removal failure is.
+		// an error; only a genuine removal failure is.
 		if let Err(e) = self
 			.client
 			.post_empty_ok_within(&stop_path, stop_deadline(grace))
@@ -392,7 +392,7 @@ impl Engine {
 				crate::ui::progress_line("Container", container_name, "Removed");
 				Ok(())
 			}
-			// The container was already gone (404) — nothing to do, but the row
+			// The container was already gone (404), so nothing to do, but the row
 			// has to close, or the live board leaves it spinning on `Stopping`
 			// forever (#1347).
 			Err(e) if e.is_status(404) => {

--- a/internal/engine/lifecycle/prefetch.rs
+++ b/internal/engine/lifecycle/prefetch.rs
@@ -5,13 +5,13 @@
 //! service's image acquisition does not even begin until every level-1 service
 //! is fully up. This stage collects every image the upcoming `up`/`create` pass will
 //! pull and warms the local Podman cache for all of them up front,
-//! concurrently, before the first level barrier — instead of one at a time as
+//! concurrently, before the first level barrier, instead of one at a time as
 //! each level's services reach their turn.
 //!
 //! Best-effort only for prefetch *misses*: an unreachable socket or a registry
 //! that 500s is logged at debug and otherwise swallowed. `up_one_service`'s
 //! own pull call is unchanged and remains the sole source of a real pull
-//! failure — this stage can only make `up` faster, never change whether it
+//! failure: this stage can only make `up` faster, never change whether it
 //! succeeds.
 //!
 //! An invalid `pull_policy:` (or `--pull`) is **not** a prefetch miss. It is
@@ -50,7 +50,7 @@ impl Engine {
 		target_set: &Option<HashSet<String>>,
 	) -> Result<()> {
 		// One representative service per unique image reference is enough to
-		// issue the pull — this is what dedupes 50 services on one image down
+		// issue the pull; this is what dedupes 50 services on one image down
 		// to a single request instead of 50. The service *name* travels with
 		// the representative so the pull / policy error can name it, instead
 		// of using the image as a stand-in for the originating service.
@@ -92,13 +92,13 @@ impl Engine {
 				Ok(p) => p,
 				// Propagate the validation error out of the prefetch join via a
 				// shared poison cell. The prefetch stage itself is best-effort
-				// for *I/O*, but a configuration error must surface loud — the
+				// for *I/O*, but a configuration error must surface loud: the
 				// outer `join_bounded` join collapses every concurrent task into
 				// one result, and there is no other channel back (#1443).
 				Err(e) => return Err(e),
 			};
 			// `missing` (and its aliases, already normalized by
-			// `pull_policy_checked`) only pulls when the image is absent —
+			// `pull_policy_checked`) only pulls when the image is absent, so
 			// checking first turns a warm cache into a cheap presence check
 			// instead of a redundant pull request. `always`/`newer` mean to
 			// hit the registry regardless, so skip the check and prefetch
@@ -108,7 +108,7 @@ impl Engine {
 				// Record what this check just observed, so the per-service pull
 				// site does not repeat it: without this the stage returns having
 				// learned the image is here, and `acquire_service_image` pulls it
-				// once per service anyway — 42 of the 88 requests a 42-service
+				// once per service anyway: 42 of the 88 requests a 42-service
 				// warm `up` used to issue.
 				//
 				// Not recorded for a service pinning `platform:`. Presence is
@@ -126,7 +126,7 @@ impl Engine {
 			// own pull below is the authoritative one. Reporting from both is
 			// what made `Pulling` appear twice per image on `up` while a
 			// standalone `pull` printed it once. A prefetch I/O miss is still
-			// debug-only — only the validation error above escapes.
+			// debug-only; only the validation error above escapes.
 			if let Err(e) = self.pull_image_quietly(name, service).await {
 				tracing::debug!("prefetch miss for {image}: {e}");
 			}

--- a/internal/engine/lifecycle/prefetch_tests.rs
+++ b/internal/engine/lifecycle/prefetch_tests.rs
@@ -12,7 +12,7 @@ fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 }
 
 /// Two services on the same image pull it once, and a `never`-policy
-/// service plus a `build:` service are excluded entirely — the image
+/// service plus a `build:` service are excluded entirely: the image
 /// reference never appears in a request at all.
 #[tokio::test]
 #[cfg(unix)]
@@ -133,7 +133,7 @@ async fn prefetch_rejects_an_unknown_pull_policy() {
 }
 
 /// An invalid `--pull` override (no service context) must also propagate
-/// out of the prefetch stage — same bug as the per-service typo, just
+/// out of the prefetch stage, the same bug as the per-service typo, just
 /// applied to every service at once. Before the fix the dedup phase
 /// would treat every service's effective policy as `missing` and warm
 /// every cache it could reach with the wrong intent (#1443).

--- a/internal/engine/lifecycle/readiness.rs
+++ b/internal/engine/lifecycle/readiness.rs
@@ -2,7 +2,7 @@
 //!
 //! When several services in a dependency level declare `depends_on: <svc>:
 //! {condition: service_healthy}`, they start concurrently and would each poll
-//! that container's healthcheck — and every poll *runs* the check inside the
+//! that container's healthcheck, and every poll *runs* the check inside the
 //! container, so a service N others wait on gets its healthcheck executed ~N×
 //! per interval for the whole startup. [`Engine::build_readiness_map`] memoizes
 //! one poller per container so the check runs once per interval regardless of
@@ -74,7 +74,7 @@ impl Engine {
 				if !enabled.contains(&dep) {
 					continue;
 				}
-				// A disabled healthcheck is treated as satisfied — never polled.
+				// A disabled healthcheck is treated as satisfied and never polled.
 				if dep_service
 					.healthcheck
 					.as_ref()
@@ -107,12 +107,12 @@ impl Engine {
 /// [`ComposeError::DependencyNotReady`] for every failure changes what `up()`
 /// returns: code matching `ComposeError::HealthCheckTimeout(_)` stops matching
 /// once the poller is shared, even though the message and the exit code are
-/// identical — an invisible break of a frozen public API.
+/// identical: an invisible break of a frozen public API.
 ///
 /// `wait_healthy` fails exactly three ways. Two carry cheap owned data and are
 /// reconstructed exactly, so a caller sees the variant it saw before the poller
 /// was shared. A [`ComposeError::Podman`] transport error holds a non-`Clone`
-/// payload and cannot be rebuilt, so it keeps the transparent wrapper — which is
+/// payload and cannot be rebuilt, so it keeps the transparent wrapper, which is
 /// what [`ComposeError::innermost`] exists to peel.
 pub(super) fn unshare_readiness_error(shared: &Arc<ComposeError>) -> ComposeError {
 	match &**shared {

--- a/internal/engine/lifecycle/readiness_tests.rs
+++ b/internal/engine/lifecycle/readiness_tests.rs
@@ -8,7 +8,7 @@ use crate::libpod::Client;
 
 fn engine(project: &str) -> Engine {
 	// The map is built without any socket call (the shared futures are lazy),
-	// so a client bound to a never-opened path is enough — no runtime needed.
+	// so a client bound to a never-opened path is enough, with no runtime needed.
 	let client = Client::new("/tmp/podup-readiness-test.sock");
 	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
 }
@@ -20,8 +20,8 @@ fn enabled_all(file: &crate::compose::types::ComposeFile) -> HashSet<String> {
 #[test]
 fn shares_one_poller_per_service_healthy_container() {
 	// web and api both wait on db with `service_healthy`; cache is waited on
-	// with `service_started` (never polled). Exactly one shared entry — db's
-	// container — must result, not one per dependent.
+	// with `service_started` (never polled). Exactly one shared entry, db's
+	// container, must result, not one per dependent.
 	let yaml = "\
 services:
   db:
@@ -80,7 +80,7 @@ services:
 fn sharing_a_poller_preserves_the_error_variant() {
 	// Regression guard for the public error contract: sharing the poller must
 	// not change which variant `up()` returns. Both reconstructible causes are
-	// asserted by variant, not by message — the wrapper displays transparently,
+	// asserted by variant, not by message: the wrapper displays transparently,
 	// so a message assertion would have passed while the contract was broken.
 	let timeout = Arc::new(ComposeError::HealthCheckTimeout("db-1".into()));
 	assert!(matches!(

--- a/internal/engine/lifecycle/run.rs
+++ b/internal/engine/lifecycle/run.rs
@@ -57,7 +57,7 @@ impl Engine {
 		} = self.run_overrides.clone();
 		let no_tty = self.run_no_tty;
 		// Same rule as `exec`: a TTY on both ends by default, `-T` to opt out,
-		// and only when stdin is actually a terminal — so a script or a pipeline
+		// and only when stdin is actually a terminal, so a script or a pipeline
 		// keeps the streaming path it has always had, unchanged.
 		let want_tty = crate::engine::wants_interactive_run(no_tty, detach);
 		// `--env-file` and `-l/--label` are carried on the engine (not
@@ -75,7 +75,7 @@ impl Engine {
 
 		// Compose `run` brings up the service's `depends_on` services first (and
 		// waits on their conditions), unless `--no-deps` is given. The service
-		// itself is excluded — only its transitive dependencies are started.
+		// itself is excluded; only its transitive dependencies are started.
 		if !no_deps {
 			let deps: Vec<String> =
 				super::targets::expand_targets(file, &[service_name.to_string()], false)
@@ -170,7 +170,7 @@ impl Engine {
 				.push(crate::compose::types::PortMapping::Short(p));
 		}
 		// Non-TTY forces Podman's multiplexed log framing, which is what the
-		// streaming path below decodes — TTY mode sends raw bytes with no 8-byte
+		// streaming path below decodes: TTY mode sends raw bytes with no 8-byte
 		// header and would garble that reader. The interactive path does not use
 		// that reader at all: it attaches to the raw stream, which is exactly the
 		// framing a TTY produces. So the two are consistent, not contradictory.
@@ -236,7 +236,7 @@ impl Engine {
 		// don't accumulate orphaned 'Created' containers.
 		// Interactive runs create first and start later, with the attach in
 		// between: a container started before anything is listening loses
-		// whatever it printed in that gap, and for `run` — a one-shot command —
+		// whatever it printed in that gap, and for `run`, a one-shot command,
 		// that gap is often the entire output.
 		if let Err(e) = self
 			.create_and_start(&run_name, service_name, &run_service, file, !want_tty)

--- a/internal/engine/lifecycle/run_attached.rs
+++ b/internal/engine/lifecycle/run_attached.rs
@@ -7,7 +7,7 @@
 //! The order here is the whole point. `attach` opens before `start`, because a
 //! container that has already run has already printed, and for a one-shot `run`
 //! that missed output is often all the output there was. `exec` does not have
-//! this problem — the container is already up — which is why it can attach and
+//! this problem (the container is already up) which is why it can attach and
 //! start in a single call and this cannot.
 
 use std::time::Duration;
@@ -31,8 +31,8 @@ impl super::super::Engine {
 	/// terminal over until the command exits. Returns its exit code.
 	pub(super) async fn run_attached(&self, container_name: &str) -> Result<i64> {
 		// stdin=1 so keystrokes reach the command; stream=1 keeps the connection
-		// open both ways. With a TTY the stream is raw — no 8-byte frame headers,
-		// because the pty merges stdout and stderr — which is also why an
+		// open both ways. With a TTY the stream is raw, with no 8-byte frame headers,
+		// because the pty merges stdout and stderr, which is also why an
 		// interactive run cannot separate them, exactly as `podman run -it`.
 		let attach_path = format!(
 			"{API_PREFIX}/containers/{}/attach?stream=1&stdin=1&stdout=1&stderr=1",
@@ -50,9 +50,9 @@ impl super::super::Engine {
 		);
 		if let Err(e) = self.client.post_empty_ok(&start_path).await {
 			// The `attach` already opened the stream. The container may have
-			// written bytes — startup banners, an error it flushed before the
+			// written bytes (startup banners, an error it flushed before the
 			// daemon returned 4xx to our `start`, anything the runtime prints
-			// before the libpod handler rejects the request — and the kernel
+			// before the libpod handler rejects the request) and the kernel
 			// keeps that buffer alive until we close or drain the socket.
 			// Drop the connection here without reading and the peer blocks on
 			// the next `write` until the socket is GC'd; with a long-lived
@@ -90,7 +90,7 @@ impl super::super::Engine {
 /// path drains the same buffer through `pump_terminal` while it pumps bytes
 /// to the caller's terminal, and the failure path must not enter raw mode or
 /// read from stdin (that is the whole reason `pump_terminal` is gated on a
-/// successful start) — so this is the bounded-read variant that drops the
+/// successful start) so this is the bounded-read variant that drops the
 /// bytes on the floor.
 async fn drain_hijacked(hijacked: crate::libpod::client::Hijacked) {
 	let mut stream = hijacked.stream;

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -22,13 +22,13 @@ pub(crate) struct LiveContainer {
 	pub state: String,
 }
 
-/// Whether a container in this state is currently active — i.e. `stop` would
+/// Whether a container in this state is currently active, i.e. `stop` would
 /// actually transition it. A `running` or `paused` container is stopped; a
 /// `created`/`exited`/`dead`/… one is already not running, so stopping it is a
 /// no-op that must not be reported as "stopped" (#876). Pure for unit testing.
 ///
 /// Unused in production since the per-service lifecycle commands stopped
-/// filtering by state themselves (#1363) — kept here for the unit test that
+/// filtering by state themselves (#1363), kept here for the unit test that
 /// pins its truth table.
 #[allow(dead_code)]
 pub(crate) fn state_is_active(state: &str) -> bool {
@@ -170,8 +170,8 @@ impl Engine {
 	/// Surplus containers are stopped and removed concurrently so a large
 	/// scale-down costs roughly one grace period rather than one per replica.
 	///
-	/// Best-effort across every surplus replica — one that fails to stop/remove
-	/// must not block the rest from being reclaimed — but the first real
+	/// Best-effort across every surplus replica (one that fails to stop/remove
+	/// must not block the rest from being reclaimed) but the first real
 	/// failure is remembered and returned once every replica has been
 	/// attempted, so `scale`/`up --scale` does not exit 0 with a surplus
 	/// replica silently left running (#598).
@@ -341,7 +341,7 @@ impl Engine {
 	/// replicas are kept on purpose so a service scaled beyond its static
 	/// compose count (or never reaped by a prior `down`) is not silently
 	/// dropped from the bucket. The static-name fallback for a service absent
-	/// from the map is the *caller's* responsibility — this helper returns an
+	/// from the map is the *caller's* responsibility; this helper returns an
 	/// empty vec for one, since it does not see the compose file.
 	pub(crate) async fn live_project_replicas_sorted(
 		&self,
@@ -399,7 +399,7 @@ impl Engine {
 	/// (`top`), where a stopped replica has to be skipped rather than asked: the
 	/// libpod endpoints answer a non-running container with an HTTP 500, which
 	/// callers must not have to tell apart from a real failure by parsing its
-	/// message. There is no fallback to statically-derived names — a service
+	/// message. There is no fallback to statically-derived names: a service
 	/// that was never created has nothing running, so it yields an empty vec
 	/// instead of a phantom name.
 	pub(crate) async fn running_replica_names(&self, service_name: &str) -> Result<Vec<String>> {

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -29,7 +29,7 @@ fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 
 /// #598: a `scale`/`up --scale` down-sizing that can't remove a surplus
 /// replica (e.g. an active exec session) must not exit 0 with it left
-/// running — but a sibling replica that removes cleanly must still be
+/// running, but a sibling replica that removes cleanly must still be
 /// reclaimed.
 #[tokio::test]
 #[cfg(unix)]
@@ -70,7 +70,7 @@ async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_t
 }
 
 /// Surplus replicas that are already gone (404 on removal) stay an
-/// idempotent no-op — a re-run of `scale` down must still exit 0.
+/// idempotent no-op: a re-run of `scale` down must still exit 0.
 #[tokio::test]
 #[cfg(unix)]
 async fn remove_surplus_replicas_tolerates_already_gone() {
@@ -132,7 +132,7 @@ async fn live_project_replicas_sorted_sorts_shuffled_replicas_ascending() {
 
 /// #1445: the bulk GET that the per-replica query paths now share must
 /// cover a scaled service's full replica set, including replicas that are
-/// stopped — `logs`/`port`/`exec` need to see the second replica even when
+/// stopped: `logs`/`port`/`exec` need to see the second replica even when
 /// it is in `exited`, so the bulk request must NOT silently drop them the
 /// way libpod's `runningOnly` default would.
 #[tokio::test]
@@ -157,7 +157,7 @@ async fn live_project_replicas_sorted_includes_stopped_replicas() {
 		.await
 		.expect("live_project_replicas_sorted should succeed");
 
-	// All three replicas — running and stopped — must be in the bucket.
+	// All three replicas, running and stopped, must be in the bucket.
 	// A bug that silently filtered to running (libpod's `runningOnly`
 	// default) would return just `proj-web-1` and `proj-web-2`, missing the
 	// third replica entirely.
@@ -168,7 +168,7 @@ async fn live_project_replicas_sorted_includes_stopped_replicas() {
 			"proj-web-2".to_string(),
 			"proj-web-3".to_string(),
 		]),
-		"the stopped replica must not be filtered out — got {:?}",
+		"the stopped replica must not be filtered out; got {:?}",
 		by_service.get("web")
 	);
 }
@@ -178,7 +178,7 @@ async fn live_project_replicas_sorted_includes_stopped_replicas() {
 /// the compose file; the per-replica query paths (`exec`/`cp`/`port`/
 /// `logs`) layer the static-name fallback on top. Without that contract,
 /// `logs` could not `docker compose logs`-style behave on a never-created
-/// service — `port`/`exec`/`cp` would 404 immediately instead of letting
+/// service: `port`/`exec`/`cp` would 404 immediately instead of letting
 /// the caller see the predictable static name.
 #[tokio::test]
 #[cfg(unix)]
@@ -218,7 +218,7 @@ async fn live_project_replicas_sorted_omits_services_with_no_live_container() {
 }
 
 /// #1445: the per-replica query paths used to fan out one container-list
-/// round-trip per service — 40 services meant 40 GETs for a single
+/// round-trip per service: 40 services meant 40 GETs for a single
 /// `podup logs`. The bulk helper is the shared single GET. With the fake
 /// pinned to answer only `/containers/json`, a single resolution call must
 /// still satisfy the per-service query helpers without issuing a follow-up
@@ -230,7 +230,7 @@ async fn live_project_replicas_sorted_omits_services_with_no_live_container() {
 #[cfg(unix)]
 async fn logs_resolves_replicas_in_one_bulk_get_not_one_per_service() {
 	// Three services; `db` is scaled to 3, `web` to 2, `worker` to 1, all
-	// running — so the bulk GET is the only fetch needed for `logs` to
+	// running, so the bulk GET is the only fetch needed for `logs` to
 	// find 6 targets across 3 services.
 	let body = r#"[
 		{"Names":["/proj-db-1"],"Labels":{"podup.service":"db"}},
@@ -259,7 +259,7 @@ async fn logs_resolves_replicas_in_one_bulk_get_not_one_per_service() {
 	file.services
 		.insert("worker".into(), crate::compose::types::Service::default());
 
-	// Drive `logs` once across all 3 services — the resolution path is the
+	// Drive `logs` once across all 3 services; the resolution path is the
 	// one under test, not the streaming.
 	let _ = e
 		.logs_with_options(&file, &[], crate::engine::query::LogsOptions::default())
@@ -281,7 +281,7 @@ async fn logs_resolves_replicas_in_one_bulk_get_not_one_per_service() {
 /// every container that exists for its process list, and libpod answers a
 /// non-running one with an HTTP 500. The exited replica must be dropped
 /// before the call, and the survivors must keep the ascending order every
-/// other by-service command produces — so this asserts both, on a listing
+/// other by-service command produces, so this asserts both, on a listing
 /// that is shuffled and mixed-state at once.
 #[tokio::test]
 #[cfg(unix)]
@@ -341,7 +341,7 @@ async fn running_replica_names_does_not_fall_back_to_static_names() {
 	);
 }
 
-/// #1363 — the bulk project listing must include every project's
+/// #1363: the bulk project listing must include every project's
 /// containers, not just the running ones. With `all=true` libpod drops the
 /// `runningOnly` default and a 100-service project with 5 stopped replicas
 /// returns all 100 names; the gotcha caught during validation was a bare
@@ -391,7 +391,7 @@ async fn live_project_replicas_returns_every_project_container_including_stopped
 		"every project container must be returned (5 stopped included)"
 	);
 	// The 5 stopped services (svc000, svc020, …, svc080) must each be
-	// present with their replica name — i.e. `all=true` actually carried
+	// present with their replica name, i.e. `all=true` actually carried
 	// past the default filter, not just "runningOnly expanded to one".
 	for i in (0..100).step_by(20) {
 		let svc = format!("svc{i:03}");
@@ -415,7 +415,7 @@ async fn live_project_replicas_returns_every_project_container_including_stopped
 		"the bulk GET must pass all=true, got {container_list:?}"
 	);
 	// And no `status=` filter sneaked in that would have achieved the
-	// same effect — we want the all-inclusive default, not a workaround.
+	// same effect; we want the all-inclusive default, not a workaround.
 	assert!(
 		!container_list.contains("status="),
 		"the bulk GET must rely on all=true alone, not a status filter: {container_list:?}"
@@ -525,7 +525,7 @@ fn unnamed_service_scales_freely() {
 /// #1445 is a round-trip count, so pin the count rather than only the values it
 /// produces. Before it, every selected service cost its own `/containers/json`
 /// GET; a project of N services made N of them. Nothing in the value assertions
-/// above notices if that regresses — the names come back identical either way —
+/// above notices if that regresses (the names come back identical either way)
 /// so a later refactor could quietly put the call back inside the loop.
 ///
 /// Four services, and the fake records every request it answers. The assertion

--- a/internal/engine/lifecycle/schedule.rs
+++ b/internal/engine/lifecycle/schedule.rs
@@ -36,7 +36,7 @@ impl Engine {
 		//
 		// The levels are still resolved, because that is what validates the
 		// graph (a cycle or a missing required dependency is an error before
-		// anything is created) — they just no longer gate execution.
+		// anything is created); they just no longer gate execution.
 		//
 		// Measured cost of the barrier on a 41-service level with one dependent
 		// behind one of them: the dependent started 809ms after its dependency
@@ -49,7 +49,7 @@ impl Engine {
 		//
 		// * `try_join_all` polls *every* future, so a service blocked on a
 		//   dependency yields and the others make progress. `buffer_unordered`
-		//   would deadlock here — it only polls the first N, and those N can
+		//   would deadlock here: it only polls the first N, and those N can
 		//   all be waiting on a dependency that is queued behind them.
 		// * the concurrency bound is a semaphore held only across the actual
 		//   work, never across a dependency wait, for the same reason.
@@ -76,7 +76,7 @@ impl Engine {
 			let permits = permits.clone();
 			let done = &done;
 			// Only the dependencies this service actually declares, and only
-			// those that are in this run's scheduled set — a service excluded by
+			// those that are in this run's scheduled set; a service excluded by
 			// profiles or an explicit target list is not going to signal.
 			let deps: Vec<tokio::sync::watch::Receiver<bool>> = file
 				.services

--- a/internal/engine/lifecycle/seed.rs
+++ b/internal/engine/lifecycle/seed.rs
@@ -4,7 +4,7 @@
 //! The board needs the resource set up front, and nothing in the tree produced
 //! it: every progress event fires once its own work is over, so a board grown
 //! from those events would only ever show the past. This is the missing half,
-//! and it is derivable — `resolve_levels` already runs before the walk begins,
+//! and it is derivable: `resolve_levels` already runs before the walk begins,
 //! and the networks and volumes come straight off the compose file.
 //!
 //! Deliberately a *prediction*, not a promise. It is computed from the compose
@@ -85,7 +85,7 @@ impl Engine {
 	/// Every resource an `up`/`create` pass will touch, in the order it will
 	/// touch them: networks, then volumes, then containers by dependency level.
 	///
-	/// The order matters as much as the contents — the board's completed rows
+	/// The order matters as much as the contents: the board's completed rows
 	/// scroll away in this order, and that scrollback is the record the command
 	/// leaves behind.
 	pub(super) fn up_resources(
@@ -98,7 +98,7 @@ impl Engine {
 		out.extend(self.volume_resources(file));
 
 		// Containers in dependency order, which is the order they will start.
-		// Falls back to the file's own order if the graph cannot be resolved —
+		// Falls back to the file's own order if the graph cannot be resolved;
 		// a cycle is a real error, but it is `run_up`'s to report, and seeding
 		// must not be the thing that surfaces it.
 		let levels = crate::compose::resolve_levels(file)

--- a/internal/engine/lifecycle/seed_tests.rs
+++ b/internal/engine/lifecycle/seed_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::compose::parse_str;
 
-/// `up_resources` never touches the client — it reads the compose file and the
-/// project name — but an `Engine` needs one, so the tests borrow the same fake
+/// `up_resources` never touches the client (it reads the compose file and the
+/// project name) but an `Engine` needs one, so the tests borrow the same fake
 /// the rest of the lifecycle suite uses. That fake is a unix socket, which is
 /// why this module is `cfg(unix)`.
 fn engine(fake: &crate::engine::fake_podman::FakePodman) -> Engine {
@@ -100,7 +100,7 @@ async fn a_targeted_up_seeds_only_its_targets() {
 }
 
 /// A scaled service gets one row per replica, because the board tracks
-/// containers rather than services — that is the granularity every progress
+/// containers rather than services: that is the granularity every progress
 /// event in the tree already reports at.
 #[tokio::test]
 async fn a_scaled_service_seeds_one_row_per_replica() {

--- a/internal/engine/lifecycle/signal.rs
+++ b/internal/engine/lifecycle/signal.rs
@@ -2,7 +2,7 @@
 //!
 //! `kill` forwards the requested signal to libpod as a `signal=` query
 //! parameter. An empty (or whitespace-only) value renders as `signal=`, which
-//! libpod silently treats as the default SIGKILL — so an unset shell variable
+//! libpod silently treats as the default SIGKILL, so an unset shell variable
 //! passed via `-s "$SIG"` would destroy every targeted container with no
 //! warning. To match `docker compose`'s up-front validation, the signal is
 //! checked here before any request is issued.

--- a/internal/engine/lifecycle/targets.rs
+++ b/internal/engine/lifecycle/targets.rs
@@ -10,7 +10,7 @@ use crate::error::{ComposeError, Result};
 /// Extra wall-clock slack, beyond the grace period, before podup gives up on a
 /// stalled libpod `stop` and escalates to a client-side `SIGKILL`. Podman stops
 /// a container by sending `SIGTERM`, waiting the grace window, then `SIGKILL`
-/// itself — so a healthy stop returns at most ~`grace` seconds in. The buffer
+/// itself, so a healthy stop returns at most ~`grace` seconds in. The buffer
 /// absorbs daemon/reap latency so a slow-but-working stop is never escalated;
 /// anything past it means the libpod call is wedged and we kill independently.
 const STOP_GRACE_BUFFER_SECS: u64 = 30;
@@ -96,7 +96,7 @@ pub(super) fn filter_services(
 ///
 /// The up/create path expands targets into a set without checking membership, so
 /// a bogus name would silently match nothing and exit 0. This validates the list
-/// up front — matching docker-compose and the stop/start/kill commands, which
+/// up front, matching docker-compose and the stop/start/kill commands, which
 /// already reject unknown services via [`filter_services`].
 pub(super) fn validate_targets(file: &ComposeFile, target_services: &[String]) -> Result<()> {
 	for name in target_services {
@@ -114,7 +114,7 @@ pub(super) fn validate_targets(file: &ComposeFile, target_services: &[String]) -
 /// contains the targets plus, unless `no_deps` is set, their transitive
 /// `depends_on` services. Callers must validate `target_services` up front via
 /// [`validate_targets`] so a typo'd/unknown name fails loudly instead of being
-/// silently skipped — mirroring [`filter_services`] (and docker compose's "no
+/// silently skipped, mirroring [`filter_services`] (and docker compose's "no
 /// such service").
 pub(super) fn expand_targets(
 	file: &ComposeFile,
@@ -149,7 +149,7 @@ pub(super) fn expand_targets(
 /// service is in scope, so the answer is always `true`). Otherwise a name is
 /// "started" only if it is present in the set. Under `up --no-deps`,
 /// [`expand_targets`] omits the targets' dependencies, so this returns `false`
-/// for an intentionally-excluded dependency — letting the caller skip its
+/// for an intentionally-excluded dependency, letting the caller skip its
 /// `depends_on` readiness wait, matching docker-compose.
 pub(super) fn in_started_set(target_set: &Option<HashSet<String>>, name: &str) -> bool {
 	match target_set {

--- a/internal/engine/lifecycle/teardown.rs
+++ b/internal/engine/lifecycle/teardown.rs
@@ -48,7 +48,7 @@ impl Engine {
 		// Best-effort across every level/container/network/volume so one failure
 		// never leaves the rest of the teardown undone, but the first real
 		// REMOVAL failure is remembered and returned at the end instead of being
-		// swallowed into a warning — a `down` whose container/network/volume
+		// swallowed into a warning: a `down` whose container/network/volume
 		// removal genuinely fails (storage error, active exec session) must exit
 		// non-zero, not print a warning and exit 0 (#598). A stalled or failed
 		// `stop` does NOT count towards this: the force-remove below SIGKILLs the
@@ -56,16 +56,16 @@ impl Engine {
 		// outcome is aggregated. A 404 (already gone) stays an idempotent no-op
 		// throughout.
 		//
-		// Levels are walked strictly in order — every container in one level is
+		// Levels are walked strictly in order: every container in one level is
 		// attempted before the next level starts, preserving the dependency
-		// inversion above — but the containers *within* one level tear down
+		// inversion above, but the containers *within* one level tear down
 		// concurrently via `join_bounded`, which returns results in input
 		// (service, then container) order rather than completion order. That
 		// keeps "the first error" deterministic regardless of which container
 		// happens to finish first: `first_error` picks the earliest in that
 		// fixed order, and since levels themselves are visited in a fixed
 		// sequence, only the first level with any failure can ever set
-		// `first_err` — a later level's failure is never mistaken for "first".
+		// `first_err`, so a later level's failure is never mistaken for "first".
 		let mut first_err: Option<crate::error::ComposeError> = None;
 
 		for level in &levels {
@@ -75,7 +75,7 @@ impl Engine {
 				// Act only on containers Podman actually has. A defined-but-never-
 				// created service (or one already torn down) has no live
 				// containers, so it contributes nothing here rather than
-				// synthesizing predicted names and POSTing stop/rm to them —
+				// synthesizing predicted names and POSTing stop/rm to them:
 				// those 404 and, pre-fix, leaked warnings. docker compose
 				// enumerates by label and treats "nothing there" as a quiet
 				// idempotent no-op (#758).
@@ -130,7 +130,7 @@ impl Engine {
 			// compose file *declares*, which is not the same set as the networks
 			// that exist. `delete_ok` throws away the boolean that tells the two
 			// apart, so every 404 arrived here as `Ok(())` and was announced as a
-			// removal — measured on a project that had never been created,
+			// removal: measured on a project that had never been created,
 			// `down -v` reported removing two networks and a volume, none of
 			// which had ever existed. The `Err(404)` arm below was unreachable
 			// for the same reason: the layer underneath had already turned the
@@ -138,13 +138,13 @@ impl Engine {
 			crate::ui::progress::start("Network", &network_name, "Removing");
 			match self.client.delete_existed(&net_path).await {
 				Ok(true) => crate::ui::progress_line("Network", &network_name, "Removed"),
-				// The network was already gone (404) — nothing to do, but the row
+				// The network was already gone (404), so nothing to do, but the row
 				// has to close, or the live board leaves it spinning on
 				// `Removing` forever (#1347).
 				Ok(false) => crate::ui::progress_line("Network", &network_name, "Absent"),
 				Err(e) => {
 					tracing::warn!("could not remove network {network_name}: {e}");
-					// Close the row visibly — a `down` whose removal genuinely
+					// Close the row visibly: a `down` whose removal genuinely
 					// failed previously hid the failure behind a spinner (#1347).
 					crate::ui::progress_line("Network", &network_name, "Failed");
 					first_err.get_or_insert(crate::error::ComposeError::Podman(e));
@@ -152,9 +152,9 @@ impl Engine {
 			}
 		}
 
-		// Sweep any remaining project networks by label — the implicit
+		// Sweep any remaining project networks by label: the implicit
 		// `<project>_default` (present only when the file was normalized), or a
-		// network whose compose key changed — mirroring the container sweep so
+		// network whose compose key changed, mirroring the container sweep so
 		// teardown is complete regardless of how the file was parsed. Only
 		// podup-labelled networks match, so external networks are never touched.
 		// This is a supplementary catch-all on top of the file-driven network
@@ -180,12 +180,12 @@ impl Engine {
 				);
 				// See the network loop above: only a delete that found something
 				// may be reported, and a volume is the object where a false
-				// "Removed" is worst — it names data the operator believes is
+				// "Removed" is worst: it names data the operator believes is
 				// gone.
 				crate::ui::progress::start("Volume", &volume_name, "Removing");
 				match self.client.delete_existed(&vol_path).await {
 					Ok(true) => crate::ui::progress_line("Volume", &volume_name, "Removed"),
-					// The volume was already gone (404) — nothing to do, but the
+					// The volume was already gone (404), so nothing to do, but the
 					// row has to close, or the live board leaves it spinning on
 					// `Removing` forever (#1347).
 					Ok(false) => crate::ui::progress_line("Volume", &volume_name, "Absent"),
@@ -201,7 +201,7 @@ impl Engine {
 		}
 
 		// Internal native secrets are podup-owned (not user data), so remove
-		// them unconditionally — independent of `remove_volumes`.
+		// them unconditionally, independent of `remove_volumes`.
 		let secrets = self.remove_internal_secrets(file).await;
 
 		// Close the board before returning, on every path: the region hides the
@@ -217,7 +217,7 @@ impl Engine {
 
 	/// Remove the images used by the project's services (`down --rmi`). With
 	/// `local_only`, only images of services that build locally (a `build:`
-	/// section) are removed — matching `docker compose down --rmi local`.
+	/// section) are removed, matching `docker compose down --rmi local`.
 	pub async fn remove_service_images(&self, file: &ComposeFile, local_only: bool) -> Result<()> {
 		// Aggregate like every sibling loop in this teardown: complete the sweep,
 		// then report the first real failure. Warning and returning Ok meant
@@ -234,7 +234,7 @@ impl Engine {
 				None => continue,
 			};
 			// Do NOT force: a force-removal cascades to every container using the
-			// image — including ones owned by other compose projects that share it
+			// image, including ones owned by other compose projects that share it
 			// (e.g. two stacks both on `nginx:latest`). docker compose leaves an
 			// in-use image in place, so an "in use" conflict is a skip, not a
 			// failure.
@@ -243,7 +243,7 @@ impl Engine {
 				Ok(_) => crate::ui::progress_line("Image", &image, "Removed"),
 				Err(e) if e.is_status(404) => {}
 				Err(e) if e.is_image_in_use() => {
-					tracing::debug!("image {image} is still in use — skipping removal")
+					tracing::debug!("image {image} is still in use; skipping removal")
 				}
 				Err(e) => {
 					tracing::warn!("could not remove image {image}: {e}");

--- a/internal/engine/lifecycle/teardown_tests.rs
+++ b/internal/engine/lifecycle/teardown_tests.rs
@@ -37,7 +37,7 @@ fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 /// Two containers to tear down: one whose removal genuinely fails (a busy
 /// mount, an active exec session), one that removes cleanly. `down` must
 /// still attempt (and complete) the second before exiting non-zero for the
-/// first (#598) — a CI teardown must not be told it succeeded.
+/// first (#598): a CI teardown must not be told it succeeded.
 #[tokio::test]
 #[cfg(unix)]
 async fn down_propagates_a_real_removal_failure_after_completing_the_rest() {
@@ -84,7 +84,7 @@ async fn down_propagates_a_real_removal_failure_after_completing_the_rest() {
 }
 
 /// #598 regression: `container_rm_path` always forces removal (`?force=true`),
-/// which SIGKILLs the container regardless of how `stop` went — so a stop
+/// which SIGKILLs the container regardless of how `stop` went, so a stop
 /// that fails or stalls (HTTP 500) is superseded, not fatal, once the
 /// force-remove that follows it succeeds. This pins the exact gap that let the
 /// bug through: folding the `stop` failure into `first_err` made `down` return
@@ -130,7 +130,7 @@ async fn down_tolerates_a_stalled_stop_when_the_force_remove_succeeds() {
 }
 
 /// A second `down` on an already torn-down project (no live containers,
-/// nothing left to sweep) must still exit 0 — idempotency is preserved.
+/// nothing left to sweep) must still exit 0; idempotency is preserved.
 #[tokio::test]
 #[cfg(unix)]
 async fn down_on_an_already_torn_down_project_is_still_ok() {
@@ -209,8 +209,8 @@ async fn down_tears_down_dependent_levels_before_their_dependencies() {
 /// `parallel::tests::join_bounded_preserves_input_order`, instead of one
 /// await-per-container in strict sequence. Asserting real wall-clock overlap
 /// against a synchronous test responder would require a multi-thread runtime
-/// and a blocking rendezvous inside the fake — a source of exactly the
-/// flakiness the testing standard forbids — so this test instead pins the
+/// and a blocking rendezvous inside the fake, a source of exactly the
+/// flakiness the testing standard forbids, so this test instead pins the
 /// dispatch contract (both containers are targeted, the level completes) and
 /// leaves the concurrency guarantee itself to `join_bounded`'s own test plus
 /// the code structure (no `.await` between the two containers' futures).
@@ -257,8 +257,8 @@ async fn down_targets_every_independent_service_within_one_level() {
 
 /// Determinism regression: with `web depends_on db`, both containers' removal
 /// fail with distinct statuses. Levels are visited in a fixed order (web's
-/// level first, post-reversal), so `down` must return web's failure — never
-/// db's — regardless of how `join_bounded`'s internal `buffer_unordered`
+/// level first, post-reversal), so `down` must return web's failure, never
+/// db's, regardless of how `join_bounded`'s internal `buffer_unordered`
 /// happens to interleave completions within each level. db's level must still
 /// be attempted (best-effort teardown continues past the first failing
 /// level).
@@ -333,7 +333,7 @@ fn rm_path_url_encodes_container_name() {
 }
 
 /// `down --rmi` used to warn and return Ok on a real removal failure, so it
-/// reported success having left images behind — the one arm of this teardown
+/// reported success having left images behind, the one arm of this teardown
 /// that did not aggregate, while its network, volume and container siblings all
 /// did.
 #[cfg(unix)]

--- a/internal/engine/lifecycle/tests.rs
+++ b/internal/engine/lifecycle/tests.rs
@@ -62,7 +62,7 @@ async fn ensure_started_tolerates_404_and_304() {
 }
 
 /// #6.3 regression: before this fix, each service's image was pulled inside
-/// `up_one_service`, gated behind the level barrier — so a level-2 service's
+/// `up_one_service`, gated behind the level barrier, so a level-2 service's
 /// pull never even started until level 1 finished. `web depends_on db` puts
 /// db alone in level 1 and web alone in level 2; both images must now be
 /// pulled by the up-front prefetch stage, before the very first container is
@@ -161,8 +161,8 @@ async fn up_creates_and_starts_every_scaled_replica() {
 }
 
 /// A genuine per-replica create/start failure must still surface as `Err`
-/// (not be swallowed into an exit-0 `up`), and — since replicas 1 and 3 both
-/// fail with distinct statuses — the reported error must deterministically be
+/// (not be swallowed into an exit-0 `up`) and, since replicas 1 and 3 both
+/// fail with distinct statuses, the reported error must deterministically be
 /// replica 1's (earliest in the fixed replica-index order `join_bounded`
 /// preserves), never replica 3's, regardless of which one's future actually
 /// completes first. Every replica must still have been attempted: a failing
@@ -214,7 +214,7 @@ async fn up_replica_fanout_surfaces_deterministic_first_error_after_attempting_t
 
 /// The per-replica `no_recreate` skip logic must survive the concurrent
 /// fan-out: an already-present replica is left alone (`ensure_started`, no
-/// create) while its sibling — not yet present — is still created and
+/// create) while its sibling, not yet present, is still created and
 /// started, matching what the pre-parallel serial loop did for each replica
 /// in turn.
 #[tokio::test]

--- a/internal/engine/lifecycle/up.rs
+++ b/internal/engine/lifecycle/up.rs
@@ -106,8 +106,8 @@ impl Engine {
 			let levels = crate::compose::resolve_levels(file)?;
 			let active = active_profiles_set(active_profiles);
 			// Which services this `up`/`create` should start. A profiled service
-			// that an active service depends on is implicitly activated here —
-			// the same set `config` reports — so `up` never leaves a started
+			// that an active service depends on is implicitly activated here,
+			// the same set `config` reports, so `up` never leaves a started
 			// service with an unsatisfied (never-created) dependency.
 			let enabled = enabled_profile_services(file, &active, target_services);
 
@@ -161,9 +161,9 @@ impl Engine {
 			}
 
 			// Seed the board before any work starts. This is the whole point of
-			// the phase: the resource set is knowable here — `levels` is already
+			// the phase: the resource set is knowable here, since `levels` is already
 			// resolved above, and the networks and volumes come straight off the
-			// compose file — while every progress event in the tree fires once
+			// compose file, while every progress event in the tree fires once
 			// its work is already over. A board grown from those events would be
 			// a transcript with extra steps.
 			let mut resources = self.up_resources(file, &enabled, &target_set);
@@ -239,7 +239,7 @@ impl Engine {
 			// Best-effort: warm the image cache for every service this pass will
 			// pull, concurrently, before the per-level walk below serializes a
 			// level-2+ service's image acquisition behind the level-1 barrier.
-			// A prefetch I/O miss is never fatal — `up_one_service`'s own pull
+			// A prefetch I/O miss is never fatal: `up_one_service`'s own pull
 			// below is still authoritative and the only path that can fail `up`
 			// on a transport / registry error. A configuration error (an
 			// unrecognized `pull_policy:`) does propagate: it is reported here

--- a/internal/engine/lifecycle/up_one.rs
+++ b/internal/engine/lifecycle/up_one.rs
@@ -20,7 +20,7 @@ impl Engine {
 	/// replica (skipping containers that are unchanged unless `force_recreate`).
 	/// Used by [`super::run_up`]; safe to run concurrently for services in
 	/// the same dependency level (the `Engine` holds no per-call mutable
-	/// state — the libpod client is connection-per-request).
+	/// state; the libpod client is connection-per-request).
 	#[allow(clippy::too_many_arguments)]
 	pub(crate) async fn up_one_service(
 		&self,
@@ -47,7 +47,7 @@ impl Engine {
 		}
 
 		// `create` (start = false) only builds the containers, so there is nothing
-		// to gate on — skip the `depends_on` readiness waits entirely.
+		// to gate on, so skip the `depends_on` readiness waits entirely.
 		for dep in service
 			.depends_on
 			.service_names()
@@ -60,12 +60,12 @@ impl Engine {
 			// waiting on (and 404-ing against) a container that was never
 			// created.
 			if !super::targets::in_started_set(target_set, &dep) {
-				tracing::debug!("{dep} not in started target set — skipping {name} readiness wait");
+				tracing::debug!("{dep} not in started target set; skipping {name} readiness wait");
 				continue;
 			}
 
 			let condition = service.depends_on.condition_for(&dep);
-			// `required: false` makes the dependency optional — a failed wait
+			// `required: false` makes the dependency optional: a failed wait
 			// must not abort `up`, matching docker-compose v2.
 			let required = service.depends_on.required_for(&dep);
 			let dep_service = match file.services.get(&dep) {
@@ -92,7 +92,7 @@ impl Engine {
 						.is_some_and(|h| h.is_disabled());
 					if disabled {
 						tracing::debug!(
-							"{dep} healthcheck disabled — skipping service_healthy wait"
+							"{dep} healthcheck disabled; skipping service_healthy wait"
 						);
 						Ok(())
 					} else {
@@ -142,7 +142,7 @@ impl Engine {
 		let new_hash = config_hash(service, file)?;
 
 		// Fan the replicas out with the same bounded concurrency the level
-		// walk uses, instead of creating and starting them one at a time —
+		// walk uses, instead of creating and starting them one at a time:
 		// `up --scale web=5` used to pay 5x (create+start) in strict
 		// sequence. Every replica is still attempted even when one fails
 		// (`join_bounded` runs the whole batch), and `first_error` picks the
@@ -176,7 +176,7 @@ impl Engine {
 	/// config-hash skip logic, then fall through to create+start. One future
 	/// in the per-service replica fan-out ([`Self::up_one_service`]); safe to
 	/// run concurrently with the service's other replicas, since replicas of
-	/// one service share no per-replica mutable state — a fixed host port
+	/// one service share no per-replica mutable state: a fixed host port
 	/// that would make concurrent starts race is already rejected up front by
 	/// `super::scale::check_scale_port_conflict`.
 	#[allow(clippy::too_many_arguments)]
@@ -195,7 +195,7 @@ impl Engine {
 		let present = existing.contains_key(&container_name);
 		if !force_recreate {
 			if no_recreate && present {
-				tracing::debug!("{container_name} already exists — skipping recreate");
+				tracing::debug!("{container_name} already exists; skipping recreate");
 				// `create` leaves an existing container as-is; `up` ensures it runs.
 				if start {
 					self.ensure_started(&container_name).await?;
@@ -211,7 +211,7 @@ impl Engine {
 				.unchanged(&container_name, name, service, existing, new_hash)
 				.await?
 			{
-				tracing::debug!("{container_name} is up to date — skipping recreate");
+				tracing::debug!("{container_name} is up to date; skipping recreate");
 				if start {
 					self.ensure_started(&container_name).await?;
 				}

--- a/internal/engine/lock.rs
+++ b/internal/engine/lock.rs
@@ -32,7 +32,7 @@ impl Engine {
 	pub fn lock_project(&self) -> Result<ProjectLock> {
 		if !super::staging::is_safe_project_name(&self.project) {
 			return Err(ComposeError::Unsupported(format!(
-				"unsafe project name '{}' — refusing to create a lock file",
+				"unsafe project name '{}'; refusing to create a lock file",
 				self.project
 			)));
 		}

--- a/internal/engine/lock_tests.rs
+++ b/internal/engine/lock_tests.rs
@@ -53,7 +53,7 @@ fn second_holder_blocks_until_first_releases() {
 
 	// The lock is exclusive, so the waiter cannot acquire until `held` is
 	// dropped; the store is sequenced before the drop, so the waiter is
-	// guaranteed to observe `released == true`. This is deterministic — it
+	// guaranteed to observe `released == true`. This is deterministic: it
 	// never depends on how long the waiter takes to reach `flock`.
 	barrier.wait();
 	released.store(true, Ordering::SeqCst);

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -124,7 +124,7 @@ pub struct Engine {
 	///
 	/// Only ever a record of what this engine saw itself, this run: it is not
 	/// persisted and not shared between engines. Two engines against different
-	/// sockets must not pool observations — a process-wide cache would let one
+	/// sockets must not pool observations: a process-wide cache would let one
 	/// skip a pull for an image that only exists on the other's host, which
 	/// matters because podup is consumed as a library and a caller may hold more
 	/// than one engine.
@@ -133,7 +133,7 @@ pub struct Engine {
 	/// warnings the engine emits during `up`/`create`/`run`/`exec`. The
 	/// operator wrote the compose file deliberately, so the default-warning
 	/// behaviour is opt-out per run rather than per command. `config`'s
-	/// surface-mode listing is unaffected — `config` is the "show me what will
+	/// surface-mode listing is unaffected; `config` is the "show me what will
 	/// happen" command, where the warnings stay visible there.
 	pub(super) no_warn: bool,
 	/// The pre-URL-encoded libpod `filters` JSON object that scopes a
@@ -151,7 +151,7 @@ impl Engine {
 	/// If the working directory cannot be resolved (the process's CWD was
 	/// deleted or is unreadable at construction time), the engine falls back
 	/// to an empty `base_dir` and a warning is logged. Callers that need a
-	/// definite base directory — the CLI does — should use
+	/// definite base directory (the CLI does) should use
 	/// [`Engine::with_base_dir`] instead, which surfaces a missing or
 	/// unreadable directory as a hard error rather than a silent empty
 	/// path that later surfaces as a confusing "compose file not found".
@@ -189,7 +189,7 @@ impl Engine {
 		}
 	}
 
-	/// Create an engine with an explicit base directory — use when the compose file is not in the working directory.
+	/// Create an engine with an explicit base directory, for when the compose file is not in the working directory.
 	pub fn with_base_dir(client: Client, project: String, base_dir: PathBuf) -> Self {
 		Self {
 			client,
@@ -543,7 +543,7 @@ impl Engine {
 		let live_by_service = self.live_project_replicas_sorted().await?;
 		let names = match live_by_service.get(service_name) {
 			Some(names) if !names.is_empty() => names.clone(),
-			// Service has no live container yet — fall back to the static
+			// Service has no live container yet, so fall back to the static
 			// compose names so a never-created service still has an
 			// addressable replica.
 			_ => self.replica_names(service_name, service),
@@ -568,7 +568,7 @@ impl Engine {
 /// Serialise `v` to a compact JSON string for embedding into a libpod query
 /// parameter or NDJSON row.
 ///
-/// Six sites flow through this — five in [`build`](super::build) (`cachefrom`,
+/// Six sites flow through this: five in [`build`](super::build) (`cachefrom`,
 /// `buildargs`, `labels`, `secrets`, `cacheto`) and one in
 /// [`events`](super::events) (the `--format json` event row). Each of them
 /// used to call `serde_json::to_string(...).unwrap_or_default()`, which
@@ -596,8 +596,8 @@ pub(super) fn to_query_json<T: serde::Serialize>(what: &str, v: &T) -> Result<St
 /// printed the empty string and exited 0, so a script consuming
 /// `podup <cmd> --format json` received an empty document indistinguishable
 /// from "no results" (#1444). Unlike the NDJSON path in
-/// [`to_query_json`](self)/[`events`](super::events) — where one row can be
-/// dropped and the stream continue — `--format json` is the *whole* output,
+/// [`to_query_json`](self)/[`events`](super::events), where one row can be
+/// dropped and the stream continue, `--format json` is the *whole* output,
 /// so a failure must propagate as an error and exit non-zero.
 ///
 /// `what` names the offending field in the error so the operator sees which
@@ -626,7 +626,7 @@ pub(crate) fn write_frame<W: std::io::Write>(out: &mut W, bytes: &[u8]) -> std::
 ///
 /// The `config` command uses this to surface the active modes at the default
 /// log level (CI logs see them even when the operator never runs `up`). It is
-/// deliberately not gated on `--no-warn` — `config` is the "show me what will
+/// deliberately not gated on `--no-warn`; `config` is the "show me what will
 /// happen" command, where the warning is the whole point. The live
 /// `up`/`create`/`run`/`exec` paths emit the same warnings per-call but honour
 /// `--no-warn`.

--- a/internal/engine/names.rs
+++ b/internal/engine/names.rs
@@ -3,7 +3,7 @@
 //! Podman enforces an object-name regex (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`) on
 //! volumes, networks, and containers, rejecting anything else with an opaque
 //! HTTP 500 ("names must match …"). [`Engine::validate_object_names`] applies
-//! the same check up front — before a single create is issued — so a bad name
+//! the same check up front, before a single create is issued, so a bad name
 //! (typically an explicit `name:` on a top-level volume/network, or an explicit
 //! `container_name:`) surfaces as a clear error naming the offending object,
 //! and nothing is created.

--- a/internal/engine/network/mod.rs
+++ b/internal/engine/network/mod.rs
@@ -81,7 +81,7 @@ impl Engine {
 				// An existing network is not an error on re-`up`; accept any
 				// already-exists conflict (network-create returns 409, but share
 				// the same predicate as volume-create for consistency). The row
-				// still needs to close — without an explicit closing verb the
+				// still needs to close: without an explicit closing verb the
 				// live board leaves it spinning on `Creating` (#1347).
 				Err(ref e) if e.is_already_exists() => {
 					crate::ui::progress_line("Network", &network_name, "Exists");
@@ -165,7 +165,7 @@ const ISOLATE_OPT: &str = "isolate";
 /// Docker isolates its bridge networks from each other and podman does not, so
 /// without this a service reaches ports on a neighbouring network that were
 /// never published. Measured on 2026-08-20 with the same experiment on both
-/// engines — a listener on an unpublished port in network B, and a container in
+/// engines: a listener on an unpublished port in network B, and a container in
 /// network A dialling its address:
 ///
 /// | engine | result |
@@ -185,8 +185,8 @@ const ISOLATE_OPT: &str = "isolate";
 /// isolated connects. So this does not harden a network against the world; it
 /// makes networks that share the default stop seeing each other. Since podup
 /// now sets it on every bridge network it creates, the effect is that two
-/// podup projects no longer reach each other's unpublished ports — verified
-/// end to end with two projects — while a network created outside podup
+/// podup projects no longer reach each other's unpublished ports, verified
+/// end to end with two projects, while a network created outside podup
 /// without the option still can. Being a default rather than opt-in is the
 /// whole point: one project opting in would protect nobody.
 ///
@@ -228,7 +228,7 @@ pub(super) fn resolve_network_mode(
 				// docker-compose attaches to Docker's shared default `bridge`;
 				// Podman reads `--network bridge` as a fresh isolated bridge netns,
 				// so project siblings are unreachable. Warn here (at container
-				// create) so every path — CLI, library, embedded — surfaces it, not
+				// create) so every path (CLI, library, embedded) surfaces it, not
 				// only the parse-time diagnostics.
 				tracing::warn!(
 					"service '{service_name}': network_mode 'bridge' attaches to a fresh \

--- a/internal/engine/network/tests.rs
+++ b/internal/engine/network/tests.rs
@@ -78,7 +78,7 @@ fn network_mode_service_single_replica_uses_first_replica_name() {
 
 #[test]
 fn network_mode_service_scaled_replicas_resolves_replica_one() {
-	// `scale:`/`deploy.replicas` > 1 means the base name does not exist —
+	// `scale:`/`deploy.replicas` > 1 means the base name does not exist,
 	// docker-compose attaches to replica `-1`.
 	let target = Service {
 		scale: Some(3),

--- a/internal/engine/profiles.rs
+++ b/internal/engine/profiles.rs
@@ -1,4 +1,4 @@
-//! Profile filtering — determines which services run given the active profile set.
+//! Profile filtering: determines which services run given the active profile set.
 
 use std::collections::HashSet;
 
@@ -8,7 +8,7 @@ use crate::compose::types::{ComposeFile, Service};
 ///
 /// `active` is the CLI `--profile` list, falling back to `COMPOSE_PROFILES`.
 /// A profiled service that is a transitive `depends_on` target of a retained
-/// service is implicitly enabled, matching docker compose — so the output never
+/// service is implicitly enabled, matching docker compose, so the output never
 /// carries a dangling dependency reference.
 pub fn retain_active_profiles(file: &mut ComposeFile, active: &[String]) {
 	retain_active_profiles_with_targets(file, active, &[]);
@@ -33,15 +33,15 @@ pub fn retain_active_profiles_with_targets(
 /// A service is enabled when it is unprofiled, matches an active profile (or the
 /// `*` wildcard), or is explicitly named in `targets` (naming a service on the
 /// command line activates its profile). Implicit activation then pulls in the
-/// transitive `depends_on` targets of every enabled service — even profiled
-/// ones whose profile is inactive — so a started service never depends on a
+/// transitive `depends_on` targets of every enabled service, even profiled
+/// ones whose profile is inactive, so a started service never depends on a
 /// service that was filtered out. Mirrors docker compose, which activates a
 /// profiled service that is depended on by a started one.
 ///
 /// This is the single source of truth for "which services does an `up`/`config`
 /// with these profiles touch": [`retain_active_profiles_with_targets`] uses it
 /// to prune the config, and the `up`/`create` lifecycle path uses it to decide
-/// which services to actually start — so the two never disagree.
+/// which services to actually start, so the two never disagree.
 pub(crate) fn enabled_profile_services(
 	file: &ComposeFile,
 	active: &HashSet<String>,

--- a/internal/engine/profiles_tests.rs
+++ b/internal/engine/profiles_tests.rs
@@ -76,7 +76,7 @@ fn retain_active_profiles_keeps_unprofiled_and_active() {
 		debugger:\n    image: x\n    profiles: [debug]\n  \
 		db:\n    image: x\n    profiles: [prod]\n";
 	// With `debug` active: the unprofiled `web` and the `debug` service stay,
-	// the `prod`-only `db` is dropped — exactly what `up --profile debug` runs.
+	// the `prod`-only `db` is dropped, exactly what `up --profile debug` runs.
 	let mut file = crate::parse_str(yaml).unwrap();
 	retain_active_profiles(&mut file, &["debug".to_string()]);
 	assert!(file.services.contains_key("web"));
@@ -114,7 +114,7 @@ fn wildcard_enables_all_profiles() {
 #[test]
 fn implicit_activation_keeps_profiled_dependency() {
 	// `app` (active) depends on `db` (profiles: [storage]). With no profile
-	// active, `db` is implicitly enabled so `app` keeps a satisfiable dep —
+	// active, `db` is implicitly enabled so `app` keeps a satisfiable dep:
 	// no dangling reference, matching docker compose.
 	let yaml = "services:\n  \
 		app:\n    image: x\n    depends_on: [db]\n  \
@@ -147,7 +147,7 @@ fn implicit_activation_is_transitive() {
 
 #[test]
 fn unrelated_profiled_service_still_dropped() {
-	// Implicit activation only reaches dependencies — an unrelated profiled
+	// Implicit activation only reaches dependencies; an unrelated profiled
 	// service is still removed.
 	let yaml = "services:\n  \
 		app:\n    image: x\n    depends_on: [db]\n  \
@@ -166,7 +166,7 @@ fn enabled_set_activates_profiled_dependency_for_up() {
 	// The `up`/`create` lifecycle path consults this set directly. `app`
 	// (unprofiled, started) depends on `db` (profiles: [storage]). With no
 	// profile active, `db` must be in the enabled set so `up` actually
-	// creates it — otherwise `app` runs with an unsatisfied dependency.
+	// creates it; otherwise `app` runs with an unsatisfied dependency.
 	let yaml = "services:\n  \
 		app:\n    image: x\n    depends_on: [db]\n  \
 		db:\n    image: x\n    profiles: [storage]\n";
@@ -182,7 +182,7 @@ fn enabled_set_activates_profiled_dependency_for_up() {
 
 #[test]
 fn enabled_set_excludes_unrelated_profiled_service() {
-	// Only dependencies are pulled in — an unrelated profiled service stays
+	// Only dependencies are pulled in; an unrelated profiled service stays
 	// out of the started set, so `up` does not over-activate it.
 	let yaml = "services:\n  \
 		app:\n    image: x\n    depends_on: [db]\n  \

--- a/internal/engine/projects.rs
+++ b/internal/engine/projects.rs
@@ -1,4 +1,4 @@
-//! `ls` — discover podup-managed compose projects on the host.
+//! `ls` discovers podup-managed compose projects on the host.
 //!
 //! Unlike the other commands this is project-agnostic: it scans every container
 //! carrying a `podup.project` label and groups by project, so it needs only a
@@ -106,7 +106,7 @@ struct Tally {
 	paused: usize,
 	total: usize,
 	/// The `podup.config-files` label, from the first container that carries one.
-	/// Empty when no container in the project has it — created before the label
+	/// Empty when no container in the project has it: created before the label
 	/// existed, or by an embedder that supplied no paths.
 	config_files: String,
 }
@@ -170,7 +170,7 @@ pub async fn list_projects_filtered(
 		}
 	}
 
-	// An unsupported key is an error, not a warning — see the note on the ps
+	// An unsupported key is an error, not a warning; see the note on the ps
 	// filters: silently answering a different question is worse than refusing.
 	let (name_filter, status_filter, unknown) = split_ls_filters(filters);
 	if let Some(u) = unknown.first() {
@@ -231,7 +231,7 @@ pub async fn list_projects_filtered(
 	Ok(())
 }
 
-/// Per-state replica counts joined as `running(2), paused(1), exited(1)` —
+/// Per-state replica counts joined as `running(2), paused(1), exited(1)`,
 /// mirrors the `docker compose ls` status column, which surfaces each state
 /// rather than collapsing to a single running count and discarding the rest.
 fn status_label(t: &Tally) -> String {
@@ -256,7 +256,7 @@ fn status_label(t: &Tally) -> String {
 /// One `ls --format json` row, matching `docker compose ls --format json`.
 ///
 /// `ConfigFiles` comes from the `podup.config-files` label the containers carry
-/// — projects are discovered by label and there is no other record of where a
+/// Projects are discovered by label and there is no other record of where a
 /// compose file lives. It is empty for a container created before that label
 /// existed, or by an embedder that did not supply the paths.
 fn project_row(name: &str, t: &Tally, config_files: &str) -> serde_json::Value {

--- a/internal/engine/query/attach.rs
+++ b/internal/engine/query/attach.rs
@@ -2,7 +2,7 @@
 //!
 //! The single-service `attach` / `attach_with_index` commands and the
 //! `attach_log_query` helper that backs them stay in `inspect.rs`; this file
-//! holds everything that follows the multi-service streams — the public
+//! holds everything that follows the multi-service streams: the public
 //! `AttachOutcome` / `AttachOptions` / `AttachSummary` types, the abort
 //! plumbing (`Phase`, `StreamEnd`, `wait_for_phase`, `container_exit_code`)
 //! and the `Engine::attach_logs*` methods that produce them. Split out of
@@ -61,7 +61,7 @@ pub enum AttachOutcome {
 	Aborted,
 }
 
-/// Options that go with [`Engine::attach_logs_with`] — every flag `podup up`
+/// Options that go with [`Engine::attach_logs_with`]: every flag `podup up`
 /// exposes that affects what an attached stream does or how it ends.
 ///
 /// `#[non_exhaustive]` since 4.1.0, so the next flag is not a breaking change
@@ -124,7 +124,7 @@ impl AttachOptions {
 /// `service` and `exit_code` are only meaningful when `outcome` is
 /// [`AttachOutcome::Aborted`]; they are `None` for the other three endings.
 /// The two-abort-fields split off into this struct is what keeps the enum
-/// `Copy` (and keeps its discriminant values defined) — putting a `String`
+/// `Copy` (and keeps its discriminant values defined); putting a `String`
 /// next to an `i64` inside the variant would have broken both, and the
 /// caller still needs to read them.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,7 +162,7 @@ impl Engine {
 		timestamps: bool,
 	) -> Result<AttachOutcome> {
 		// Delegate with the abort set fully off, so the call path the rest of
-		// the 4.0.0 callers still take is exercised by the wrapper itself —
+		// the 4.0.0 callers still take is exercised by the wrapper itself,
 		// not just by the underlying method when the new flags are turned on.
 		self.attach_logs_with(
 			file,
@@ -188,7 +188,7 @@ impl Engine {
 	/// container exits, with the propagating service name and exit code in
 	/// the sibling fields of the returned [`AttachSummary`]. On that path the
 	/// remaining containers are stopped before the function returns, so the
-	/// caller does not need to call [`Engine::stop`] — and `dispatch.rs` skips
+	/// caller does not need to call [`Engine::stop`], and `dispatch.rs` skips
 	/// its own stop call on that outcome for the same reason.
 	///
 	/// The two abort-specific fields live on [`AttachSummary`] rather than as
@@ -314,7 +314,7 @@ impl Engine {
 							}
 						}
 					}
-					// Clean end of the stream — the container stopped and the
+					// Clean end of the stream: the container stopped and the
 					// transport delivered its terminator.
 					(svc, cname, StreamEnd::ContainerStopped)
 				}
@@ -322,7 +322,7 @@ impl Engine {
 			.collect();
 
 		// Which arm wins is the whole point: `docker compose up` exits 130 on both
-		// SIGINT and SIGTERM (measured against v5.1.3, not assumed — it is 130 for
+		// SIGINT and SIGTERM (measured against v5.1.3, not assumed: it is 130 for
 		// SIGTERM too, not the 143 the signal number would suggest), and podup
 		// exited 0 for both. A CI job that runs `up` in the foreground and is
 		// cancelled therefore reported success.
@@ -370,7 +370,7 @@ impl Engine {
 
 				// Pick the exit code to propagate. With `--exit-code-from`,
 				// the named service's code wins even if some other container
-				// exited first — and that container may have been SIGKILLed
+				// exited first, and that container may have been SIGKILLed
 				// during the `stop` above (docker compose v5.1.3 prints 137
 				// for that case, measured). Otherwise the trigger's code is the
 				// one podup returns.
@@ -422,7 +422,7 @@ impl Engine {
 /// How one stream of `attach_logs_with_options` ended.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StreamEnd {
-	/// The stream's transport died while its container was still running — a
+	/// The stream's transport died while its container was still running: a
 	/// truncated live read, not a finished one (#1104).
 	Broke,
 	/// The container is stopped (clean end or transport died *because* the
@@ -439,7 +439,7 @@ enum Phase {
 	/// than `StreamsEnded`.
 	AllEnded { saw_break: bool },
 	/// `abort_on_container_exit` is set and the named stream finished while
-	/// its container was stopped — the first container to exit. The outer
+	/// its container was stopped, the first container to exit. The outer
 	/// code stops the rest and reports the exit code.
 	FirstExited {
 		trigger_service: String,

--- a/internal/engine/query/attach_stream_tests.rs
+++ b/internal/engine/query/attach_stream_tests.rs
@@ -61,7 +61,7 @@ fn engine(fake: &fake_podman::FakePodman) -> Engine {
 
 /// Fake that ends both services' log streams cleanly, lists both as exited, and
 /// answers `/wait` with the per-container exit code passed in. Stop calls
-/// return 204 (idempotent on already-stopped containers is fine — the abort
+/// return 204 (idempotent on already-stopped containers is fine; the abort
 /// path's `engine.stop` runs against an already-exited project).
 fn fake_two_services_exited(first_code: i64, second_code: i64) -> fake_podman::FakePodman {
 	fake_podman::start_replying(move |method, target| {
@@ -77,7 +77,7 @@ fn fake_two_services_exited(first_code: i64, second_code: i64) -> fake_podman::F
 		} else if method == "POST" && target.contains("proj-second-1/wait") {
 			FakeReply::Body(200, second_code.to_string())
 		} else if target.contains("/containers/json") {
-			// Both containers are listed as exited — the abort path's
+			// Both containers are listed as exited, so the abort path's
 			// `container_still_running` will answer "stopped" for either.
 			FakeReply::Body(
 				200,
@@ -86,7 +86,7 @@ fn fake_two_services_exited(first_code: i64, second_code: i64) -> fake_podman::F
 					.to_string(),
 			)
 		} else if method == "POST" {
-			// Stop calls (POST /containers/X/stop?t=...) — 204 makes them
+			// Stop calls (POST /containers/X/stop?t=...): 204 makes them
 			// idempotent no-ops against the already-stopped containers, which
 			// is what `engine.stop` does when the project is already down.
 			FakeReply::Body(204, String::new())
@@ -197,7 +197,7 @@ async fn abort_with_exit_code_from_returns_named_service_exit_code() {
 /// `--exit-code-from ghost` names a service that does not exist in the compose
 /// file. The check runs before any container is created so the error surfaces
 /// as a clear `ServiceNotFound`, not a generic `is_err()` that could mean
-/// anything. Asserts the variant — a bare `is_err()` would be satisfied by
+/// anything. Asserts the variant; a bare `is_err()` would be satisfied by
 /// any failure.
 #[tokio::test]
 async fn exit_code_from_with_unknown_service_is_rejected() {
@@ -243,7 +243,7 @@ async fn exit_code_from_with_known_service_is_accepted() {
 }
 
 /// Without `--abort-on-container-exit` (and without `--exit-code-from`), a
-/// container that exits mid-stream is **not** an event — we keep waiting for
+/// container that exits mid-stream is **not** an event: we keep waiting for
 /// the others, and the function returns `StreamsEnded` when they finish. This
 /// is the existing-attached-`up` behavior, kept intact.
 ///

--- a/internal/engine/query/exec.rs
+++ b/internal/engine/query/exec.rs
@@ -14,7 +14,7 @@ use crate::libpod::{urlencoded, LogOutput, API_PREFIX};
 use super::Engine;
 
 /// Ceiling on how long to wait for the libpod exec-start *response head*. A
-/// healthy engine returns it almost instantly — either the hijacked stream or a
+/// healthy engine returns it almost instantly: either the hijacked stream or a
 /// prompt error (e.g. HTTP 500 "unable to find user … no matching entries in
 /// passwd file"). When the target user/workdir does not resolve, some engine
 /// builds instead stall before answering, which the default client read timeout
@@ -177,12 +177,12 @@ fn map_not_running(e: crate::libpod::PodmanError, service_name: &str) -> Compose
 
 /// Translate a failure *starting* the exec session into a clear error. A
 /// client-side timeout means the libpod exec-start never returned its response
-/// head within [`EXEC_START_TIMEOUT`] — almost always a wedged launch (e.g. a
+/// head within [`EXEC_START_TIMEOUT`], almost always a wedged launch (e.g. a
 /// nonexistent `--user`/`--workdir` the server stalls resolving) rather than an
 /// unhealthy socket, so surface that with the likely cause instead of the
-/// generic "timed out waiting for the Podman socket" message. Every other error
-/// — including the prompt HTTP error an engine *does* return for a bad user
-/// ("unable to find user … no matching entries in passwd file") — passes through
+/// generic "timed out waiting for the Podman socket" message. Every other error,
+/// including the prompt HTTP error an engine *does* return for a bad user
+/// ("unable to find user … no matching entries in passwd file"), passes through
 /// unchanged so legitimate diagnostics are never masked. Pure so it is
 /// unit-tested.
 fn map_exec_start_err(e: crate::libpod::PodmanError, opts: &ExecOptions) -> ComposeError {
@@ -239,7 +239,7 @@ impl Engine {
 		// `up` path would have emitted, so `exec` against a privileged or
 		// host-networked container does not appear safer than the same
 		// container's `up`. The container itself was created with these modes,
-		// but `exec` is the operator's chance to notice them — and the command
+		// but `exec` is the operator's chance to notice them, and the command
 		// they are about to run executes inside that container. `--no-warn`
 		// still opts out.
 		if !self.no_warn {
@@ -249,7 +249,7 @@ impl Engine {
 		}
 		// Resolve the target replica against the *running* containers (matching
 		// `cp`), so `--index N` and a bare `exec` reach a live replica of a service
-		// scaled by an earlier `up --scale`/`scale` — not just the compose static
+		// scaled by an earlier `up --scale`/`scale`, not just the compose static
 		// count. `--index 0`/out-of-range indexes stay rejected consistently.
 		let container_name = self
 			.live_replica_name_at(service_name, service, opts.index)
@@ -281,7 +281,7 @@ impl Engine {
 		let resp: ExecCreateResponse = match self.client.post_json(&create_path, &exec_cfg).await {
 			Ok(resp) => resp,
 			// The exec create is where the drops measured in #1339 land most
-			// often — twice of six, more than any other endpoint. Unlike the
+			// often: twice of six, more than any other endpoint. Unlike the
 			// lifecycle calls, a lost response here cannot be resolved by looking
 			// at the container: what is lost is the exec id, and a container
 			// running several execs at once cannot say which of its `ExecIDs` was
@@ -290,7 +290,7 @@ impl Engine {
 			// Retrying is safe instead, because creating an exec changes nothing.
 			// Measured on Podman 5.7.0: five execs created and never started leave
 			// the container `running` on the same pid with no extra process
-			// inside — they are inert handles that die with it. So the worst case
+			// inside; they are inert handles that die with it. So the worst case
 			// of a retry is one leaked handle, against an `exec` that fails for a
 			// reason that was never about the command.
 			//
@@ -380,7 +380,7 @@ impl Engine {
 	/// Read the session's exit code and turn a non-zero one into
 	/// `RunExited`, so `podup exec` propagates the command's status the way
 	/// `docker compose exec` does. Shared by the streaming and interactive
-	/// paths — an interactive shell that exits 1 must still exit 1.
+	/// paths: an interactive shell that exits 1 must still exit 1.
 	async fn exec_exit_status(&self, exec_id: &str) -> Result<()> {
 		let inspect_path = format!("{API_PREFIX}/exec/{}/json", urlencoded(exec_id));
 		let inspect: ExecInspect = self
@@ -401,15 +401,15 @@ impl Engine {
 ///
 /// Three things must all hold: the caller did not pass `-T`, the caller did not
 /// detach, and stdin is actually a terminal. The last is what keeps a scripted
-/// `podup exec` on the unchanged streaming path — allocating a pty for a
+/// `podup exec` on the unchanged streaming path, because allocating a pty for a
 /// pipeline would change output framing for every existing script.
 ///
 /// Pure except for the `isatty` probe, which is behind `stdin_is_terminal` so
 /// the decision itself is unit-testable.
 fn interactive_exec(opts: &ExecOptions) -> bool {
 	// Both ends, not just stdin. A pty merges stdout and stderr and writes
-	// CRLF, so `podup exec db psql > out.txt` typed at a shell — stdin still a
-	// terminal, stdout a file — wrote pty bytes with stderr folded in where it
+	// CRLF, so `podup exec db psql > out.txt` typed at a shell (stdin still a
+	// terminal, stdout a file) wrote pty bytes with stderr folded in where it
 	// used to write clean demultiplexed output. Measured against
 	// `docker compose`, which keeps that redirect clean.
 	wants_interactive(opts, stdin_is_terminal() && stdout_is_terminal())
@@ -436,7 +436,7 @@ pub(crate) fn stdout_is_terminal() -> bool {
 	std::io::stdout().is_terminal()
 }
 
-/// Whether stdin is a terminal — the gate that keeps a scripted `exec` on the
+/// Whether stdin is a terminal: the gate that keeps a scripted `exec` on the
 /// unchanged streaming path.
 pub(crate) fn stdin_is_terminal() -> bool {
 	use std::io::IsTerminal;
@@ -452,7 +452,7 @@ mod interactive_decision_tests;
 mod tests;
 
 /// The exec create is the endpoint the #1339 drops land on most, and a lost
-/// response there cannot be resolved by looking at the container — what is lost
+/// response there cannot be resolved by looking at the container; what is lost
 /// is the exec id. Retrying is safe because creating an exec changes nothing:
 /// measured on Podman 5.7.0, five unstarted execs leave the container running on
 /// the same pid with no extra process inside.

--- a/internal/engine/query/exec_create_retry_tests.rs
+++ b/internal/engine/query/exec_create_retry_tests.rs
@@ -35,7 +35,7 @@ fn fake_dropping_creates(drops: usize) -> (fake_podman::FakePodman, Arc<AtomicUs
 }
 
 /// Drive the real `exec` entry point, detached so the hijacked streaming path
-/// is out of the picture — the retry under test is on the CREATE, which both
+/// is out of the picture: the retry under test is on the CREATE, which both
 /// paths share. Driving `test_exec_capture` instead would have measured
 /// nothing: it builds its own request and never reaches this code.
 async fn run_exec(fake: &fake_podman::FakePodman) -> crate::error::Result<()> {

--- a/internal/engine/query/exec_interactive.rs
+++ b/internal/engine/query/exec_interactive.rs
@@ -16,8 +16,8 @@ use super::Engine;
 impl Engine {
 	/// Run an exec session with a pty and a live stdin.
 	///
-	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path —
-	/// command exits, socket dies, `?` on an unrelated error, panic — leaves the
+	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path
+	/// (command exits, socket dies, `?` on an unrelated error, panic) leaves the
 	/// caller's shell usable. That is the one thing this must not get wrong: a
 	/// terminal left raw has no echo and no line discipline, and the user cannot
 	/// even see what they type to fix it.

--- a/internal/engine/query/exec_interactive_decision_tests.rs
+++ b/internal/engine/query/exec_interactive_decision_tests.rs
@@ -1,6 +1,6 @@
 use super::{wants_interactive, ExecOptions};
 
-/// #1079: `-T` opts out, matching `docker compose exec` — which has no `-i`
+/// #1079: `-T` opts out, matching `docker compose exec`, which has no `-i`
 /// because a TTY on both ends is the default.
 #[test]
 fn no_tty_flag_disables_the_pty() {
@@ -15,8 +15,8 @@ fn detach_disables_the_pty() {
 	assert!(!wants_interactive(&opts, true));
 }
 
-/// The decisive one for existing users: with stdin not a terminal — any
-/// script or pipeline — `exec` stays on the unchanged streaming path.
+/// The decisive one for existing users: with stdin not a terminal (any
+/// script or pipeline) `exec` stays on the unchanged streaming path.
 /// Allocating a pty there would change output framing for every script that
 /// already calls `podup exec`.
 #[test]

--- a/internal/engine/query/exec_tests.rs
+++ b/internal/engine/query/exec_tests.rs
@@ -67,7 +67,7 @@ fn map_not_running_maps_404_and_stopped() {
 fn exec_start_timeout_with_user_names_the_user() {
 	use crate::libpod::PodmanError;
 	// A client-side head timeout (the wedged-launch symptom) becomes a clear,
-	// fast ExecFailed naming the likely culprit — never the raw socket-timeout.
+	// fast ExecFailed naming the likely culprit, never the raw socket-timeout.
 	let timeout = PodmanError::Api {
 		status: 0,
 		message: format!(

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -12,7 +12,7 @@ use super::Engine;
 /// How `images` renders a size: decimal units at three significant digits.
 ///
 /// Decimal because this table exists to be read against `podman images` and
-/// `docker compose images`, which are decimal — not against `free`. Three
+/// `docker compose images`, which are decimal, not against `free`. Three
 /// digits because that is what those two print, measured rather than assumed:
 /// `docker compose` v5.1.3 rendered `98.2MB` for `redis:8-alpine` and `podman
 /// images` rendered `1.01 GB` and `805 kB` on the same host. A fixed decimal
@@ -31,7 +31,7 @@ struct ImageRow {
 	tag: String,
 	id: String,
 	/// Raw bytes as libpod reported them. Zero when the image is not present
-	/// locally, which the table renders as an empty cell — a missing image has
+	/// locally, which the table renders as an empty cell: a missing image has
 	/// no size, and `0B` would claim it has one.
 	size: u64,
 	/// The RFC 3339 string libpod sent, kept raw so the table can render an age
@@ -100,7 +100,7 @@ impl Engine {
 						created: img.created,
 					});
 				}
-				// A 404 means the image is simply not present locally — list it with
+				// A 404 means the image is simply not present locally, so list it with
 				// an empty ID rather than silently dropping it, matching docker
 				// compose. Any other error (a connection failure / unreachable
 				// socket, or an HTTP 500) is a real failure that must propagate with
@@ -194,7 +194,7 @@ impl Engine {
 /// The SIZE cell for one row.
 ///
 /// An image that is not present locally has no size to report, so the cell is
-/// empty. `0B` would be a claim — that podup asked and the answer was zero —
+/// empty. `0B` would be a claim (that podup asked and the answer was zero)
 /// and the row already says the image is missing by carrying no ID.
 fn size_cell(size: u64) -> String {
 	if size == 0 {

--- a/internal/engine/query/images_tests.rs
+++ b/internal/engine/query/images_tests.rs
@@ -26,7 +26,7 @@ fn the_size_cell_uses_the_decimal_ladder() {
 	assert!(!cell.contains("iB"), "{cell:?} used a binary unit");
 }
 
-/// An image that is not present locally reports zero, and zero is not a size —
+/// An image that is not present locally reports zero, and zero is not a size:
 /// it is the absence of an answer. An empty cell says that; `0B` would claim
 /// podup asked and the image really is empty.
 #[test]

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -44,7 +44,7 @@ impl Engine {
 			}
 			// Deduplicate repeated positionals (`top web web`) preserving order, so
 			// a service's process block is not rendered twice and we avoid redundant
-			// `/top` API calls — matching docker compose top.
+			// `/top` API calls, matching docker compose top.
 			dedup_preserving_order(target_services)
 		};
 
@@ -53,7 +53,7 @@ impl Engine {
 			// Only running containers are asked for their process list, so a
 			// stopped replica is skipped before the call rather than after it
 			// fails: `/top` answers a non-running container with an HTTP 500, and
-			// the rule below — that a non-404 must surface — is deliberate and
+			// the rule below (that a non-404 must surface) is deliberate and
 			// stays. Measured against `docker compose top` v5.1.3 on the same
 			// Podman socket: it omits a stopped service, prints the rest and exits
 			// 0 (#1250).
@@ -82,8 +82,8 @@ impl Engine {
 						Self::print_process_table(&titles, &processes);
 					}
 					// A container removed between the listing above and this call
-					// (404) is tolerated; any other failure — an unreachable socket,
-					// a container that died in that same window — is a real error
+					// (404) is tolerated; any other failure (an unreachable socket,
+					// a container that died in that same window) is a real error
 					// that must surface with a non-zero exit instead of being
 					// swallowed into a warning.
 					Err(e) if e.is_status(404) => {
@@ -104,7 +104,7 @@ impl Engine {
 	/// On `ui::Table` rather than the hand-rolled aligner it replaces: cells are
 	/// escaped and columns sized in one place, so `top` stops being a third
 	/// layout dialect that has to be fixed separately every time. The escaping
-	/// is not incidental — these cells hold a process `argv` read out of a
+	/// is not incidental: these cells hold a process `argv` read out of a
 	/// container, which is attacker-controlled.
 	///
 	/// The bookkeeping columns are dimmed so the command line is what the eye
@@ -150,7 +150,7 @@ impl Engine {
 		// compose replica count: a service scaled purely via CLI `--scale` has no
 		// `scale:` in the file, so the static count is 1 and would target the
 		// never-created un-indexed base name. Falls back to the static names
-		// when nothing is running yet — the bulk map (`#1445`) only sees what
+		// when nothing is running yet; the bulk map (`#1445`) only sees what
 		// Podman has, not the compose file.
 		let live_by_service = self.live_project_replicas_sorted().await?;
 		let live = match live_by_service.get(service_name) {

--- a/internal/engine/query/inspect_util.rs
+++ b/internal/engine/query/inspect_util.rs
@@ -82,7 +82,7 @@ pub(super) fn select_replica(
 }
 
 /// Resolve the `(port, proto)` for `port` from a `PORT` or `PORT/proto` argument,
-/// the `/proto` suffix overriding the `--protocol` flag — matching
+/// the `/proto` suffix overriding the `--protocol` flag, matching
 /// `docker compose port`. Pure so the parsing is unit-tested.
 ///
 /// The private port is parsed strictly like docker's port spec: only a canonical
@@ -90,7 +90,7 @@ pub(super) fn select_replica(
 /// (`080`), surrounding whitespace, or any trailing junk (`80/tcp/extra`) are
 /// rejected rather than silently coerced. The protocol is validated to
 /// `tcp`/`udp` (case-insensitive) and normalised to lowercase so it matches the
-/// lowercase keys Podman reports — an unknown or empty protocol errors clearly
+/// lowercase keys Podman reports; an unknown or empty protocol errors clearly
 /// instead of yielding an empty, exit-0 "no mapping" result.
 pub(super) fn parse_port_proto(
 	private_port: &str,
@@ -204,7 +204,7 @@ pub(super) fn top_dim_columns(titles: &[String]) -> Vec<usize> {
 ///
 /// On `ui::Table` rather than a hand-rolled aligner: cells are escaped and
 /// columns sized in one place, so `top` stops being a third layout dialect that
-/// has to be fixed separately every time. The escaping is not incidental — these
+/// has to be fixed separately every time. The escaping is not incidental: these
 /// cells hold a process `argv` read out of a container, which is
 /// attacker-controlled, and a process can name itself.
 ///

--- a/internal/engine/query/inspect_util_tests.rs
+++ b/internal/engine/query/inspect_util_tests.rs
@@ -1,6 +1,6 @@
 /// A process can name itself, and `top` prints that name. Without escaping,
 /// a container process called `\x1b[31mevil` repaints the reader's terminal
-/// — the one table in podup that formatted by hand rather than through
+/// the one table in podup that formatted by hand rather than through
 /// `fit_cell`, which has sanitized since it was written.
 #[test]
 fn top_escapes_control_characters_from_process_argv() {
@@ -121,7 +121,7 @@ fn top_pads_columns_to_the_widest_cell() {
 	let lines = super::process_table(&titles, &processes).unwrap().render();
 	assert_eq!(lines.len(), 3);
 	// The invariant is that the second column starts at one offset on every
-	// line, header included — not any particular prefix. Asserting a literal
+	// line, header included, not any particular prefix. Asserting a literal
 	// `"1      "` pinned the old hand-rolled aligner's two-space join, so it
 	// failed when `top` moved onto the shared table for no reason a reader of
 	// `top` would care about.

--- a/internal/engine/query/log_prefix.rs
+++ b/internal/engine/query/log_prefix.rs
@@ -3,8 +3,8 @@
 use std::io::Write;
 
 /// Cap on the buffered partial line. A container that emits a very long run
-/// with no newline — a `\r`-updated progress bar, binary output, a pathological
-/// single line — must not grow `pending` without bound. At this size the
+/// with no newline (a `\r`-updated progress bar, binary output, a pathological
+/// single line) must not grow `pending` without bound. At this size the
 /// partial is flushed as its own prefixed line (as docker does) rather than
 /// held in memory forever.
 const MAX_PENDING: usize = 64 * 1024;
@@ -16,13 +16,13 @@ const MAX_PENDING: usize = 64 * 1024;
 /// (`web-1`, from `display_label`), and only `identity_slot` strips that (and
 /// a project prefix) before resolving through the per-project colour registry
 /// `set_services` fills. Resolving `service_slot` against the raw label
-/// bypassed the registry entirely — that key was never in it — so every log
+/// bypassed the registry entirely (that key was never in it) so every log
 /// prefix silently fell back to the per-label hash instead of the sequential
 /// colour `ps` uses. Measured on an 8-service project: `ps` gave 8 distinct
 /// colours, `logs` only 6, before this indirection existed.
 ///
 /// [`prefix_style`] renders this into a [`crate::ui::Style`] and nothing else
-/// — so the routing choice this function makes is the one thing a regression
+/// so the routing choice this function makes is the one thing a regression
 /// test needs to pin down, and it can compare the slot directly rather than a
 /// rendered `Style`. That distinction matters: the narrow (6-colour) fallback
 /// wraps a slot index mod 6, so two different wide-palette slots can render
@@ -71,7 +71,7 @@ impl LinePrefixer {
 		// (a raw write anstream does not strip for us) and on `--no-color`.
 		// One space before the bar, not two. Attached `up` already prints
 		// `{prefix} | ` with one, so the same container was tagged two different
-		// ways by two commands in the same binary — and anything parsing the
+		// ways by two commands in the same binary, and anything parsing the
 		// prefix had to accept both. docker compose uses one space too.
 		let plain = format!("{label} | ");
 		let label = crate::ui::paint(
@@ -88,8 +88,8 @@ impl LinePrefixer {
 	/// Buffer `chunk` and write every complete line it now completes.
 	///
 	/// Returns `Err` when the sink is gone. Every write used to be discarded with
-	/// `let _ =`, so a reader that closed the pipe — `logs -f | head`,
-	/// `| grep -q`, `| less` and quit — was never noticed and the follow loop
+	/// `let _ =`, so a reader that closed the pipe (`logs -f | head`,
+	/// `| grep -q`, `| less` and quit) was never noticed and the follow loop
 	/// streamed into a dead pipe until the process was killed. The error is
 	/// returned rather than handled here so the caller decides: a broken pipe is
 	/// a clean end of output, any other io error is a real failure.

--- a/internal/engine/query/log_prefix_tests.rs
+++ b/internal/engine/query/log_prefix_tests.rs
@@ -2,7 +2,7 @@ use super::{prefix_slot, prefix_style, LinePrefixer};
 
 /// The regression this guards: `new` used to resolve `service_slot(label)`
 /// directly against the raw, replica-suffixed label, which is never a key
-/// in the per-project registry `identity_slot` resolves against — every log
+/// in the per-project registry `identity_slot` resolves against, so every log
 /// prefix silently fell back to the hash instead of the sequential colour
 /// `ps` uses for the same container.
 ///
@@ -13,7 +13,7 @@ use super::{prefix_slot, prefix_style, LinePrefixer};
 /// was red on any terminal that never announces the wide palette (no
 /// `TERM`/`COLORTERM`, which is every Linux/macOS CI leg today) whether or
 /// not the regression it guards was present. The slot itself never wraps,
-/// so it stays a real, palette-independent assertion — and since
+/// so it stays a real, palette-independent assertion, and since
 /// `prefix_style` does nothing but render `prefix_slot`'s output (see its
 /// doc comment), pinning the slot pins the `Style` too.
 #[test]
@@ -29,7 +29,7 @@ fn prefix_style_routes_through_identity_style_not_service_style() {
 		"the raw, suffixed label must not be hashed directly"
 	);
 	// `prefix_style` is a pure rendering of `prefix_slot`, so its `Style`
-	// still agrees with `identity_style` on a wide-palette terminal — kept
+	// still agrees with `identity_style` on a wide-palette terminal, kept
 	// as a smoke test that the rendering step itself is wired up.
 	assert_eq!(
 		prefix_style("web-1"),

--- a/internal/engine/query/mod.rs
+++ b/internal/engine/query/mod.rs
@@ -115,7 +115,7 @@ fn is_go_duration(v: &str) -> bool {
 ///
 /// Attached `up` already strips it this way (`inspect.rs`), so before this the
 /// same container was tagged `myproj-web-1  | ` by one command and `web-1 | ` by
-/// the other — two shapes for one thing, in one binary. docker compose prints
+/// the other: two shapes for one thing, in one binary. docker compose prints
 /// the short form.
 pub(crate) fn display_label(container_name: &str, project: &str) -> String {
 	container_name
@@ -127,7 +127,7 @@ pub(crate) fn display_label(container_name: &str, project: &str) -> String {
 /// Whether a failed write to the log sink should end the follow loop.
 ///
 /// A `BrokenPipe` is the ordinary way a piped consumer signals it has read
-/// enough — `logs -f | head`, `| grep -q`, `| less` and quit. It is a clean end
+/// enough: `logs -f | head`, `| grep -q`, `| less` and quit. It is a clean end
 /// of output, not a failure, and the loop must stop: podup used to discard the
 /// write result entirely and go on streaming into a dead pipe until the process
 /// was killed. Any other io error is worth a warning before stopping, since it
@@ -152,7 +152,7 @@ fn stop_on_write_error(container_name: &str, result: std::io::Result<()>) -> boo
 /// `None` counts as a break. It is tempting to read "could not tell" as a clean
 /// end, and that is wrong in the exact case this matters: the severed connection
 /// that ends the stream is usually the same one the re-check needs, so treating
-/// the unknown as success turns every transport failure back into exit 0 — which
+/// the unknown as success turns every transport failure back into exit 0, which
 /// is the bug, not the fix. Measured: with the permissive version, restarting the
 /// libpod socket under an attached `logs -f` reported a still-running container
 /// as stopped.
@@ -244,7 +244,7 @@ impl Engine {
 		}
 		let selected: std::collections::HashSet<&str> =
 			target_services.iter().map(String::as_str).collect();
-		// (container_name, is_tty) — TTY containers send raw bytes; non-TTY use
+		// (container_name, is_tty): TTY containers send raw bytes; non-TTY use
 		// multiplexed 8-byte-header framing. Resolved against the containers
 		// Podman actually has, not the static compose replica count: after a
 		// runtime `scale`/`up --scale` the file's count no longer matches the
@@ -253,15 +253,15 @@ impl Engine {
 		// the map (the bulk helper does not see the compose file).
 		//
 		// Hoisted out of the per-service loop so a `logs` over N services
-		// costs one container-list round-trip, not N (#1445) — the same bulk
+		// costs one container-list round-trip, not N (#1445), the same bulk
 		// path the per-service lifecycle commands took in #1363.
 		//
 		// A failure resolving ONE service is tolerated so the others still
-		// print — that is deliberate and tested. The bulk GET is now the only
+		// print; that is deliberate and tested. The bulk GET is now the only
 		// point where a single engine-side failure can land, so the same
 		// tolerance collapses into "warn + remember, the post-loop empty
 		// check surfaces the error when there is no partial result to
-		// protect" — i.e. an unreachable engine used to look like a project
+		// protect": an unreachable engine used to look like a project
 		// with no logs and still exit 0; this preserves that fix.
 		//
 		// The skip-on-fetch-error case must NOT fall back to the static
@@ -299,14 +299,14 @@ impl Engine {
 		}
 
 		// A container that is simply not there yet is tolerated per-container so
-		// the services that *do* exist still stream — that is deliberate. Anything
+		// the services that *do* exist still stream; that is deliberate. Anything
 		// else (the socket refusing, a 500) is not a per-container fact, it is the
 		// command failing, and `logs` reported exit 0 for it. Collected here and
 		// returned at the end so every reachable container is still shown first.
 		//
 		// Nothing resolved and something went wrong: there is no partial result to
 		// preserve, so the tolerance has nothing left to protect. This is separate
-		// from #1104 — nothing here classifies how a stream *ended*, the request
+		// from #1104: nothing here classifies how a stream *ended*, the request
 		// never opened.
 		if targets.is_empty() {
 			if let Some(e) = first_err {
@@ -354,7 +354,7 @@ impl Engine {
 						// These futures run concurrently under `join_all` on the
 						// same task, so the stdout/stderr lock is taken and
 						// released within each frame rather than held across the
-						// `.await` above — holding a guard across the await would
+						// `.await` above: holding a guard across the await would
 						// let a sibling future block the thread on the same lock
 						// and deadlock. Each frame still locks once and flushes,
 						// keeping interleaved `logs -f` output prompt.
@@ -385,7 +385,7 @@ impl Engine {
 								//
 								// The re-check is point-in-time, so a genuine break that
 								// coincides with the container stopping is knowingly
-								// read as a clean end — the transport cannot separate
+								// read as a clean end, because the transport cannot separate
 								// them and the container is gone either way.
 								Err(e) => {
 									let kind = e.stream_end_kind();
@@ -520,12 +520,12 @@ impl Engine {
 	///
 	/// A `logs -f` stream lives as long as its container runs and ends when the
 	/// container stops. libpod signals that end with a chunked terminator, and a
-	/// lost terminator — a dropped connection, or a version that omits it —
+	/// lost terminator (a dropped connection, or a version that omits it)
 	/// arrives as an `Err` that the transport layer cannot tell apart from a real
 	/// mid-stream break (#1104). Re-checking the container out of band resolves
 	/// it: still running means the stream truncated live output.
 	///
-	/// `Ok(None)` is "could not tell" — an unreadable state is not confirmation
+	/// `Ok(None)` is "could not tell": an unreadable state is not confirmation
 	/// the end was expected, so the caller keeps the original error rather than
 	/// masking a possible failure. Mirrors the fail-closed rule `stats` uses.
 	pub(super) async fn container_still_running(&self, container_name: &str) -> Option<bool> {
@@ -547,12 +547,12 @@ impl Engine {
 			})
 			.map(|e| e.state == "running")
 			// A container the listing no longer holds has been removed, which is a
-			// stop by any other name — the stream had every reason to end.
+			// stop by any other name; the stream had every reason to end.
 			.or(Some(false))
 	}
 
 	/// Names of this project's containers (by label) that the current compose file
-	/// no longer defines — the orphans, shared by removal and the warning.
+	/// no longer defines: the orphans, shared by removal and the warning.
 	async fn orphan_container_names(&self, file: &ComposeFile) -> Result<Vec<String>> {
 		let path = format!(
 			"{API_PREFIX}/containers/json?all=true&filters={}",
@@ -584,8 +584,8 @@ impl Engine {
 
 	/// Remove containers labelled for this project that are not defined in the current compose file.
 	///
-	/// Best-effort across every orphan — one that fails to remove must not stop
-	/// the rest from being reaped — but the first real failure is remembered and
+	/// Best-effort across every orphan (one that fails to remove must not stop
+	/// the rest from being reaped) but the first real failure is remembered and
 	/// returned once every orphan has been attempted, so a removal that
 	/// genuinely fails does not exit 0 with the orphan left behind (#598). A 404
 	/// (already gone) stays an idempotent no-op.

--- a/internal/engine/query/ps.rs
+++ b/internal/engine/query/ps.rs
@@ -1,4 +1,4 @@
-//! `ps` — list this project's containers as a table or JSON. Split out of the
+//! `ps` lists this project's containers as a table or JSON. Split out of the
 //! query root so each file stays within the source line limit.
 
 use crate::compose::types::ComposeFile;
@@ -64,7 +64,7 @@ impl PsOptions {
 ///
 /// **`#[non_exhaustive]` from birth, and that is the whole point.** Both
 /// [`PsOptions`] and [`PsFilterOptions`] are externally constructible with a
-/// struct literal, so adding a field to either requires a MAJOR — measured with
+/// struct literal, so adding a field to either requires a MAJOR, measured with
 /// `cargo semver-checks`, which reports `constructible_struct_adds_field`, not
 /// assumed from the rules. `PsFilterOptions` was itself introduced to keep
 /// `PsOptions` stable and inherited the same problem, so a third frozen struct
@@ -195,7 +195,7 @@ const SPAN_FORMAT: DurationFormat = DurationFormat::default_parts();
 /// span answers "did it just restart", which is the question someone runs `ps`
 /// to settle.
 ///
-/// The health suffix only appears when the container has a healthcheck —
+/// The health suffix only appears when the container has a healthcheck:
 /// libpod leaves `Status` empty otherwise, measured on Podman 5.7.0, so there is
 /// nothing to append rather than an unknown to invent.
 ///
@@ -221,7 +221,7 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 	};
 	// `health_from_status` answers with an empty string when the container has
 	// no healthcheck, which is the same case as libpod sending an empty
-	// `Status` — nothing to append rather than an unknown to invent.
+	// `Status`, so nothing to append rather than an unknown to invent.
 	match health_from_status(status) {
 		"" => format!("Up {uptime}"),
 		health => format!("Up {uptime} ({health})"),
@@ -232,8 +232,8 @@ fn table_status(c: &ContainerListEntry, now: i64) -> String {
 ///
 /// Pure so the query it builds can be asserted without a server. The `size`
 /// parameter is the one worth pinning: `size=true` is not a bigger payload, it
-/// is work — libpod walks each container's writable layer to answer, measured
-/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0 — so asking for it
+/// is work: libpod walks each container's writable layer to answer, measured
+/// at 21 ms against 109 ms over 59 containers on Podman 5.7.0, so asking for it
 /// unconditionally would make every `ps` pay for a column most readers do not
 /// look at. `docker ps -s` is opt-in for the same reason.
 ///
@@ -251,7 +251,7 @@ fn containers_path(project: &str, all: bool, size: bool) -> String {
 
 /// How `ps` renders a size: decimal units at three significant digits.
 ///
-/// The same shape `images` uses, and for the same reason — this column is read
+/// The same shape `images` uses, and for the same reason: this column is read
 /// against `podman ps -s`, which prints `143kB (virtual 225MB)`. Measured
 /// against it rather than assumed.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
@@ -259,7 +259,7 @@ const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 /// Table SIZE cell: the writable layer, then the image behind it.
 ///
 /// `143kB (virtual 225MB)`, matching `podman ps -s` and `docker ps -s`.
-/// **`virtual` is the image's own size, not the sum** — verified on three
+/// **`virtual` is the image's own size, not the sum**, verified on three
 /// containers whose two readings differ at three significant digits, because on
 /// a container with a small writable layer the two are indistinguishable and a
 /// wrong choice would never show.
@@ -296,7 +296,7 @@ fn table_created(c: &ContainerListEntry, now: i64) -> String {
 /// render.
 ///
 /// A zero `then` means the field was absent, not that the instant was the epoch.
-/// A `then` in the future is clock skew between this process and the server —
+/// A `then` in the future is clock skew between this process and the server,
 /// clamped to zero rather than rendered as a negative age, since `Up 0s` on a
 /// container that just started is right and `Up -3s` is never right.
 fn span_since(then: i64, now: i64) -> Option<String> {
@@ -380,8 +380,8 @@ fn span_len(p: &ContainerPort) -> u16 {
 }
 
 /// `base + offset` widened to `u32` before adding. `host_port`,
-/// `container_port` and `range` all come straight off libpod's JSON — untrusted
-/// input a hostile or buggy daemon could set to any `u16` value — so a plain
+/// `container_port` and `range` all come straight off libpod's JSON, untrusted
+/// input a hostile or buggy daemon could set to any `u16` value, so a plain
 /// `u16 + u16` (e.g. `host_port: 65535` with a `range` of 2) can overflow: it
 /// wraps silently in a release build and panics under overflow-checks. Doing
 /// the addition in `u32` keeps every legitimate port value identical while a
@@ -470,7 +470,7 @@ fn ps_json_row(c: &ContainerListEntry) -> serde_json::Value {
 		// wants an instant it can compute with rather than `2mo 1d`.
 		"Created": c.created,
 		"StartedAt": c.started_at,
-		// Raw byte counts, and null when the size was not requested — the same
+		// Raw byte counts, and null when the size was not requested, the same
 		// distinction the table draws between an empty cell and a zero.
 		"Size": c.size.map(|s| serde_json::json!({
 			"RwSize": s.rw,
@@ -619,7 +619,7 @@ impl Engine {
 		// second cannot render different ages.
 		let now = now_unix();
 		// SIZE is appended rather than inserted, so a reader's existing column
-		// positions do not move when the flag is off — and `docker ps -s` puts
+		// positions do not move when the flag is off, and `docker ps -s` puts
 		// it last too.
 		let mut headers: Vec<&str> = vec!["NAME", "IMAGE", "CREATED", "STATUS", "PORTS"];
 		if display.size {

--- a/internal/engine/query/ps/tests.rs
+++ b/internal/engine/query/ps/tests.rs
@@ -170,7 +170,7 @@ fn format_ports_expands_a_collapsed_range() {
 
 #[test]
 fn format_port_record_does_not_overflow_u16_on_pathological_range() {
-	// `host_port`/`container_port`/`range` come straight from libpod's JSON —
+	// `host_port`/`container_port`/`range` come straight from libpod's JSON:
 	// untrusted input. host_port=65535 with a range of 2 needs
 	// `host_port + (range - 1)` = 65536, which does not fit in a u16: it
 	// wraps to 0 in release and panics under overflow-checks (this test runs
@@ -234,7 +234,7 @@ fn health_is_derived_from_status_text() {
 	);
 	assert_eq!(health_from_status("Exited (1) 4 seconds ago"), "");
 	// A restarting container with no healthcheck must not be misread as
-	// "starting" health — only the real `health: starting` token counts.
+	// "starting" health; only the real `health: starting` token counts.
 	assert_eq!(health_from_status("Restarting (1) 3 seconds ago"), "");
 }
 
@@ -310,7 +310,7 @@ fn a_start_time_in_the_future_clamps_to_zero() {
 /// useful fact about it. The case that actually exercises the guard is
 /// **paused**: it has a real `StartedAt` and is not running, so without the
 /// check it would claim `Up 1h` for a container that is doing nothing. The
-/// first version of this test used an exited container and proved nothing —
+/// first version of this test used an exited container and proved nothing:
 /// that path returns from the exit-code branch before the guard is reached, so
 /// deleting the guard left it green.
 #[test]
@@ -414,7 +414,7 @@ fn the_size_cell_matches_what_podman_prints() {
 /// `virtual` is the image's own size, **not** the sum of the two. On a
 /// container with a small writable layer the two are indistinguishable at three
 /// significant digits, so this uses the three real containers whose readings
-/// actually differ — otherwise the test passes under either reading and pins
+/// actually differ; otherwise the test passes under either reading and pins
 /// nothing.
 #[test]
 fn virtual_is_the_image_size_and_not_the_total() {
@@ -460,7 +460,7 @@ fn a_zero_byte_writable_layer_still_renders() {
 }
 
 /// The JSON path carries the raw counts, and `null` when the size was not
-/// requested — the same distinction the table draws, so a machine consumer can
+/// requested, the same distinction the table draws, so a machine consumer can
 /// tell "not asked" from "empty" too.
 #[test]
 fn the_json_row_distinguishes_an_absent_size_from_a_zero() {

--- a/internal/engine/query/terminal/mod.rs
+++ b/internal/engine/query/terminal/mod.rs
@@ -5,7 +5,7 @@
 //! ioctl and `SIGWINCH`; Windows speaks the console API (`SetConsoleMode`,
 //! `GetConsoleScreenBufferInfo`) and polls for window changes, because the
 //! console has no resize signal to subscribe to. Callers see the same three
-//! names either way — [`RawMode`], [`window_size`], [`ResizeWatcher`] — and
+//! names either way ([`RawMode`], [`window_size`], [`ResizeWatcher`]) and
 //! the pump in `terminal_pump` compiles once against them.
 //!
 //! The invariant both implementations exist to hold: **the terminal is

--- a/internal/engine/query/terminal/unix.rs
+++ b/internal/engine/query/terminal/unix.rs
@@ -1,8 +1,8 @@
-//! The termios implementation of the terminal contract — see the module doc
+//! The termios implementation of the terminal contract; see the module doc
 //! in `mod.rs` for the contract and the restore-on-drop invariant.
 
 // termios and the winsize ioctl are libc FFI. The crate denies `unsafe` and
-// modules that need it opt back in locally, with a soundness comment per block —
+// modules that need it opt back in locally, with a soundness comment per block;
 // see `engine::lock` and `engine::staging` for the same pattern.
 #![allow(unsafe_code)]
 
@@ -32,7 +32,7 @@ impl RawMode {
 	///
 	/// `enable` is the only place that consults the ambient stdin, which keeps
 	/// this testable: a test that asserted on `enable()` directly would be
-	/// asserting that whoever runs `cargo test` has no terminal — true under a
+	/// asserting that whoever runs `cargo test` has no terminal: true under a
 	/// pipe, false in a shell, and on the way to being false it would put the
 	/// developer's own terminal into raw mode.
 	pub(super) fn enable_on(fd: i32) -> Option<Self> {
@@ -54,7 +54,7 @@ impl RawMode {
 		unsafe { libc::cfmakeraw(&mut raw) };
 		// SAFETY: `raw` is a fully initialized `termios` derived from the current
 		// settings. TCSANOW applies immediately, which is what an interactive
-		// session wants — a drained flush would swallow keystrokes already typed.
+		// session wants; a drained flush would swallow keystrokes already typed.
 		if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
 			return None;
 		}
@@ -83,8 +83,8 @@ impl Drop for RawMode {
 /// this, a full-screen program inside the container draws to an 80x24 default
 /// and redraws wrong the moment the window changes.
 ///
-/// **stdin first, then stdout.** Asking only stdout looks natural — that is
-/// where the drawing goes — but the two can differ: `podup exec -it db psql >
+/// **stdin first, then stdout.** Asking only stdout looks natural, since that is
+/// where the drawing goes, but the two can differ: `podup exec -it db psql >
 /// out.txt` types into a terminal and writes to a file, and stdout then answers
 /// "not a terminal" while a perfectly good size sits on stdin. Interactivity is
 /// decided by stdin, so the size is asked of stdin too, and stdout is the
@@ -102,7 +102,7 @@ fn size_of(fd: i32) -> Option<(u16, u16)> {
 	if unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) } != 0 {
 		return None;
 	}
-	// A terminal that reports 0x0 has no usable geometry — treat it as unknown
+	// A terminal that reports 0x0 has no usable geometry, so treat it as unknown
 	// rather than sizing the remote pty to nothing.
 	if ws.ws_row == 0 || ws.ws_col == 0 {
 		return None;

--- a/internal/engine/query/terminal/unix_tests.rs
+++ b/internal/engine/query/terminal/unix_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// A non-terminal descriptor is declined rather than failing — the path
+/// A non-terminal descriptor is declined rather than failing: the path
 /// `podup exec` takes inside a pipeline, which must keep working.
 ///
 /// Asked of an explicit `/dev/null` rather than of ambient stdin: the same

--- a/internal/engine/query/terminal/windows.rs
+++ b/internal/engine/query/terminal/windows.rs
@@ -1,4 +1,4 @@
-//! The console-API implementation of the terminal contract — see the module
+//! The console-API implementation of the terminal contract; see the module
 //! doc in `mod.rs` for the contract and the restore-on-drop invariant.
 //!
 //! Windows has no termios: raw mode is a console *mode* cleared on the stdin
@@ -11,7 +11,7 @@
 
 // The console mode and screen-buffer calls are Win32 FFI. The crate denies
 // `unsafe` and modules that need it opt back in locally, with a soundness
-// comment per block — see `engine::lock` and `engine::staging` for the same
+// comment per block; see `engine::lock` and `engine::staging` for the same
 // pattern.
 #![allow(unsafe_code)]
 
@@ -29,8 +29,8 @@ use windows_sys::Win32::System::Console::{
 /// Holding the *original* modes rather than reconstructing "sane" ones
 /// matters: the caller's shell may run with its own console flags, and putting
 /// the console into what podup thinks is normal would quietly change them.
-/// Both ends are touched — stdin so keystrokes stop being line-buffered and
-/// echoed, stdout so the VT sequences a pty emits are interpreted — so both
+/// Both ends are touched (stdin so keystrokes stop being line-buffered and
+/// echoed, stdout so the VT sequences a pty emits are interpreted) so both
 /// originals are held and both are restored.
 pub(crate) struct RawMode {
 	stdin: HANDLE,
@@ -64,7 +64,7 @@ impl RawMode {
 	///
 	/// `enable` is the only place that consults the ambient handles, which
 	/// keeps this testable: a test that asserted on `enable()` directly would
-	/// be asserting on whether the test runner has a console — and on the way
+	/// be asserting on whether the test runner has a console, and on the way
 	/// to failing it would put that console into raw mode.
 	pub(super) fn enable_on(stdin: HANDLE, stdout: HANDLE) -> Option<Self> {
 		if stdin.is_null() || stdin == INVALID_HANDLE_VALUE {
@@ -77,7 +77,7 @@ impl RawMode {
 		let mut stdin_original: CONSOLE_MODE = 0;
 		// SAFETY: `stdin_original` is a correctly sized mode owned here, and
 		// `GetConsoleMode` only writes into it. A non-console handle fails the
-		// call rather than misbehaving — that is exactly the "not a terminal"
+		// call rather than misbehaving; that is exactly the "not a terminal"
 		// answer.
 		if unsafe { GetConsoleMode(stdin, &mut stdin_original) } == 0 {
 			return None;
@@ -90,7 +90,7 @@ impl RawMode {
 
 		// Line input and echo are the console's line discipline; processed
 		// input turns Ctrl-C into an event instead of a byte. All three must
-		// go so keystrokes — including Ctrl-C — travel to the remote command,
+		// go so keystrokes, including Ctrl-C, travel to the remote command,
 		// which is what raw mode means. Virtual-terminal input makes arrows
 		// and function keys arrive as the VT sequences the remote pty expects.
 		let stdin_raw = (stdin_original
@@ -145,7 +145,7 @@ impl Drop for RawMode {
 /// without this, a full-screen program inside the container draws to an 80x24
 /// default and redraws wrong the moment the window changes.
 ///
-/// **stdout first, then stderr** — not stdin, unlike Unix: the screen buffer
+/// **stdout first, then stderr**, not stdin, unlike Unix: the screen buffer
 /// is an output-side object, and the input handle does not answer
 /// `GetConsoleScreenBufferInfo`. stderr covers a redirected stdout, the same
 /// reverse case the Unix fallback covers.
@@ -177,12 +177,12 @@ fn size_of(handle: HANDLE) -> Option<(u16, u16)> {
 /// `srWindow`, not `dwSize`: the buffer runs thousands of lines of scrollback,
 /// and sizing the remote pty to it would have a full-screen program paint a
 /// frame taller than the screen. The rectangle is inclusive on both ends,
-/// hence the `+ 1`s. Pure, so the arithmetic — the part worth pinning — is
+/// hence the `+ 1`s. Pure, so the arithmetic (the part worth pinning) is
 /// testable without a console.
 fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
 	let rows = i32::from(info.srWindow.Bottom) - i32::from(info.srWindow.Top) + 1;
 	let cols = i32::from(info.srWindow.Right) - i32::from(info.srWindow.Left) + 1;
-	// A degenerate or inverted rectangle has no usable geometry — treat it as
+	// A degenerate or inverted rectangle has no usable geometry, so treat it as
 	// unknown rather than sizing the remote pty to nothing.
 	if rows <= 0 || cols <= 0 {
 		return None;
@@ -194,8 +194,8 @@ fn window_extent(info: &CONSOLE_SCREEN_BUFFER_INFO) -> Option<(u16, u16)> {
 /// caller's window changes.
 ///
 /// The console has no resize signal, so this polls [`window_size`] four times
-/// a second and reports only changes. The alternative — `ReadConsoleInput`
-/// watching `WINDOW_BUFFER_SIZE_EVENT` — is event-driven but competes with the
+/// a second and reports only changes. The alternative, `ReadConsoleInput`
+/// watching `WINDOW_BUFFER_SIZE_EVENT`, is event-driven but competes with the
 /// stdin byte pump for the same console handle; polling costs one cheap call
 /// per tick and touches nothing the pump owns.
 pub(crate) struct ResizeWatcher {
@@ -232,7 +232,7 @@ impl ResizeWatcher {
 
 /// Whether a polled size warrants a resize: `Some` only when it is readable
 /// and differs from the last one reported, recording it as reported. Pure so
-/// the dedup — the part that decides whether the pump spams resize calls —
+/// the dedup (the part that decides whether the pump spams resize calls)
 /// is testable without a console.
 fn resize_due(last: &mut Option<(u16, u16)>, current: Option<(u16, u16)>) -> Option<(u16, u16)> {
 	let current = current?;

--- a/internal/engine/query/terminal/windows_tests.rs
+++ b/internal/engine/query/terminal/windows_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// A non-console handle is declined rather than failing — the path
+/// A non-console handle is declined rather than failing: the path
 /// `podup exec` takes inside a pipeline, which must keep working.
 ///
 /// Asked of an explicit `NUL` handle rather than of ambient stdin: the

--- a/internal/engine/query/tests.rs
+++ b/internal/engine/query/tests.rs
@@ -19,7 +19,7 @@ fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
 }
 
 /// #598: `--remove-orphans` that can't remove every orphan (e.g. an active
-/// exec session) must not exit 0 with one silently left behind — but a
+/// exec session) must not exit 0 with one silently left behind, but a
 /// sibling orphan that removes cleanly must still be reclaimed.
 #[tokio::test]
 #[cfg(unix)]
@@ -131,7 +131,7 @@ async fn logs_targets_every_live_replica_after_scale() {
 ///
 /// #1445 collapsed the per-service `live_replica_names` resolution into a
 /// single bulk fetch (`live_project_replicas_sorted`), so the per-service
-/// error path this test used to drive no longer exists — there is one
+/// error path this test used to drive no longer exists: there is one
 /// container-list call for the whole project, not one per service, so a
 /// per-service 500 is no longer reachable in this code. The companion
 /// `logs_fails_when_no_service_resolves_at_all` covers the only failure
@@ -232,7 +232,7 @@ fn is_valid_log_time_classifies_forms() {
 /// partial result left to protect.
 ///
 /// An unreachable engine made `logs` print nothing and exit 0, which is
-/// indistinguishable from a project that simply has no logs — so a health check
+/// indistinguishable from a project that simply has no logs, so a health check
 /// or deploy gate built on `compose logs` read success from an engine that was
 /// not there. Every service 500s here, so no target survives.
 ///
@@ -323,7 +323,7 @@ fn an_unreadable_state_counts_as_a_break() {
 	// The rule that is easy to get backwards, and the one that matters most: the
 	// severed connection that ends the stream is usually the same one the
 	// re-check needs, so reading "could not tell" as a clean end turns every
-	// transport failure back into exit 0. Measured — the permissive version
+	// transport failure back into exit 0. Measured: the permissive version
 	// reported a still-running container as stopped when the socket restarted
 	// under an attached `logs -f`.
 	assert!(stream_broke_mid_output(None));

--- a/internal/engine/replicas.rs
+++ b/internal/engine/replicas.rs
@@ -14,7 +14,7 @@ use crate::error::{ComposeError, Result};
 /// anything is created) and a 1-based `--index`. Each name is either the
 /// unsuffixed base (the sole replica) or `{base}-{n}`.
 ///
-/// `--index n` targets the replica numbered `n` — by name, not by position —
+/// `--index n` targets the replica numbered `n` by name, not by position,
 /// so it stays correct after a runtime `scale`/`up --scale` and regardless of
 /// the order Podman lists containers; `0` is rejected (indexes are 1-based);
 /// `None` picks the lowest-numbered replica. Pure so it is unit-testable

--- a/internal/engine/secrets/create.rs
+++ b/internal/engine/secrets/create.rs
@@ -17,7 +17,7 @@ use super::{collect_payload_union, Engine};
 impl Engine {
 	/// Create the union of the `content:`/`environment:`/`file:` secrets and
 	/// configs declared across *all* services in the project, once, before the
-	/// per-level start loop — mirroring how [`Engine::create_networks`] and
+	/// per-level start loop, mirroring how [`Engine::create_networks`] and
 	/// [`Engine::create_volumes`] pre-create their resources.
 	///
 	/// Doing this up front fixes the race in which two services in the same
@@ -64,7 +64,7 @@ impl Engine {
 		// `join_bounded`, and that is a compiler limitation rather than a
 		// preference. `join_bounded` is built on `buffer_unordered`, whose
 		// `FuturesUnordered` is `Send` only if its future is `Send` for *every*
-		// lifetime. Reaching it from here — where the futures borrow `self` —
+		// lifetime. Reaching it from here, where the futures borrow `self`,
 		// makes that bound higher-ranked and propagates out through `up` until an
 		// unrelated `tokio::spawn(engine.watch(…))` stops compiling with
 		// "implementation of `Send` is not general enough", reported in a test
@@ -76,7 +76,7 @@ impl Engine {
 		//
 		// Note the behaviour change this carries: previously the first failing
 		// secret aborted before the rest were touched, and now every secret in
-		// its chunk is attempted. Nothing leaks — `down` sweeps by label — but a
+		// its chunk is attempted. Nothing leaks (`down` sweeps by label) but a
 		// failed `up` can leave later secrets created where it used to leave none.
 		let mut results: Vec<Result<()>> = Vec::with_capacity(work.len());
 		for chunk in work.chunks(crate::engine::lifecycle::parallel::MAX_LIFECYCLE_CONCURRENCY) {
@@ -100,11 +100,11 @@ impl Engine {
 	/// is checked up front to turn Podman's opaque 500 into a clear message.
 	///
 	/// Idempotent across re-`up`s: rather than `replace=true` (which some Podman
-	/// 5.x builds reject when the secret does not yet exist — the internal delete
+	/// 5.x builds reject when the secret does not yet exist: the internal delete
 	/// fails with "no secret data with ID"), the existing secret of this name is
 	/// removed first (a 404 is fine) and then created fresh.
 	///
-	/// # Concurrency contract — read before touching the inspect → delete → create sequence
+	/// # Concurrency contract: read before touching the inspect → delete → create sequence
 	///
 	/// The inspect-then-delete-then-create is **not** atomic at the libpod wire
 	/// level, so a race in the window could delete something the caller does
@@ -119,7 +119,7 @@ impl Engine {
 	///    naming. Every secret created here has a name of the form
 	///    `<project>_...`, which is unique to this `Engine` instance, and the
 	///    inspect rejects any name that does not carry `podup.project=<proj>`
-	///    — so a foreign secret of the same literal name is refused rather
+	///    so a foreign secret of the same literal name is refused rather
 	///    than clobbered. A race with the same project therefore cannot
 	///    happen in the same process.
 	///
@@ -128,7 +128,7 @@ impl Engine {
 	/// claims a project-scoped name in the window between inspect and create.
 	/// That falls through to a `500 from libpod`, which this function
 	/// recognises and rewraps into a legible "something else created a secret
-	/// of that name in between" message — the operator can act on it without
+	/// of that name in between" message, so the operator can act on it without
 	/// having to read the libpod error verbatim.
 	async fn create_secret(&self, name: &str, payload: &SecretBytes) -> Result<()> {
 		check_secret_size(name, payload.byte_len())?;
@@ -147,7 +147,7 @@ impl Engine {
 				if !owned {
 					return Err(ComposeError::Unsupported(format!(
 						"a secret named '{name}' already exists and is not labelled \
-						 podup.project={} — refusing to overwrite a secret podup did \
+						 podup.project={}; refusing to overwrite a secret podup did \
 						 not create",
 						self.project
 					)));
@@ -185,13 +185,13 @@ impl Engine {
 			.map_err(|e| {
 				// Skipping the delete opens a window: the inspect said the name was
 				// free, and something claimed it before the create landed. `up` now
-				// fails there instead of clobbering whatever arrived — the better
+				// fails there instead of clobbering whatever arrived, the better
 				// outcome, but only if it is legible. Podman's own message for this
 				// is an opaque 500, so it is named here rather than passed through.
 				if !existed {
 					ComposeError::Unsupported(format!(
 						"secret '{name}' did not exist when podup checked but could not \
-						 be created: {e} — something else created a secret of that name \
+						 be created: {e}. Something else created a secret of that name \
 						 in between. Re-run `up`, or remove it if it is not wanted."
 					))
 				} else {

--- a/internal/engine/secrets/create_tests.rs
+++ b/internal/engine/secrets/create_tests.rs
@@ -4,7 +4,7 @@ use crate::engine::fake_podman;
 use crate::engine::secrets::tests_support::{engine_on, file_with_content_secrets};
 
 /// #1219: on a first `up` every secret inspect is a 404, so there is nothing
-/// to remove — the delete-then-create was spending a round trip per secret
+/// to remove: the delete-then-create was spending a round trip per secret
 /// deleting a secret that does not exist. Measured on the six-secret bench
 /// scenario, this is what takes a cold `up` from 25 requests to 19.
 #[tokio::test]
@@ -72,7 +72,7 @@ async fn create_still_deletes_a_secret_that_already_exists() {
 /// The behaviour change the fan-out carries, stated in #1219 and asserted
 /// here rather than left to the reader: the pass no longer stops at the
 /// first failure, so every secret is attempted, and the error that surfaces
-/// is the first *by name* — not whichever chain happened to lose the race.
+/// is the first *by name*, not whichever chain happened to lose the race.
 #[tokio::test]
 #[cfg(unix)]
 async fn fan_out_attempts_every_secret_and_reports_the_first_by_name() {
@@ -107,7 +107,7 @@ async fn fan_out_attempts_every_secret_and_reports_the_first_by_name() {
 
 /// Skipping the delete opens a window between the inspect and the create.
 /// If something claims the name in it, `up` fails rather than clobbering
-/// what arrived — but Podman's own message for that is an opaque 500, so
+/// what arrived, but Podman's own message for that is an opaque 500, so
 /// the failure has to name the race or the operator cannot act on it.
 #[tokio::test]
 #[cfg(unix)]
@@ -135,7 +135,7 @@ async fn a_name_claimed_after_the_inspect_fails_with_a_legible_message() {
 		err.contains("proj_secret_s1"),
 		"the message must name which secret, got: {err}"
 	);
-	// The engine's own error is kept as the cause — it is useful — but it must
+	// The engine's own error is kept as the cause, since it is useful, but it must
 	// not be the whole of what the operator is handed, which is what the bare
 	// `ComposeError::Podman` passthrough would have given them.
 	assert!(

--- a/internal/engine/secrets/mod.rs
+++ b/internal/engine/secrets/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! `file:` sources used to be read-only bind mounts of the host path instead.
 //! That worked until the host enforced SELinux, where the container is denied
-//! the read outright and `up` still reports the container as started — measured
+//! the read outright and `up` still reports the container as started, measured
 //! on Fedora with both supported Podman majors, and reproduced by plain `podman
 //! run`, so the denial was the missing relabel and not podup. Relabelling was
 //! the other way out, but `z` rewrites the label of a file the user owns and may
@@ -26,7 +26,7 @@
 //!
 //! The trade is that the payload is a copy taken at `up`, so an in-place edit of
 //! the host file no longer reaches a running container. An atomic replace never
-//! did — a file bind pins the inode, so the write-new-and-rename that every
+//! did: a file bind pins the inode, so the write-new-and-rename that every
 //! careful rotation tool performs was already invisible.
 //!
 //! The pure compose→plan mapping lives in [`plan`].
@@ -49,10 +49,10 @@ use super::Engine;
 
 impl Engine {
 	/// Build the Podman-native secret references for a service. Every source podup
-	/// creates — `content:`, `environment:` and `file:` — must already have been
+	/// creates (`content:`, `environment:` and `file:`) must already have been
 	/// created by [`Engine::create_project_secrets`] (run once up front), so this
-	/// only preflights `external: true` sources for existence — failing closed
-	/// rather than starting a container that lacks the secret — and assembles the
+	/// only preflights `external: true` sources for existence, failing closed
+	/// rather than starting a container that lacks the secret, and assembles the
 	/// per-service references attached to the container spec.
 	///
 	/// Creation is deliberately *not* done here: services in the same
@@ -125,7 +125,7 @@ pub(super) mod tests_support {
 	use crate::engine::fake_podman;
 
 	/// A compose file with `n` `content:` secrets named `s1..sn`, all on one
-	/// service — the shape the union deduplicates and then fans out over.
+	/// service, the shape the union deduplicates and then fans out over.
 	#[cfg(unix)]
 	pub(in crate::engine::secrets) fn file_with_content_secrets(n: usize) -> ComposeFile {
 		let refs: String = (1..=n).map(|i| format!("      - s{i}\n")).collect();

--- a/internal/engine/secrets/mod_tests.rs
+++ b/internal/engine/secrets/mod_tests.rs
@@ -24,7 +24,7 @@ fn only_file_path(engine: &Engine, yaml: &str) -> PathBuf {
 #[test]
 fn secret_file_relative_path_is_anchored_to_base_dir() {
 	// A relative `file:` resolves against the project dir, not the Podman
-	// service's cwd — same as a bind-mount source, which is what this was.
+	// service's cwd, the same as a bind-mount source, which is what this was.
 	let base = PathBuf::from("/srv/project");
 	let yaml = "services:\n  web:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    file: secret.txt\n";
 	let engine = engine_with_base(&base.to_string_lossy());
@@ -47,7 +47,7 @@ fn config_file_absolute_path_is_passed_through() {
 fn inline_union_dedups_shared_secret_across_services() {
 	// Two services in the same project both reference the same inline secret.
 	// The up-front union must create it once (one scoped name), not once per
-	// service — which is what previously raced delete-then-create.
+	// service, which is what previously raced delete-then-create.
 	let yaml = "services:\n  a:\n    image: nginx\n    secrets: [tok]\n  b:\n    image: nginx\n    secrets: [tok]\nsecrets:\n  tok:\n    content: shared\n";
 	let file = crate::compose::parse_str_raw(yaml).unwrap();
 	let union = collect_payload_union("proj", &file, Path::new("/base")).unwrap();

--- a/internal/engine/secrets/plan.rs
+++ b/internal/engine/secrets/plan.rs
@@ -21,15 +21,15 @@ pub(super) const MAX_SECRET_BYTES: usize = 512_000;
 /// mapping unit-testable, so the read happens in the effectful layer that creates
 /// the secret.
 pub(super) enum Payload {
-	/// Inline `content:`/`environment:` — the bytes, already resolved.
+	/// Inline `content:`/`environment:`: the bytes, already resolved.
 	Inline(SecretBytes),
-	/// `file:` — the resolved host path to read at creation time.
+	/// `file:` is the resolved host path to read at creation time.
 	File(PathBuf),
 }
 
 /// A planned native secret for a service: the Podman secret `source` to attach,
-/// the in-container `target`, optional permissions, and — for every source podup
-/// creates itself — the `payload` to create under `source`. `external: true`
+/// the in-container `target`, optional permissions, and, for every source podup
+/// creates itself, the `payload` to create under `source`. `external: true`
 /// references carry no payload (the secret must pre-exist).
 pub(super) struct NativePlan {
 	pub(super) source: String,
@@ -53,11 +53,11 @@ struct SourceDef<'a> {
 
 /// Where a secret/config's bytes come from once the compose def is resolved.
 enum Source {
-	/// Inline `content:`/`environment:` — `(scoped podman name, payload bytes)`.
+	/// Inline `content:`/`environment:`: `(scoped podman name, payload bytes)`.
 	Inline(String, SecretBytes),
-	/// `file:` — `(scoped podman name, resolved host path)`.
+	/// `file:`: `(scoped podman name, resolved host path)`.
 	File(String, PathBuf),
-	/// `external: true` — name of the pre-existing podman secret.
+	/// `external: true`: name of the pre-existing podman secret.
 	External(String),
 }
 
@@ -119,7 +119,7 @@ pub(super) fn collect_native_plans(
 				},
 				base_dir,
 			)?;
-			// Configs default to an absolute container-root path — `/name`, not
+			// Configs default to an absolute container-root path: `/name`, not
 			// `/run/secrets/name`. That is what separates a config from a secret
 			// here, and it is the path a `file:` config landed on when it was a
 			// bind mount.
@@ -132,8 +132,8 @@ pub(super) fn collect_native_plans(
 }
 
 /// Resolve a secret/config definition to its native [`Source`]. `external`
-/// wins (it may also carry a custom `name:`); every other populated source —
-/// inline `content:`/`environment:` and `file:` alike — becomes a project-scoped
+/// wins (it may also carry a custom `name:`); every other populated source,
+/// inline `content:`/`environment:` and `file:` alike, becomes a project-scoped
 /// native secret. An empty def yields `None` and contributes no plan.
 fn resolve_source(
 	project: &str,
@@ -183,7 +183,7 @@ fn resolve_source(
 	}
 	if let Some(host_path) = file_source {
 		// Resolve like a bind-mount source: a relative `file:` is anchored to the
-		// project dir (not the Podman service's cwd) and `~` is expanded — the same
+		// project dir (not the Podman service's cwd) and `~` is expanded, the same
 		// handling `volumes:` gets, and the same this had when it was a bind.
 		return Ok(Some(Source::File(
 			scoped_name(project, kind, name),
@@ -220,7 +220,7 @@ fn push_plan(
 	//
 	// A `file:` source is the exception: it is left unset here so the effectful
 	// layer can mirror the host file's own permission bits. That keeps what the
-	// container sees identical to the bind this used to be — a `0600` secret stays
+	// container sees identical to the bind this used to be: a `0600` secret stays
 	// unreadable to a non-root container user instead of being widened to `0444`.
 	let mode = if from_file {
 		mode
@@ -260,7 +260,7 @@ pub(super) fn check_secret_size(name: &str, len: usize) -> Result<()> {
 }
 
 /// Whether a secret/config def is one podup creates as a project-scoped native
-/// secret — inline `content:`/`environment:` or a `file:` source. `external:`
+/// secret, inline `content:`/`environment:` or a `file:` source. `external:`
 /// wins and is never created (nor removed) by podup.
 pub(super) fn is_podup_created_source(
 	external: Option<bool>,
@@ -272,7 +272,7 @@ pub(super) fn is_podup_created_source(
 }
 
 /// The permission bits to mount a `file:` secret with when the compose file
-/// names no `mode:` — the host file's own, so the container sees what it saw
+/// names no `mode:`: the host file's own, so the container sees what it saw
 /// when this was a bind mount.
 ///
 /// Execute and the special bits are masked off: a secret holds data, never code,

--- a/internal/engine/secrets/plan_tests.rs
+++ b/internal/engine/secrets/plan_tests.rs
@@ -261,7 +261,7 @@ fn native_secret_without_mode_defaults_to_0444() {
 #[test]
 fn secret_mode_leading_zero_is_octal() {
 	// `0444` (leading-zero octal, the Compose Specification spelling) parses as
-	// octal 0o444, not decimal 444 (which would fail) — issue #2.
+	// octal 0o444, not decimal 444 (which would fail); issue #2.
 	let p = plans("services:\n  web:\n    image: x\n    secrets:\n      - source: tok\n        mode: 0444\nsecrets:\n  tok:\n    content: data\n");
 	assert_eq!(p[0].mode, Some(0o444));
 }

--- a/internal/engine/secrets/remove.rs
+++ b/internal/engine/secrets/remove.rs
@@ -5,10 +5,10 @@
 //! since every secret podup creates carries `podup.project=<proj>`, so a single
 //! pass over it sweeps the declared secrets and the orphans alike.
 //!
-//! Every secret podup creates — including `file:` sources, whose bytes are
+//! Every secret podup creates, including `file:` sources, whose bytes are
 //! copied into a Podman-native secret at `up` time and **persist independently
 //! of any container** (`podman-secret-rm(1)`: the secret lives in the podman
-//! store, not in container state) — is removed on `down`. Without this sweep
+//! store, not in container state), is removed on `down`. Without this sweep
 //! the bytes from a `file:` source survive a `down`/`up` cycle until the next
 //! `up` overwrites them, which is a defence-in-depth gap (#1360): a stale
 //! secret payload outlives the container that read it. A summary log line
@@ -36,7 +36,7 @@ impl Engine {
 		// One list answers the ownership question for every name at once (#1263).
 		// It used to be fetched only for the orphan sweep, *after* each
 		// compose-named secret had already been inspected individually for the
-		// same label — so every label was fetched twice, once per secret and once
+		// same label, so every label was fetched twice, once per secret and once
 		// for all of them.
 		//
 		// The label-carrying list is also a superset of what the compose loops
@@ -68,7 +68,7 @@ impl Engine {
 			}
 			// The list failed. Falling through to an empty set would silently
 			// delete nothing and report a clean teardown, so this drops back to
-			// the per-secret guarded path instead — the same requests as before
+			// the per-secret guarded path instead, the same requests as before
 			// #1263, only reached when the cheap route is unavailable. The orphan
 			// sweep is not possible without a list, which is also how it behaved
 			// before.
@@ -106,7 +106,7 @@ impl Engine {
 		Ok(())
 	}
 
-	/// Names of all native secrets labelled `podup.project=<proj>` — the secrets
+	/// Names of all native secrets labelled `podup.project=<proj>`, the secrets
 	/// podup created for this project. libpod's `/secrets/json` rejects a `label`
 	/// filter (HTTP 500 `invalid filter "label"`), so the full list is fetched and
 	/// filtered client-side by the `podup.project` label.
@@ -154,7 +154,7 @@ impl Engine {
 	/// make: this one is only reachable from a name the list vouched for.
 	///
 	/// Returns `true` when the secret was actually removed (or was already
-	/// absent — a 404 still counts as teardown success). The caller collects
+	/// absent; a 404 still counts as teardown success). The caller collects
 	/// the names for the summary log line.
 	async fn delete_listed_secret(&self, name: &str) -> bool {
 		let path = format!("{API_PREFIX}/secrets/{}", urlencoded(name));
@@ -171,7 +171,7 @@ impl Engine {
 	}
 
 	/// Delete a project-scoped secret, but only after confirming it carries our
-	/// `podup.project=<proj>` label — so a same-named secret the user created by
+	/// `podup.project=<proj>` label, so a same-named secret the user created by
 	/// hand (and which podup never created) is never destroyed on `down`. A
 	/// missing secret (404) is a no-op.
 	///
@@ -190,7 +190,7 @@ impl Engine {
 					== Some(self.project.as_str());
 				if !owned {
 					tracing::warn!(
-						"secret {name} is not labelled podup.project={} — \
+						"secret {name} is not labelled podup.project={}, \
 						 leaving it untouched (not created by podup)",
 						self.project
 					);
@@ -220,7 +220,7 @@ impl Engine {
 /// One summary log line that lists the podup-created secrets removed on
 /// `down`. The per-secret `info` lines stay as the per-record audit;
 /// the summary is the line the operator actually searches for when
-/// the teardown finishes. Empty lists are silent — a `down` with no
+/// the teardown finishes. Empty lists are silent: a `down` with no
 /// declared secrets composes cleanly with the rest of the teardown
 /// without adding noise.
 fn log_removed_secrets(project: &str, removed: &[String]) {

--- a/internal/engine/secrets/remove_tests.rs
+++ b/internal/engine/secrets/remove_tests.rs
@@ -53,7 +53,7 @@ async fn down_uses_the_list_and_inspects_no_secret_individually() {
 }
 
 /// The guard the batch has to keep: a secret carrying another project's label
-/// is not in the owned set, so it is neither inspected nor removed — even
+/// is not in the owned set, so it is neither inspected nor removed, even
 /// though the compose file names it.
 #[tokio::test]
 #[cfg(unix)]
@@ -88,7 +88,7 @@ async fn down_never_deletes_a_secret_labelled_for_another_project() {
 }
 
 /// A secret podup created whose compose key was since renamed or removed is
-/// still swept, because the labelled list — not the compose file — is what
+/// still swept, because the labelled list, not the compose file, is what
 /// teardown walks.
 #[tokio::test]
 #[cfg(unix)]
@@ -116,7 +116,7 @@ async fn down_sweeps_an_orphan_the_compose_file_no_longer_names() {
 }
 
 /// The failure mode worth more than the saving. Since the list *is* the
-/// ownership check now, a failed list must not read as "nothing is ours" —
+/// ownership check now, a failed list must not read as "nothing is ours":
 /// that would delete nothing and report a clean `down`. It falls back to the
 /// per-secret guarded path instead.
 #[tokio::test]

--- a/internal/engine/secrets/secret_bytes.rs
+++ b/internal/engine/secrets/secret_bytes.rs
@@ -12,13 +12,13 @@ use std::fmt;
 /// [`ComposeError`] carries a `String`, so any error built on this path is one
 /// `format!` away from putting a secret into a public CI log. Keeping that from
 /// happening was, until this type existed, a property of nobody having written
-/// it — not of anything stopping them.
+/// it, not of anything stopping them.
 ///
 /// So the guarantee is moved into the type. `SecretBytes` implements neither
 /// `Display` nor a derived `Debug`: `format!("{payload}")` does not compile at
 /// all, and `format!("{payload:?}")` prints the length instead of the contents.
 /// Those two are how every message in this module is built, which leaves exactly
-/// one way for the bytes to get out — [`SecretBytes::expose_secret`], named after
+/// one way for the bytes to get out: [`SecretBytes::expose_secret`], named after
 /// the `secrecy` crate's convention so that grepping for it enumerates the
 /// audit surface. It has one caller: the body of the `secrets/create` request.
 pub(super) struct SecretBytes(Vec<u8>);

--- a/internal/engine/secrets/secret_bytes_tests.rs
+++ b/internal/engine/secrets/secret_bytes_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 /// The redaction is the whole point of [`SecretBytes`], so it is asserted
-/// rather than assumed. Without this, someone deriving `Debug` on the type —
-/// the obvious thing to reach for — would silently undo it.
+/// rather than assumed. Without this, someone deriving `Debug` on the type,
+/// the obvious thing to reach for, would silently undo it.
 #[test]
 fn secret_bytes_debug_redacts_the_contents_and_keeps_the_length() {
 	let payload = SecretBytes::new(b"a-secret-that-must-not-be-printed".to_vec());
@@ -30,7 +30,7 @@ fn the_bare_byte_form_this_replaces_leaks_in_decimal() {
 }
 
 /// [`SecretBytes::expose_secret`] is the only way the bytes get out, so
-/// grepping for it is the audit — and an audit surface nothing measures is one
+/// grepping for it is the audit, and an audit surface nothing measures is one
 /// that grows. Test code may call it freely; production may not.
 #[test]
 fn the_escape_hatch_has_exactly_one_production_caller() {

--- a/internal/engine/staging.rs
+++ b/internal/engine/staging.rs
@@ -2,8 +2,8 @@
 //!
 //! [`staging_base`] returns a directory that must never be usable by another
 //! local user. On unix it is created 0700 under `$XDG_RUNTIME_DIR` (fallback:
-//! `temp_dir()/podup-<euid>`) and verified — real directory, owned by the
-//! current user, no group/other bits — failing closed on anything else. On
+//! `temp_dir()/podup-<euid>`) and verified (real directory, owned by the
+//! current user, no group/other bits) failing closed on anything else. On
 //! Windows the base lives under the per-user temp directory, whose default
 //! ACLs already restrict access to the owning user; only the non-symlink
 //! directory check applies. [`reject_dangerous_secret_mode`] guards a compose
@@ -23,7 +23,7 @@ use std::path::Path;
 /// name prefix. Matches docker-compose's project-name rule `^[a-z0-9][a-z0-9_-]*$`:
 /// non-empty, bounded, lowercase ASCII letters/digits/`-`/`_` only, and a first
 /// character that is a letter or digit. This rejects a leading separator
-/// (`-rf`, `--all`, `_x` — a latent flag-injection vector for forwarding paths),
+/// (`-rf`, `--all`, `_x`, a latent flag-injection vector for forwarding paths),
 /// uppercase, dots (`.`, `..`, hidden directories, `bad.` trailing-dot names),
 /// and all-separator names.
 pub fn is_safe_project_name(name: &str) -> bool {
@@ -45,7 +45,7 @@ pub fn is_safe_project_name(name: &str) -> bool {
 /// parent in the fallback case, so after creation it is verified to be a
 /// real directory (not a symlink), owned by the current user, with no
 /// group/other permission bits. Anything else aborts (fail closed) instead
-/// of writing secret material under — or later deleting — a path another
+/// of writing secret material under, or later deleting, a path another
 /// local user may control.
 #[cfg(unix)]
 pub(super) fn staging_base() -> Result<PathBuf> {
@@ -72,7 +72,7 @@ pub(super) fn staging_base() -> Result<PathBuf> {
 ///
 /// Unlike `/tmp` on unix, the Windows temp directory resolves under the
 /// user profile and its default ACLs grant access to the owning user only,
-/// so no ownership or permission-bit verification applies — just the
+/// so no ownership or permission-bit verification applies, just the
 /// non-symlink directory check.
 #[cfg(windows)]
 pub(super) fn staging_base() -> Result<PathBuf> {
@@ -82,7 +82,7 @@ pub(super) fn staging_base() -> Result<PathBuf> {
 	if !meta.is_dir() || meta.file_type().is_symlink() {
 		return Err(ComposeError::Unsupported(format!(
 			"staging directory {} is not a private directory owned by the \
-             current user — refusing to use it",
+             current user; refusing to use it",
 			base.display()
 		)));
 	}
@@ -118,7 +118,7 @@ pub(super) fn reject_dangerous_secret_mode(mode: u32, ctx: &str) -> Result<()> {
 ///
 /// `DirBuilder` does not reset permissions on a pre-existing directory, so
 /// a leftover directory we own whose bits drifted is self-healed with a
-/// chmod first — only if it is a real directory (never chmod through a
+/// chmod first, and only if it is a real directory (never chmod through a
 /// symlink; in the worst race the chmod tightens something we own to 0700).
 /// `verify_private_dir` then rejects anything not ours (fail closed).
 #[cfg(unix)]
@@ -149,7 +149,7 @@ fn verify_private_dir(dir: &Path, euid: u32) -> Result<()> {
 	if !meta.is_dir() || meta.uid() != euid || meta.mode() & 0o077 != 0 {
 		return Err(ComposeError::Unsupported(format!(
 			"staging directory {} is not a private directory owned by the \
-             current user — refusing to use it",
+             current user; refusing to use it",
 			dir.display()
 		)));
 	}

--- a/internal/engine/staging_ensure_dir_tests.rs
+++ b/internal/engine/staging_ensure_dir_tests.rs
@@ -41,7 +41,7 @@ fn symlinked_dir_is_rejected_not_healed() {
 	// SAFETY: geteuid takes no arguments, touches no memory and cannot fail.
 	let euid = unsafe { libc::geteuid() };
 	assert!(ensure_private_dir(&link, euid).is_err());
-	// Target permissions stay untouched — no chmod through the link.
+	// Target permissions stay untouched: no chmod through the link.
 	let meta = std::fs::metadata(&target).expect("metadata");
 	assert_eq!(meta.mode() & 0o777, 0o755);
 }

--- a/internal/engine/stats.rs
+++ b/internal/engine/stats.rs
@@ -1,4 +1,4 @@
-//! `stats` — live resource-usage stream for a project's service containers.
+//! `stats` is the live resource-usage stream for a project's service containers.
 
 use std::collections::{HashMap, HashSet};
 
@@ -89,7 +89,7 @@ const NAME_WIDTH: usize = 32;
 /// or an empty string when none are wanted (which falls back to the daemon
 /// default). libpod's `/containers/stats` expects the `containers` parameter
 /// **repeated** once per container (`&containers=a&containers=b`), not a single
-/// comma-joined value — a comma-joined list is parsed as one container name and
+/// comma-joined value: a comma-joined list is parsed as one container name and
 /// 404s. Names are sorted for a stable URL and each is URL-encoded.
 fn containers_query(wanted: &HashSet<String>) -> String {
 	if wanted.is_empty() {
@@ -175,7 +175,7 @@ struct NetStat {
 /// How `stats` renders a size: binary units at one decimal.
 ///
 /// Binary because this table is read next to `free` and `htop`, which are
-/// binary — not next to podman's own output, which is decimal. One decimal
+/// binary, not next to podman's own output, which is decimal. One decimal
 /// because the columns below are fixed-width by design (a live view must not
 /// resize itself mid-repaint), and a second decimal does not fit `NET I/O`.
 const SIZE_FORMAT: SizeFormat = SizeFormat::binary().with_decimals(1);
@@ -220,7 +220,7 @@ fn load_style(pct: f64) -> crate::ui::Style {
 	use crate::ui::AnsiColor;
 	// Four bands, not three, and the lowest one is dim rather than green.
 	// Everything under 70% used to be the same green, so a container at 0.02%
-	// looked exactly like one at 69% — colour that does not vary with the value
+	// looked exactly like one at 69%: colour that does not vary with the value
 	// carries no information, and the whole reason to read `stats` is to find
 	// the row in trouble. Idle rows now recede instead of competing.
 	if pct < 5.0 {
@@ -239,7 +239,7 @@ fn load_style(pct: f64) -> crate::ui::Style {
 /// Format one stats row into the table layout, optionally coloured. With
 /// `no_trunc` a long name is left intact (and may overflow its column);
 /// otherwise it is truncated to [`NAME_WIDTH`]. Pure, so the layout is testable
-/// without a terminal — the tests pass `colour = false`.
+/// without a terminal; the tests pass `colour = false`.
 ///
 /// Each cell is padded to its width *before* being painted: the ANSI codes are
 /// zero-width, so padding afterwards would count them and knock every later
@@ -414,7 +414,7 @@ impl Engine {
 
 		if opts.no_stream || running.is_empty() {
 			// Nothing running means nothing to sample (and an empty `containers=`
-			// filter would otherwise fall back to the whole host) — skip the call
+			// filter would otherwise fall back to the whole host), so skip the call
 			// and render an empty/`--all`-only frame.
 			let report = if running.is_empty() {
 				StatsReport::default()
@@ -440,7 +440,7 @@ impl Engine {
 		let mut frames = parse_json_lines::<StatsReport>(resp.into_body());
 
 		// A live region only where one belongs: stdout a terminal, colour on, the
-		// width readable — the same three conditions the lifecycle board uses,
+		// width readable, the same three conditions the lifecycle board uses,
 		// asked of stdout rather than stderr because `stats` *is* its output. A
 		// `--format json` stream is a machine path and never repaints.
 		let mut region = wants_region(opts.json, live_stats_allowed())
@@ -459,13 +459,13 @@ impl Engine {
 					// it out of band: re-check what is still running. If nothing the
 					// stream was sampling is alive, the end was expected and the
 					// command succeeded; if something is still running, the stream
-					// truncated a live sample and the command failed — which is the
+					// truncated a live sample and the command failed, which is the
 					// exit code a monitor scraping `stats` needs (#1080).
 					//
 					// The re-check is point-in-time: it samples state a moment after
 					// the break, so a genuine break that happens to coincide with
 					// every sampled container stopping is knowingly tolerated as a
-					// clean end — the transport layer cannot tell the two apart, and
+					// clean end: the transport layer cannot tell the two apart, and
 					// the sampled containers are gone either way.
 					let still_running = match self.target_containers(file, target_services).await {
 						Ok(targets) => targets
@@ -505,7 +505,7 @@ impl Engine {
 		Ok(())
 	}
 
-	/// The containers to report on — every existing replica of the targeted
+	/// The containers to report on: every existing replica of the targeted
 	/// services (all services when `target_services` is empty), paired with
 	/// whether each is currently running. Only containers that actually exist are
 	/// returned (no static-name fallback): an absent service simply contributes
@@ -595,7 +595,7 @@ fn frame_rows(
 ///
 /// Pure, and separate from the terminal probe, so the `--format json` half is
 /// testable: a piped test cannot exercise it at all, because the terminal probe
-/// is already false there — a version that let JSON repaint on a tty passed
+/// is already false there: a version that let JSON repaint on a tty passed
 /// every integration test in the suite.
 fn wants_region(json: bool, live_terminal: bool) -> bool {
 	// Never for the machine path, whatever the terminal says. A parser reading
@@ -629,7 +629,7 @@ fn print_frame(
 
 	if opts.json {
 		let json: Vec<_> = rows.iter().map(stat_json_row).collect();
-		// While streaming, one compact array per line — NDJSON, the shape
+		// While streaming, one compact array per line: NDJSON, the shape
 		// `events` already emits. A pretty-printed array per frame, concatenated,
 		// is neither a single JSON document nor NDJSON, so no parser accepts it:
 		// `stats --format json` was unreadable by anything for as long as it

--- a/internal/engine/stats_tests.rs
+++ b/internal/engine/stats_tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests for `stats` — split out to keep the module inside the source line
+//! Unit tests for `stats`, split out to keep the module inside the source line
 //! limit, following the same `tests.rs` split used by `autostart` and the libpod
 //! client.
 
@@ -33,7 +33,7 @@ fn format_bytes_scales_units() {
 }
 
 /// The edges the scaling test steps over. It goes from 512 straight to 1024, so
-/// the last value that must stay in bytes — and the empty case — were never
+/// the last value that must stay in bytes, and the empty case, were never
 /// pinned, and a threshold with no test on either side of it is where an
 /// off-by-one lives.
 #[test]
@@ -204,7 +204,7 @@ fn stat_tolerates_missing_network() {
 
 #[test]
 fn containers_query_repeats_param_per_container() {
-	// libpod wants `containers` repeated, not comma-joined — a comma-joined
+	// libpod wants `containers` repeated, not comma-joined: a comma-joined
 	// list is read as a single container name and 404s.
 	let mut wanted = HashSet::new();
 	wanted.insert("proj-web-1".to_string());
@@ -229,7 +229,7 @@ fn stats_stream_break_is_fatal_only_while_a_sampled_container_still_runs() {
 	let sampled = name_set(&["proj-web-1", "proj-db-1"]);
 
 	// A sampled container is still running: the stream truncated a live sample,
-	// so the error is a real failure (#1080) — the exit code a monitor needs.
+	// so the error is a real failure (#1080), the exit code a monitor needs.
 	assert!(stats_stream_broke_mid_sample(
 		&sampled,
 		&name_set(&["proj-web-1"])

--- a/internal/engine/stream_end_tests.rs
+++ b/internal/engine/stream_end_tests.rs
@@ -14,15 +14,15 @@
 //!
 //! 1. **podup's parsing is not the ambiguity.** A properly terminated chunked body
 //!    reaches the caller as a clean end, every time. So when a *finished* stream
-//!    arrives as an error on some Podman version, the framing came that way — no
+//!    arrives as an error on some Podman version, the framing came that way: no
 //!    predicate on `hyper::Error` can invent a difference the server did not send.
 //!    That is the case for the out-of-band re-check `logs` and `stats` already use,
 //!    and for `events` needing one of its own.
 //! 2. **A severed stream is not `IncompleteMessage`.** That predicate is about the
 //!    message head. Both places a cut can land in a body arrive as a hyper Body
 //!    error wrapping `io::ErrorKind::UnexpectedEof`, which used to fall through to
-//!    `hyper-other`. Anything keyed on the `IncompleteMessage` text — including the
-//!    lane's own flake counter — cannot see them.
+//!    `hyper-other`. Anything keyed on the `IncompleteMessage` text, including the
+//!    lane's own flake counter, cannot see them.
 
 #![cfg(unix)]
 
@@ -38,7 +38,7 @@ async fn read_stream(reply: FakeReply) -> (Vec<serde_json::Value>, Option<String
 		FakeReply::ChunkedEnd(c) => FakeReply::ChunkedEnd(c.clone()),
 		FakeReply::ChunkedTruncated(c) => FakeReply::ChunkedTruncated(c.clone()),
 		FakeReply::ChunkedCutMidPayload(c) => FakeReply::ChunkedCutMidPayload(c.clone()),
-		// Not a stream *ending* — it never becomes a stream. `get_stream` fails
+		// Not a stream *ending*; it never becomes a stream. `get_stream` fails
 		// at the response head rather than reaching the parser this measures, so
 		// this shape belongs to the lifecycle re-check tests instead.
 		FakeReply::ClosedWithoutResponse => FakeReply::ClosedWithoutResponse,
@@ -70,7 +70,7 @@ fn frame(action: &str) -> String {
 }
 
 /// A stream that ends the way HTTP says it should reaches the caller as a clean
-/// end — no error at all. Every frame written arrives first.
+/// end, with no error at all. Every frame written arrives first.
 #[tokio::test]
 async fn a_properly_terminated_stream_ends_clean() {
 	let (frames, ended_as) =
@@ -83,7 +83,7 @@ async fn a_properly_terminated_stream_ends_clean() {
 	);
 }
 
-/// A body cut off between chunks — the connection closes where the next chunk
+/// A body cut off between chunks: the connection closes where the next chunk
 /// header should begin.
 #[tokio::test]
 async fn a_cut_between_chunks_is_a_body_eof() {
@@ -102,7 +102,7 @@ async fn a_cut_between_chunks_is_a_body_eof() {
 	);
 }
 
-/// And a body cut mid-payload — the chunk header promises bytes that never come.
+/// And a body cut mid-payload: the chunk header promises bytes that never come.
 /// hyper words it differently (`IncompleteBody`) but the io kind is the same, and
 /// the kind is what podup keys on.
 #[tokio::test]
@@ -138,7 +138,7 @@ async fn neither_cut_is_an_incomplete_message() {
 /// The crux of #1104, as a test rather than a comment: the payload delivered is
 /// identical either way, so a caller that only looks at whether an error arrived
 /// cannot tell a finished stream from a severed one. Telling them apart needs a
-/// second, out-of-band observation — is the thing this stream was following still
+/// second, out-of-band observation: is the thing this stream was following still
 /// alive?
 #[tokio::test]
 async fn the_two_shapes_carry_the_same_payload() {

--- a/internal/engine/terminal_pump.rs
+++ b/internal/engine/terminal_pump.rs
@@ -1,8 +1,8 @@
 //! The bidirectional terminal loop, shared by interactive `exec` and `run`.
 //!
 //! Both hand a hijacked socket to the caller's terminal and pump bytes until the
-//! command ends. They differ only in which libpod object gets resized — an exec
-//! session or a container — so that is the one parameter, and the loop that must
+//! command ends. They differ only in which libpod object gets resized (an exec
+//! session or a container) so that is the one parameter, and the loop that must
 //! not get raw mode wrong lives once rather than twice.
 //!
 //! The loop itself is platform-independent: raw mode, the size query and the
@@ -21,8 +21,8 @@ use super::Engine;
 impl Engine {
 	/// Pump the caller's terminal against a hijacked stream until it ends.
 	///
-	/// `resize_base` is the libpod path segment identifying what to resize —
-	/// `exec/{id}` or `containers/{name}` — since the endpoint differs and
+	/// `resize_base` is the libpod path segment identifying what to resize,
+	/// `exec/{id}` or `containers/{name}`, since the endpoint differs and
 	/// nothing else does.
 	///
 	/// The terminal is restored by `RawMode`'s `Drop`, so every exit path leaves
@@ -35,7 +35,7 @@ impl Engine {
 		let _raw = RawMode::enable();
 
 		// Size the pty now, not before: there is nothing to resize until the
-		// session exists, and libpod rejects the call — silently, since a failed
+		// session exists, and libpod rejects the call, silently, since a failed
 		// resize is only cosmetic. Sizing here means a full-screen program draws
 		// correctly from its first frame rather than at libpod's 80x24 default.
 		if let Some((rows, cols)) = window_size() {

--- a/internal/engine/tests.rs
+++ b/internal/engine/tests.rs
@@ -108,7 +108,7 @@ fn replica_name_at_out_of_range_is_rejected() {
 fn replica_name_at_none_is_first_replica() {
 	let e = engine("proj");
 	// Single replica: the first index-suffixed name (always-suffix parity
-	// with docker/podman — there is no bare, unnumbered container).
+	// with docker/podman: there is no bare, unnumbered container).
 	assert_eq!(
 		e.replica_name_at("web", &Service::default(), None).unwrap(),
 		"proj-web-1"

--- a/internal/engine/to_pretty_json_tests.rs
+++ b/internal/engine/to_pretty_json_tests.rs
@@ -28,7 +28,7 @@ impl Serialize for AlwaysFails {
 /// The happy path: a `Vec<serde_json::Value>` of the same shape the five
 /// `--format json` call sites serialise round-trips through `to_pretty_json`
 /// unchanged. Parse-and-compare rather than pinning the literal pretty
-/// format — the round-trip is what matters and is portable across minor
+/// format; the round-trip is what matters and is portable across minor
 /// formatting tweaks.
 #[test]
 fn to_pretty_json_serialises_vec_of_json_values() {

--- a/internal/engine/volume/list.rs
+++ b/internal/engine/volume/list.rs
@@ -1,4 +1,4 @@
-//! `volumes` — list the named volumes declared by a compose project.
+//! `volumes` lists the named volumes declared by a compose project.
 //!
 //! Mirrors `docker compose volumes [SERVICE...]`: with no services it lists
 //! every top-level `volumes:` entry; with services it lists only the named
@@ -18,8 +18,8 @@ use super::super::Engine;
 /// How `volumes` renders a size: decimal units at three significant digits.
 ///
 /// Three rather than the four `podman system df -v` prints (`193.2MB`,
-/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here —
-/// `podman images` and `podman ps -s` both use three — and matching podup's own
+/// `67.33MB`, measured on Podman 5.7.0). podman is not self-consistent here
+/// (`podman images` and `podman ps -s` both use three) and matching podup's own
 /// other size columns is worth more than reproducing that split.
 const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 
@@ -27,7 +27,7 @@ const SIZE_FORMAT: SizeFormat = SizeFormat::decimal().with_significant(3);
 ///
 /// `#[non_exhaustive]` from birth: [`VolumesOptions`] is externally
 /// constructible with a struct literal, so adding a field to it requires a
-/// MAJOR — `cargo semver-checks` reports `constructible_struct_adds_field`.
+/// MAJOR: `cargo semver-checks` reports `constructible_struct_adds_field`.
 /// Same reasoning, and the same shape, as `PsDisplayOptions`.
 #[derive(Default, Clone, Copy, Debug)]
 #[non_exhaustive]
@@ -166,7 +166,7 @@ impl Engine {
 				.iter()
 				.map(|(_, name, driver, external)| {
 					// Raw byte counts, and absent entirely when the size was not
-					// requested — a consumer can tell "not asked" from "empty",
+					// requested, so a consumer can tell "not asked" from "empty",
 					// the same distinction the table draws.
 					let size = display.size.then(|| {
 						let u = usage.get(name.as_str());
@@ -191,10 +191,10 @@ impl Engine {
 		// The header prints even with no rows, matching `ps`, `ls`, `images` and
 		// `stats`. `volumes` was the only list command that suppressed it, so a
 		// script parsing the header line to locate its columns broke on an empty
-		// project — and an empty result is a legitimate answer, not an absence of
+		// project, and an empty result is a legitimate answer, not an absence of
 		// one.
-		// EXTERNAL is the most consequential fact about a volume — podup neither
-		// creates nor deletes an external one — and the table dropped it while the
+		// EXTERNAL is the most consequential fact about a volume (podup neither
+		// creates nor deletes an external one) and the table dropped it while the
 		// JSON path above has always carried it. A `down -v` that leaves a volume
 		// standing is only explicable if you can see which volumes are external.
 		//
@@ -205,7 +205,7 @@ impl Engine {
 		// column in the binary carried colour, so the most consequential fact in
 		// the table was the least visible one. `caution_col` rather than
 		// `status_col`: green would say "healthy", and an external volume is not
-		// healthy or unhealthy — it is the one podup will not delete.
+		// healthy or unhealthy; it is the one podup will not delete.
 		//
 		// SIZE and RECLAIMABLE are appended rather than inserted, so a reader's
 		// existing column positions do not move when the flag is off.
@@ -246,8 +246,8 @@ impl Engine {
 
 	/// Per-volume disk usage from `system/df`, keyed by on-host volume name.
 	///
-	/// One call for the whole table. libpod has no per-volume size endpoint —
-	/// this one walks the entire installation — so the cost is paid once or not
+	/// One call for the whole table. libpod has no per-volume size endpoint, and
+	/// this one walks the entire installation, so the cost is paid once or not
 	/// at all.
 	async fn volume_disk_usage(
 		&self,
@@ -290,7 +290,7 @@ fn mount_source_name(m: &VolumeMount) -> Option<String> {
 	match m {
 		VolumeMount::Short(s) => {
 			let parts: Vec<&str> = s.splitn(3, ':').collect();
-			// `src:target[:opts]` — a leading `.`/`/`/`~` is a bind path, not a name.
+			// `src:target[:opts]`: a leading `.`/`/`/`~` is a bind path, not a name.
 			if parts.len() >= 2 && !parts[0].starts_with(['.', '/', '~']) {
 				Some(parts[0].to_string())
 			} else {

--- a/internal/engine/volume/list_tests.rs
+++ b/internal/engine/volume/list_tests.rs
@@ -15,7 +15,7 @@ fn usage(size: u64, reclaimable: u64) -> VolumeDiskUsage {
 ///
 /// `podman system df -v` prints four (`193.2MB`, `67.33MB`, measured 2026-08-03)
 /// while `podman images` and `podman ps -s` print three. podman is not
-/// self-consistent, so matching podup's own columns wins — recorded here so the
+/// self-consistent, so matching podup's own columns wins, recorded here so the
 /// divergence is a decision rather than an accident somebody later "fixes".
 #[test]
 fn the_size_cells_render_at_three_significant_digits() {
@@ -28,7 +28,7 @@ fn the_size_cells_render_at_three_significant_digits() {
 ///
 /// A compose file can declare a volume that has never been created, and libpod
 /// only reports what exists. An empty cell says it is not there; `0B` would
-/// claim it exists and holds nothing — two different answers a reader would act
+/// claim it exists and holds nothing: two different answers a reader would act
 /// on differently.
 #[test]
 fn a_volume_that_does_not_exist_yet_renders_empty() {
@@ -44,7 +44,7 @@ fn an_existing_empty_volume_renders_zero() {
 
 /// SIZE and RECLAIMABLE are different numbers and both are shown. A volume a
 /// container still links reports its full size and zero reclaimable, which is
-/// the fact someone clearing disk space needs — collapsing the two would hide
+/// the fact someone clearing disk space needs; collapsing the two would hide
 /// exactly the case worth seeing.
 #[test]
 fn reclaimable_is_reported_separately_from_size() {

--- a/internal/engine/volume/mod.rs
+++ b/internal/engine/volume/mod.rs
@@ -78,7 +78,7 @@ impl Engine {
 				// Podman's libpod volume-create returns 500 (not 409) for an
 				// existing name; treat an already-exists conflict as success so a
 				// re-`up` over an existing named volume stays idempotent. The
-				// row still needs to close — without an explicit closing verb
+				// row still needs to close: without an explicit closing verb
 				// the live board leaves it spinning on `Creating` (#1347).
 				Err(ref e) if e.is_already_exists() => {
 					crate::ui::progress_line("Volume", &volume_name, "Exists");

--- a/internal/engine/volume_mounts/mod.rs
+++ b/internal/engine/volume_mounts/mod.rs
@@ -89,7 +89,7 @@ pub(crate) fn build_mounts_all(
 						if b.create_host_path.unwrap_or(false) && !src.is_empty() {
 							// Resolve exactly like the mount source (expand `~`, anchor a
 							// relative path to the project dir) so the directory is created
-							// at the path actually bind-mounted — not a literal `~` dir.
+							// at the path actually bind-mounted, not a literal `~` dir.
 							let abs = super::container::resolve_bind_source(src, base_dir);
 							if let Err(e) = std::fs::create_dir_all(&abs) {
 								tracing::warn!("create_host_path: failed to create {abs}: {e}");
@@ -136,7 +136,7 @@ pub(crate) fn build_mounts_all(
 		}
 	}
 
-	// Top-level `tmpfs:` shorthand — equivalent to volumes with type=tmpfs.
+	// Top-level `tmpfs:` shorthand, equivalent to volumes with type=tmpfs.
 	for entry in service.tmpfs.to_list() {
 		mounts.push(spec::parse_tmpfs_string(&entry));
 	}

--- a/internal/engine/volume_mounts/mod_tests.rs
+++ b/internal/engine/volume_mounts/mod_tests.rs
@@ -231,7 +231,7 @@ fn create_host_path_creates_directory() {
 fn short_form_bind_creates_missing_host_path() {
 	// A short-form bind whose relative source is missing must have its host
 	// directory created (compose-spec implies create_host_path for short
-	// syntax), anchored to the project base dir — not left to fail with a raw
+	// syntax), anchored to the project base dir, not left to fail with a raw
 	// podman statfs 500.
 	let dir = tempfile::tempdir().unwrap();
 	let rel = "missing-dir";

--- a/internal/engine/volume_mounts/spec.rs
+++ b/internal/engine/volume_mounts/spec.rs
@@ -111,7 +111,7 @@ fn split_volume_spec(s: &str) -> (&str, &str, &str) {
 ///
 /// The entry is `<path>` or `<path>:<opt>[,<opt>…]`, split on the **first**
 /// colon: everything after it is handed to the engine as mount options. That is
-/// what docker compose does, measured against it rather than inferred — for
+/// what docker compose does, measured against it rather than inferred, for
 /// `/multi:size=64m,mode=1777,noexec` it produces the Tmpfs entry
 /// `/multi -> size=64m,mode=1777,noexec,…`, and a bare `/plain` or a trailing
 /// `/trail:` yields the path with no options.

--- a/internal/engine/volume_mounts/spec_tests.rs
+++ b/internal/engine/volume_mounts/spec_tests.rs
@@ -8,7 +8,7 @@ use crate::compose::types::BindOptions;
 fn tmpfs_short_form_splits_path_from_options() {
 	// Regression: the whole entry used to become the destination, so
 	// `/multi:size=64m,…` mounted a tmpfs at a directory *named* that, with no
-	// size cap — while the real path stayed untouched. Silent, exit 0.
+	// size cap, while the real path stayed untouched. Silent, exit 0.
 	let m = parse_tmpfs_string("/multi:size=64m,mode=1777,noexec,nosuid,nodev");
 	assert_eq!(m.destination, "/multi", "path must not carry the options");
 	assert_eq!(
@@ -110,7 +110,7 @@ fn extend_bind_opts_translates_selinux() {
 
 #[test]
 fn windows_drive_source_is_a_bind_not_a_named_volume() {
-	// `C:\data:/in/container` — the drive colon must not be read as the
+	// `C:\data:/in/container`: the drive colon must not be read as the
 	// src/dst separator, and the source must classify as a bind.
 	assert_eq!(
 		split_volume_spec(r"C:\data:/in/container"),

--- a/internal/engine/wait_timeout_tests.rs
+++ b/internal/engine/wait_timeout_tests.rs
@@ -6,7 +6,7 @@
 //! It is distinct from [`ComposeError::HealthCheckTimeout`], which is what a
 //! service's own healthcheck budget exhaustion looks like. The `--wait-timeout`
 //! exists for the case where every service still *can* become healthy given
-//! enough time — without it, a generous plan budget is the only cap, and that
+//! enough time; without it, a generous plan budget is the only cap, and that
 //! is what the user is overriding with `--wait-timeout 30`.
 //!
 //! The dispatch module builds this variant, so the test below mirrors its
@@ -25,7 +25,7 @@ use crate::libpod::API_PREFIX;
 
 /// A service that never reaches `healthy` plus a finite outer deadline is
 /// the one shape that surfaces [`ComposeError::WaitTimeout`]. The message
-/// must name the seconds — that is the only knob the operator set, and the
+/// must name the seconds: that is the only knob the operator set, and the
 /// only one they need to tweak to retry.
 #[tokio::test]
 async fn an_unhealthy_service_under_a_short_wait_timeout_surfaces_waittimeout() {
@@ -33,7 +33,7 @@ async fn an_unhealthy_service_under_a_short_wait_timeout_surfaces_waittimeout() 
 		// The inspect that `wait_healthy` reads before deciding to poll.
 		if method == "GET" && target.contains("/containers/proj-web-1/json") {
 			// `starting` health under an effective healthcheck is the
-			// `HealthVerdict::Pending` branch — exactly the one the
+			// `HealthVerdict::Pending` branch, exactly the one the
 			// wrapper sits on top of.
 			return FakeReply::Body(
 				200,
@@ -74,8 +74,8 @@ async fn an_unhealthy_service_under_a_short_wait_timeout_surfaces_waittimeout() 
 	// Mirror the dispatch.rs wrapper byte-for-byte: the variant only exists
 	// because this exact `map_err(|_| ComposeError::WaitTimeout { secs })`
 	// does. The inner future is the health wait with a generous
-	// per-service budget, so the OUTER `tokio::timeout` — the one the
-	// dispatch owns — is what elapses first.
+	// per-service budget, so the OUTER `tokio::timeout` (the one the
+	// dispatch owns) is what elapses first.
 	let fut = engine.wait_services_healthy_within(&file, &[], Some(wait_timeout * 20));
 	let result =
 		tokio::time::timeout(wait_timeout, fut)
@@ -107,8 +107,8 @@ async fn an_unhealthy_service_under_a_short_wait_timeout_surfaces_waittimeout() 
 /// A wait that *does* finish before the wrapper elapses must not produce
 /// `WaitTimeout`. The wrapper must yield the inner result (here: a
 /// `HealthCheckTimeout` because the fake never reports `healthy`). Pinning
-/// the inverse — the timeout path only fires when the inner future is
-/// genuinely slow, not on every dispatch — so a regression that always
+/// the inverse: the timeout path only fires when the inner future is
+/// genuinely slow, not on every dispatch, so a regression that always
 /// wraps cannot land as `WaitTimeout`.
 #[tokio::test]
 async fn a_wait_that_finishes_in_time_does_not_produce_waittimeout() {
@@ -146,7 +146,7 @@ async fn a_wait_that_finishes_in_time_does_not_produce_waittimeout() {
 		},
 	);
 
-	// Tight inner, loose wrapper — the inner must error first. The
+	// Tight inner, loose wrapper: the inner must error first. The
 	// dispatch.rs wrapper only fires when the inner is slow.
 	let inner_budget = std::time::Duration::from_secs(5);
 	let wrapper = std::time::Duration::from_secs(30);
@@ -170,7 +170,7 @@ async fn a_wait_that_finishes_in_time_does_not_produce_waittimeout() {
 
 /// Sanity check that the inspect path the wait uses (`/containers/{name}/json`)
 /// is the one the wrapper is built around. If libpod ever renames it, this
-/// test is the one that has to be updated first — the wrapper's behaviour
+/// test is the one that has to be updated first: the wrapper's behaviour
 /// depends on the wait polling at this URL.
 #[tokio::test]
 async fn the_wait_polls_the_expected_inspect_path() {
@@ -198,13 +198,13 @@ async fn the_wait_polls_the_expected_inspect_path() {
 		},
 	);
 
-	// Healthy on the first inspect — the wait must return without
+	// Healthy on the first inspect, so the wait must return without
 	// touching the budget.
 	engine
 		.wait_services_healthy(&file, &[])
 		.await
 		.expect("a service reported healthy on inspect must not error");
-	// The API_PREFIX constant is exported for a reason — the path the
+	// The API_PREFIX constant is exported for a reason: the path the
 	// client builds lives here; touching the wrong one breaks the wait.
 	let _ = API_PREFIX;
 }

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -3,11 +3,11 @@
 //! [`Engine::watch`] sets up an `inotify`/`kqueue` watcher via `notify`, then
 //! dispatches each change event to the matching [`WatchRule`]. Debouncing
 //! collapses rapid bursts into a single action. Actions:
-//! - `sync` — tar the changed file and upload it into the container
-//! - `rebuild` — stop container, rebuild image, restart
-//! - `restart` — stop and start the container without rebuilding
-//! - `sync+restart` — sync first, then restart
-//! - `sync+exec` — sync, then run the rule's `exec` command inside the container
+//! - `sync`: tar the changed file and upload it into the container
+//! - `rebuild`: stop container, rebuild image, restart
+//! - `restart`: stop and start the container without rebuilding
+//! - `sync+restart`: sync first, then restart
+//! - `sync+exec`: sync, then run the rule's `exec` command inside the container
 
 mod placement;
 mod sync;
@@ -64,7 +64,7 @@ impl Engine {
 	/// at all. That is deliberate and matches `docker compose watch`: a
 	/// long-running developer loop should survive one failed rebuild rather than
 	/// exit. Unlike every other command here, it means a caller cannot gate on
-	/// the status — see the exit-status section of `docs/commands.md`.
+	/// the status; see the exit-status section of `docs/commands.md`.
 	pub async fn watch(&self, file: &ComposeFile) -> Result<()> {
 		let mut rule_entries: Vec<RuleEntry> = Vec::new();
 
@@ -117,7 +117,7 @@ impl Engine {
 
 		// Bounded channel: under heavy filesystem churn an unbounded queue (and the
 		// per-batch path accumulation below) can grow without limit. Drop events
-		// when the buffer is full — a later event re-triggers the sync, so no state
+		// when the buffer is full: a later event re-triggers the sync, so no state
 		// is permanently lost, but memory stays bounded.
 		let (tx, mut rx) = mpsc::channel::<notify::Result<notify::Event>>(WATCH_CHANNEL_CAP);
 		let mut watcher = RecommendedWatcher::new(
@@ -143,7 +143,7 @@ impl Engine {
 			}
 		}
 
-		info!("watching {} rule(s) — Ctrl+C to stop", rule_entries.len());
+		info!("watching {} rule(s); Ctrl+C to stop", rule_entries.len());
 
 		let debounce = Duration::from_millis(100);
 
@@ -449,7 +449,7 @@ impl Engine {
 	/// network it is attached to.
 	///
 	/// The seam that lets a test check **podup's** contribution to service-name
-	/// resolution — registering the compose service name as an alias — without
+	/// resolution (registering the compose service name as an alias) without
 	/// depending on the runtime's DNS server being up to answer for it. Those
 	/// are two layers, and a test that only measures the second blames podup for
 	/// the first's failures (#1330).

--- a/internal/engine/watch/placement.rs
+++ b/internal/engine/watch/placement.rs
@@ -79,7 +79,7 @@ pub(super) fn plan_sync_placement(root: &Path, changed: &Path, target: &str) -> 
 /// docker-compose `watch` only reacts to write/create/remove/rename changes. The
 /// vendored notify inotify backend also emits `Access` events (it sets
 /// `WatchMask::OPEN`), so merely opening/reading a watched file would otherwise
-/// fire a sync — and the sync's own read of the source re-opens the path,
+/// fire a sync, and the sync's own read of the source re-opens the path,
 /// generating fresh `Access` events that feed back into another sync. Filtering
 /// to create/modify/remove (rename is a `Modify(Name(..))`) matches compose
 /// semantics and breaks that feedback loop.

--- a/internal/engine/watch/sync_tests.rs
+++ b/internal/engine/watch/sync_tests.rs
@@ -150,9 +150,9 @@ fn sync_tar_directory() {
 
 #[test]
 fn sync_tar_path_with_no_file_name() {
-	// A path that has no file_name (e.g. root "/") — tar should be empty but valid.
+	// A path that has no file_name (e.g. root "/"): tar should be empty but valid.
 	let dir = tempdir().unwrap();
-	// Empty directory — no entries other than root
+	// Empty directory, so no entries other than root
 	let bytes = build_sync_tar(dir.path(), Path::new(".")).unwrap();
 	assert_eq!(&bytes[..2], &[0x1f, 0x8b]);
 }

--- a/internal/env_file.rs
+++ b/internal/env_file.rs
@@ -101,7 +101,7 @@ pub fn merge_env(
 /// `config` is meant to render the canonical, fully-resolved model, and docker
 /// compose materialises `env_file` there. Leaving it unresolved meant a service
 /// that takes its whole environment from a file rendered with no `environment:`
-/// at all — so the one command you reach for to ask "what will this actually run"
+/// at all, so the one command you reach for to ask "what will this actually run"
 /// pointed away from the answer rather than merely omitting it (#1184).
 ///
 /// Precedence is the same as at run time: `environment:` wins over `env_file:`,

--- a/internal/error.rs
+++ b/internal/error.rs
@@ -48,7 +48,7 @@ pub enum ComposeError {
 	InvalidSignal(String),
 	/// Image build failed (context assembly or the Podman build step).
 	Build(String),
-	/// A `cp` (copy between a container and the host) operation failed — a missing
+	/// A `cp` (copy between a container and the host) operation failed: a missing
 	/// destination directory, a non-directory path component, an unsupported
 	/// endpoint, or a host-side packing/extraction error.
 	Copy(String),
@@ -92,7 +92,7 @@ pub enum ComposeError {
 		/// The replica count that made the binding impossible; always above one.
 		replicas: usize,
 		/// The host ports the service pins, in the order compose declared them.
-		/// Only fixed ports appear — a range or an unspecified host port cannot
+		/// Only fixed ports appear; a range or an unspecified host port cannot
 		/// collide this way.
 		ports: Vec<u16>,
 	},
@@ -172,11 +172,11 @@ pub enum ComposeError {
 	/// rather than forwarded to libpod as a raw `HTTP 400`.
 	InvalidTimeout(i32),
 	/// An explicitly requested env file (`--env-file` or a service `env_file:`)
-	/// could not be read or parsed — a missing/unreadable path or a malformed
+	/// could not be read or parsed: a missing/unreadable path or a malformed
 	/// entry such as an unterminated quoted value. The string is a ready-to-print
 	/// message.
 	EnvFile(String),
-	/// A `podup autostart` operation failed — a `systemctl --user`/`loginctl`
+	/// A `podup autostart` operation failed: a `systemctl --user`/`loginctl`
 	/// command could not run or returned non-zero, a unit file could not be
 	/// written/removed, or the requested mode is not yet available. The string is
 	/// a ready-to-print message.

--- a/internal/error_tests.rs
+++ b/internal/error_tests.rs
@@ -149,7 +149,7 @@ fn display_covers_all_variants() {
 fn parse_display_does_not_echo_offending_scalar() {
 	// A type error embeds the offending scalar in the raw serde_yaml message
 	// (`invalid type: string "s3cr3t-token", ...`). The Display must not surface
-	// that content — it points at the location instead, so a non-compose file
+	// that content; it points at the location instead, so a non-compose file
 	// pointed at with `-f` cannot leak its bytes onto stderr.
 	#[derive(Debug, serde::Deserialize)]
 	struct OnlyMap {

--- a/internal/exit_status.rs
+++ b/internal/exit_status.rs
@@ -1,8 +1,8 @@
 //! Mapping a failure onto a process exit status, and printing its reason.
 //!
 //! Split out of `main` because it is a closed responsibility with conventions
-//! of its own to hold — docker's 126/127 for a command that cannot be launched,
-//! 130 for an interrupt — and because `main` had reached the source line limit.
+//! of its own to hold (docker's 126/127 for a command that cannot be launched,
+//! 130 for an interrupt) and because `main` had reached the source line limit.
 
 /// Map a failed launch onto docker's conventional exit codes by inspecting the
 /// OCI/crun error text: a "command not found" failure → 127, a

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -1,4 +1,4 @@
-//! `podup` — docker-compose → Podman translator library.
+//! `podup` is the docker-compose → Podman translator library.
 //!
 //! Provides parsing, variable substitution, topological ordering, and an
 //! async engine that drives container lifecycle via Podman's native libpod
@@ -53,7 +53,7 @@ pub use compose::{
 	validate_config,
 };
 /// The lifecycle `Engine` and its per-command option/override types, plus the
-/// project-name/listing helpers — the surface a CLI drives compose operations
+/// project-name/listing helpers: the surface a CLI drives compose operations
 /// through.
 pub use engine::{
 	is_safe_project_name, list_projects, list_projects_filtered, resolve_image_digests,
@@ -74,7 +74,7 @@ pub use libpod::Client;
 ///
 /// An embedding daemon has to tell a transport fault it should retry from a
 /// rejection it should not, and the only alternative to these predicates is
-/// matching on the message text — which breaks silently the day libpod rewords
+/// matching on the message text, which breaks silently the day libpod rewords
 /// one.
 pub use libpod::PodmanError;
 /// Log frames as libpod delivers them, and the stream parsers that produce

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -3,8 +3,8 @@
 //! The rest of the client is connection-per-request through hyper, which is the
 //! right shape for a CLI: send, read, done. An interactive exec is not that
 //! shape. `POST /exec/{id}/start` with a TTY keeps the connection open in both
-//! directions for as long as the command runs — the caller's keystrokes go up
-//! while the command's output comes down — so there is no response to read and
+//! directions for as long as the command runs (the caller's keystrokes go up
+//! while the command's output comes down) so there is no response to read and
 //! return.
 //!
 //! Rather than teach the hyper path to hijack a connection, this writes the
@@ -28,7 +28,7 @@ const MAX_HEAD_BYTES: usize = 16 * 1024;
 /// Bytes written go to the command's stdin; bytes read are its output. With a
 /// TTY the stream is raw (no 8-byte frame headers) because the pty merges
 /// stdout and stderr, which is also why an interactive exec cannot separate
-/// them — the same is true of `podman exec -it`.
+/// them; the same is true of `podman exec -it`.
 #[derive(Debug)]
 pub(crate) struct Hijacked {
 	pub(crate) stream: SocketStream,
@@ -39,7 +39,7 @@ impl Client {
 	///
 	/// Returns once the response head is read, so a rejected exec (404, 409)
 	/// surfaces as an error instead of hanging with the terminal already in raw
-	/// mode — which would leave the user's shell unusable.
+	/// mode, which would leave the user's shell unusable.
 	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
 		let mut stream = SocketStream::connect(&self.socket_path).await?;
 
@@ -114,7 +114,7 @@ async fn read_response_head<S: AsyncRead + Unpin>(stream: &mut S) -> Result<u16>
 
 	let text = String::from_utf8_lossy(&head);
 	let status_line = text.lines().next().unwrap_or_default();
-	// `HTTP/1.1 200 OK` — the code is the second token.
+	// `HTTP/1.1 200 OK`: the code is the second token.
 	status_line
 		.split_whitespace()
 		.nth(1)

--- a/internal/libpod/client/misc.rs
+++ b/internal/libpod/client/misc.rs
@@ -4,7 +4,7 @@ use hyper::StatusCode;
 use super::{full, meets_minimum, Client, PathStat, Result, READ_TIMEOUT};
 
 impl Client {
-	/// `GET /libpod/_ping` — returns Ok(()) when Podman is reachable and
+	/// `GET /libpod/_ping` returns Ok(()) when Podman is reachable and
 	/// speaks a supported libpod API version.
 	pub async fn ping(&self) -> Result<()> {
 		let req = Self::build_request(

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -51,13 +51,13 @@ const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 
 /// Ceiling on establishing the socket connection and HTTP handshake. Bounds the
 /// wait when the Podman socket is absent, busy, or unresponsive. This times the
-/// connect only — it does not limit the duration of a streaming response body.
+/// connect only; it does not limit the duration of a streaming response body.
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Ceiling on reading a *buffered* (non-streaming) response body. Without it a
 /// daemon that accepts the request, sends headers, then stalls would hang the
 /// CLI forever. Streaming helpers (logs, attach, archive) are deliberately not
-/// bounded by this — they are long-lived by design.
+/// bounded by this; they are long-lived by design.
 const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 /// Whether a response carried `Connection: close`. When set, the socket is
@@ -85,7 +85,7 @@ pub type Result<T> = std::result::Result<T, PodmanError>;
 /// `post_empty_stream`, `post_bytes_stream`, `post_stream_body`,
 /// `post_json_stream_within`) take a dedicated connection for the lifetime of
 /// the stream's response body. Streaming connections do not share with the
-/// buffered pool — they are released when the [`Client`] is dropped, which in
+/// buffered pool; they are released when the [`Client`] is dropped, which in
 /// the CLI is the end of the command.
 pub struct Client {
 	socket_path: String,
@@ -93,12 +93,12 @@ pub struct Client {
 	streaming: Mutex<Vec<pool::StreamingConn>>,
 }
 
-/// The decoded `X-Docker-Container-Path-Stat` header — a container path's name,
+/// The decoded `X-Docker-Container-Path-Stat` header: a container path's name,
 /// size, Go file `mode` and `mtime`.
 ///
 /// `mtime` is an RFC3339 string compared only for equality, never parsed into a
-/// time. **Podman 6 reports it to whole seconds** — `2026-08-03T18:36:05Z`, no
-/// fractional part, measured on `podman-6.0.1-1.fc45` — which is why `size` is
+/// time. **Podman 6 reports it to whole seconds**: `2026-08-03T18:36:05Z`, no
+/// fractional part, measured on `podman-6.0.1-1.fc45`, which is why `size` is
 /// carried here too: two writes inside one second are indistinguishable by mtime
 /// alone. The runtime's JSON uses lowercase keys.
 #[derive(serde::Deserialize, Default, Clone, PartialEq, Eq, Debug)]
@@ -114,7 +114,7 @@ pub(crate) struct PathStat {
 /// Attach the socket path and a way forward to a connection failure.
 ///
 /// The operator saw `podman socket connection error: No such file or directory
-/// (os error 2)` — no path, no distinction between "it is not there" and "I
+/// (os error 2)`: no path, no distinction between "it is not there" and "I
 /// cannot open it", and nothing to do about it. Everything needed was already
 /// in hand one call earlier (#1146).
 ///
@@ -129,14 +129,14 @@ pub(crate) struct PathStat {
 pub(crate) fn socket_error(path: &str, e: std::io::Error) -> super::PodmanError {
 	let hint = match e.kind() {
 		std::io::ErrorKind::NotFound => {
-			" — the Podman API socket is not listening. podman itself is daemonless \
+			": the Podman API socket is not listening. podman itself is daemonless \
 			 and needs no socket, but podup speaks the libpod API and does. Enable it \
 			 with `systemctl --user enable --now podman.socket`, or for an account \
 			 with no login shell: `sudo -u <user> env XDG_RUNTIME_DIR=/run/user/$(id \
 			 -u <user>) systemctl --user enable --now podman.socket`"
 		}
 		std::io::ErrorKind::PermissionDenied => {
-			" — the socket exists but cannot be opened. Check that it is owned by \
+			": the socket exists but cannot be opened. Check that it is owned by \
 			 the user running podup; a socket created by another account is not \
 			 shared"
 		}
@@ -193,7 +193,7 @@ impl Client {
 	///
 	/// `response_timeout` bounds how long we wait for the server to return the
 	/// response head. Pass `Some` (the default [`READ_TIMEOUT`]) for ordinary and
-	/// streaming calls, where the head arrives promptly — this stops a socket that
+	/// streaming calls, where the head arrives promptly; this stops a socket that
 	/// accepts the connection but never replies from hanging the CLI indefinitely.
 	/// Pass `None` only for endpoints that legitimately block server-side before
 	/// the head (e.g. `wait?condition=stopped`), whose callers impose an outer
@@ -357,8 +357,8 @@ impl Client {
 	///
 	/// The pre-validators in [`super::validate`] catch the field-level
 	/// rejections libpod makes on its own (namespace modes, `device_cgroup_rule`
-	/// access, build-arg/label keys). For other fields — `cap_add`, `runtime`,
-	/// `devices`, `extra_hosts` — podup does not have a pre-validator (the
+	/// access, build-arg/label keys). For other fields (`cap_add`, `runtime`,
+	/// `devices`, `extra_hosts`) podup does not have a pre-validator (the
 	/// failure surfaces from the OCI runtime or the cgroup manager, not from
 	/// libpod's specgen), and podup does not know which compose-side key libpod
 	/// rejected. When the caller does know, passing `field` turns an opaque

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -68,7 +68,7 @@ struct PoolInner {
 	closed: bool,
 }
 
-/// Per-socket HTTP/1.1 connection pool. Cheap to clone — the state is behind
+/// Per-socket HTTP/1.1 connection pool. Cheap to clone; the state is behind
 /// `Arc`s internally.
 pub(crate) struct ConnPool {
 	socket_path: String,
@@ -111,12 +111,12 @@ impl ConnPool {
 	/// - `cap > 0` and an idle connection is available: hand it out.
 	/// - `cap > 0` and no idle connection: open a fresh one and track it
 	///   in the pool. If the pool is at its cap, open a transient
-	///   connection (not tracked) instead — the cap is a hint for idle
+	///   connection (not tracked) instead: the cap is a hint for idle
 	///   reuse, not a cap on concurrency.
 	pub(super) async fn acquire(self: &Arc<Self>) -> Result<PoolGuard> {
 		// No-pool short-circuit. The pool is opt-in (a cap of 0 means
 		// disabled). Every acquire opens a fresh connection that is dropped
-		// on release — the previous, proven behaviour.
+		// on release, the previous, proven behaviour.
 		if self.cap == 0 {
 			let (sender, driver) = open_one(&self.socket_path).await?;
 			return Ok(PoolGuard {
@@ -151,7 +151,7 @@ impl ConnPool {
 				// Discard any idle-but-poisoned connections first; they will
 				// be replaced by the next acquire that opens fresh. Doing this
 				// here, before the at-cap check, keeps the live_count honest
-				// — a poisoned idle slot no longer counts against `cap`.
+				// A poisoned idle slot no longer counts against `cap`.
 				while matches!(inner.idle.front(), Some(c) if c.poisoned) {
 					inner.idle.pop_front();
 					inner.live_count -= 1;
@@ -200,7 +200,7 @@ impl ConnPool {
 			// At cap. The cap is a hint for reuse, not a cap on concurrency:
 			// open a transient connection that is NOT tracked in the pool
 			// (no `live_count` increment, no slot to release into). A parallel
-			// caller that exceeds the cap is not throttled — it just does not
+			// caller that exceeds the cap is not throttled; it just does not
 			// reuse a socket. This is the same shape as Go's `http.Transport`,
 			// where `MaxIdleConnsPerHost` caps the idle pool while active
 			// requests can exceed it.
@@ -231,7 +231,7 @@ impl ConnPool {
 	}
 
 	/// Open a dedicated connection for a streaming call. The connection is
-	/// tracked on the pool only so the buffered half sees the pressure —
+	/// tracked on the pool only so the buffered half sees the pressure;
 	/// streaming callers receive their own [`StreamingConn`] regardless.
 	pub(super) async fn open_streaming(self: &Arc<Self>) -> Result<StreamingConn> {
 		{
@@ -281,7 +281,7 @@ impl ConnPool {
 ///
 /// `transient` is `true` when the pool was at its cap and the acquire fell
 /// through to a fresh connection that is NOT tracked in the pool's idle
-/// queue. A transient guard is dropped directly — there is no release to
+/// queue. A transient guard is dropped directly: there is no release to
 /// the pool, no count decrement, no wake-up. The cap is a hint for reuse,
 /// not a cap on concurrency: a parallel caller that exceeds it is not
 /// throttled, it just does not get to reuse an idle socket.
@@ -344,7 +344,7 @@ impl StreamingConn {
 impl Drop for StreamingConn {
 	fn drop(&mut self) {
 		// Aborting the driver task closes the socket via the IO half hyper
-		// holds — the sender is left alone because dropping it does not, on
+		// holds; the sender is left alone because dropping it does not, on
 		// its own, surface an EOF to the background task in a timely way.
 		if let Some(inner) = self.inner.take() {
 			inner.driver.abort();

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -102,7 +102,7 @@ impl Drop for CountingServer {
 }
 
 /// With the pool enabled (cap > 0), sequential requests ride a single
-/// connection — the pool's whole reason to exist. 100 calls → 1 accepted
+/// connection, the pool's whole reason to exist. 100 calls → 1 accepted
 /// connection. The default cap is 0 (no pool), so this test constructs
 /// the client with a non-zero cap to exercise the reuse path.
 #[tokio::test]
@@ -152,7 +152,7 @@ async fn concurrent_requests_share_connections_within_the_cap() {
 /// A parallel caller that exceeds the cap is not throttled. The pool opens
 /// transient connections beyond the cap and drops them on release; the
 /// idle queue stays at the cap. The server sees more than `pool_size`
-/// connections under load — that is the documented contract: the cap is
+/// connections under load; that is the documented contract: the cap is
 /// a hint for idle reuse, not a cap on concurrency.
 #[tokio::test]
 async fn concurrent_requests_above_cap_open_transient_connections() {
@@ -197,7 +197,7 @@ async fn a_dropped_client_closes_its_pool() {
 		// driver task.
 	}
 	// A subsequent acquire against the same socket would need a new Client;
-	// we don't reach into a closed pool — the test simply verifies the
+	// we don't reach into a closed pool; the test simply verifies the
 	// Drop-driven close did not panic and the temp dir is still usable.
 	let _ = std::fs::metadata(&sock_str).unwrap();
 }

--- a/internal/libpod/client/stream.rs
+++ b/internal/libpod/client/stream.rs
@@ -2,7 +2,7 @@
 //!
 //! Linux and macOS reach Podman over a Unix socket; Windows reaches
 //! `podman machine` over a named pipe. Both are byte streams, and everything
-//! above this file — the hyper client, the hand-written hijack — only needs
+//! above this file (the hyper client, the hand-written hijack) only needs
 //! `AsyncRead + AsyncWrite`. This enum is the one place that knows which kind
 //! of stream a platform uses, so the request path and the hijack path connect
 //! through the same code instead of each carrying its own `cfg` blocks.
@@ -68,7 +68,7 @@ impl SocketStream {
 }
 
 // Plain delegation: each poll forwards to the one variant this build has. No
-// buffering, no translation — the enum exists only to give the two transports
+// buffering, no translation: the enum exists only to give the two transports
 // one type.
 
 impl AsyncRead for SocketStream {

--- a/internal/libpod/client/tests.rs
+++ b/internal/libpod/client/tests.rs
@@ -99,7 +99,7 @@ fn parse_error_message_uses_raw_body_when_json_has_no_message() {
 #[test]
 fn check_status_with_field_promotes_to_field_error() {
 	// A 4xx with a field context renders as `field: <libpod message>
-	// (value: <value>)` — the field-shaped form the operator wants,
+	// (value: <value>)`, the field-shaped form the operator wants,
 	// not the raw HTTP framing. The libpod message is preserved inside
 	// the Field so the cause is not lost (#1357).
 	let body = br#"{"message":"namespace \"evil\" not recognised"}"#;
@@ -236,7 +236,7 @@ fn client_new_stores_socket_path() {
 // ---------------------------------------------------------------------------
 
 /// A bounded wait aborts a future that outlives the limit and names the phase
-/// in the message — the guard that stops a stalled or silent socket (whether
+/// in the message, the guard that stops a stalled or silent socket (whether
 /// waiting on the response head or reading a buffered body) from hanging the
 /// CLI. A never-resolving future stands in for the silent-socket attack.
 #[tokio::test]
@@ -292,7 +292,7 @@ fn meets_minimum_handles_malformed_and_empty() {
 /// This is the crux of the leading hypothesis for `cp` into a container failing
 /// on Podman 6. hyper sets `Content-Length` when a body reports an exact size
 /// and falls back to `Transfer-Encoding: chunked` when it does not. If boxing
-/// erased the hint, every `PUT /containers/{id}/archive` would go out chunked —
+/// erased the hint, every `PUT /containers/{id}/archive` would go out chunked,
 /// and a server that expects a length would close the connection mid-body,
 /// which is exactly the `IncompleteMessage` the lane reports.
 ///
@@ -312,7 +312,7 @@ fn a_buffered_put_body_reports_an_exact_size() {
 }
 
 /// The operator's report (#1146): `podman socket connection error: No such
-/// file or directory (os error 2)` — no path, no way to tell "it is not there"
+/// file or directory (os error 2)`: no path, no way to tell "it is not there"
 /// from "I cannot open it", nothing to act on. Everything needed was already in
 /// hand one call earlier.
 #[cfg(unix)]

--- a/internal/libpod/error.rs
+++ b/internal/libpod/error.rs
@@ -28,7 +28,7 @@ pub enum PodmanError {
 	/// specific field of the request it sent.
 	///
 	/// libpod validates a handful of fields at the `SpecGenerator` (container
-	/// create) and build-query layer — namespaces via `ParseNamespace`,
+	/// create) and build-query layer: namespaces via `ParseNamespace`,
 	/// `device_cgroup_rule` access strings via `parseLinuxResourcesDeviceAccess`,
 	/// build-arg/label keys, and a few others. When podup pre-validates these,
 	/// or when it identifies the offending field by inspecting the request it
@@ -116,9 +116,9 @@ fn conflict_hint(message: &str) -> Option<&'static str> {
 		// force"); the state is only in the leading "as it is paused/running"
 		// clause. Match that so a paused container is not mislabelled as running.
 		if m.contains("is paused") {
-			Some("the container is paused — unpause it first, or pass `-f` to force removal")
+			Some("the container is paused; unpause it first, or pass `-f` to force removal")
 		} else {
-			Some("the container is running — stop it first, or pass `-f` to force removal")
+			Some("the container is running; stop it first, or pass `-f` to force removal")
 		}
 	} else if m.contains("already paused") {
 		Some("the container is already paused")
@@ -204,7 +204,7 @@ impl PodmanError {
 	/// indistinguishable from either (#1104, pinned by `stream_end_tests`).
 	///
 	/// Every streaming command therefore answers it out of band instead, by
-	/// asking something the transport cannot see — whether the container it was
+	/// asking something the transport cannot see: whether the container it was
 	/// following is still running, or whether the caller asked for a bounded
 	/// stream at all.
 	///
@@ -219,7 +219,7 @@ impl PodmanError {
 			Self::Hyper(e) if e.is_timeout() => "hyper-timeout",
 			// A body that stopped short is none of the above. `is_incomplete_message`
 			// is about the message head, so a severed *body* misses every predicate
-			// hyper exposes and used to land in `hyper-other` — the least
+			// hyper exposes and used to land in `hyper-other`, the least
 			// informative label, for the likeliest shape.
 			//
 			// Measured against a fake socket that cuts a chunked body deliberately
@@ -287,7 +287,7 @@ impl PodmanError {
 	/// True if this API error reports the target image is still referenced by a
 	/// container. A non-force `down --rmi` must skip such an image (matching
 	/// docker compose) instead of force-removing it and cascading the deletion of
-	/// every dependent container — including ones owned by other projects. Podman
+	/// every dependent container, including ones owned by other projects. Podman
 	/// returns this as a 409 conflict, or on some versions a 500 whose message
 	/// names the in-use cause.
 	pub fn is_image_in_use(&self) -> bool {
@@ -322,7 +322,7 @@ impl PodmanError {
 	}
 }
 
-/// Whether a hyper error is a body that ended before it was complete — the shape
+/// Whether a hyper error is a body that ended before it was complete: the shape
 /// a severed stream takes, which none of hyper's own predicates report. Walks the
 /// source chain for an `io::Error` of kind `UnexpectedEof` rather than matching on
 /// message text.

--- a/internal/libpod/error/tests.rs
+++ b/internal/libpod/error/tests.rs
@@ -397,7 +397,7 @@ fn field_error_for_build_query_skips_service_prefix() {
 #[test]
 fn field_error_has_no_source() {
 	// Like the other owned variants, `Field` has no underlying error to
-	// chain — the explanation is in the variant's own fields.
+	// chain; the explanation is in the variant's own fields.
 	use std::error::Error;
 	let e = PodmanError::Field {
 		service: "web".into(),

--- a/internal/libpod/types/container/response.rs
+++ b/internal/libpod/types/container/response.rs
@@ -80,7 +80,7 @@ pub struct ContainerListEntry {
 	/// When the container was created, as an RFC 3339 string.
 	///
 	/// Not the docker-compatible `CreatedAt`, which libpod also sends and leaves
-	/// **empty** — measured on Podman 5.7.0. Reading the familiar name gets a
+	/// **empty**, measured on Podman 5.7.0. Reading the familiar name gets a
 	/// blank column, the same trap as `Status` versus `State` above.
 	#[serde(rename = "Created", default)]
 	pub created: String,
@@ -101,7 +101,7 @@ pub struct ContainerSize {
 	#[serde(rename = "rwSize", default)]
 	pub rw: u64,
 	/// The image's own size. This is what `podman ps -s` prints as `virtual`,
-	/// and it is **not** the sum of the two — verified against three containers
+	/// and it is **not** the sum of the two, verified against three containers
 	/// whose two readings differ at three significant digits.
 	#[serde(rename = "rootFsSize", default)]
 	pub root_fs: u64,

--- a/internal/libpod/types/container/response_tests.rs
+++ b/internal/libpod/types/container/response_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::libpod::types::container::spec::Namespace;
 
 // ---------------------------------------------------------------------------
-// Namespace (spec type — tested here to avoid pushing spec.rs over 500 lines)
+// Namespace (spec type, tested here to avoid pushing spec.rs over 500 lines)
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/internal/libpod/types/container/spec/mod.rs
+++ b/internal/libpod/types/container/spec/mod.rs
@@ -8,7 +8,7 @@ mod parts;
 pub use parts::*;
 
 // ---------------------------------------------------------------------------
-// SpecGenerator — container create request
+// SpecGenerator: container create request
 // ---------------------------------------------------------------------------
 
 /// Full container specification sent to `POST /libpod/containers/create`.

--- a/internal/libpod/types/container/spec/mod_tests.rs
+++ b/internal/libpod/types/container/spec/mod_tests.rs
@@ -15,7 +15,7 @@ fn security_fields_serialize_decomposed_not_as_security_opt() {
 		..Default::default()
 	};
 	let v = serde_json::to_value(&spec).unwrap();
-	// SpecGenerator has no `security_opt` field — the value must arrive decomposed.
+	// SpecGenerator has no `security_opt` field, so the value must arrive decomposed.
 	assert!(
 		v.get("security_opt").is_none(),
 		"stale security_opt key: {v}"
@@ -105,7 +105,7 @@ fn health_on_failure_and_startup_use_podman_wire_names() {
 	let v = serde_json::to_value(&spec).unwrap();
 
 	// `--health-on-failure` rides as Podman's integer action code (restart = 3),
-	// under the snake_case key — not as a string and not as `none`(0).
+	// under the snake_case key, not as a string and not as `none`(0).
 	assert_eq!(v["health_check_on_failure_action"], 3);
 
 	// The startup probe nests under the PascalCase `startupHealthConfig` key,
@@ -115,7 +115,7 @@ fn health_on_failure_and_startup_use_podman_wire_names() {
 	assert_eq!(startup["Test"][1], "true");
 	assert_eq!(startup["Interval"], 1_000_000_000_i64);
 	assert_eq!(startup["Successes"], 3);
-	// Flattened — there is no nested `health_config` wrapper key.
+	// Flattened: there is no nested `health_config` wrapper key.
 	assert!(startup.get("health_config").is_none(), "not flattened: {v}");
 }
 

--- a/internal/libpod/types/container/spec/parts.rs
+++ b/internal/libpod/types/container/spec/parts.rs
@@ -405,7 +405,7 @@ impl Serialize for HealthCheckOnFailureAction {
 /// Podman's `define.StartupHealthCheck` embeds `Schema2HealthConfig` and adds a
 /// `Successes` count; the embedded probe fields are flattened to the top level of
 /// the `startupHealthConfig` object with their PascalCase keys (`Test`,
-/// `Interval`, …), which is exactly [`HealthConfig`]'s wire shape — so it is
+/// `Interval`, …), which is exactly [`HealthConfig`]'s wire shape, so it is
 /// reused here via `#[serde(flatten)]`.
 #[derive(Serialize, Default)]
 pub struct StartupHealthCheck {

--- a/internal/libpod/types/image.rs
+++ b/internal/libpod/types/image.rs
@@ -52,7 +52,7 @@ pub struct ImageInspect {
 	/// On-disk size of the image in bytes, as libpod reports it.
 	///
 	/// Present in the default inspect response, so reading it costs no extra
-	/// call and no query parameter — unlike a container's size, which libpod
+	/// call and no query parameter, unlike a container's size, which libpod
 	/// leaves `null` until asked. Defaults to zero when the field is absent, so
 	/// an older server renders an empty cell rather than failing the whole
 	/// listing.

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -18,7 +18,7 @@ pub enum LogOutput {
 	/// Payload demuxed from the stdout stream (frame stream type 1).
 	StdOut {
 		/// The payload bytes, with the frame header already stripped. Not
-		/// guaranteed to end on a line boundary — one frame may split a line.
+		/// guaranteed to end on a line boundary; one frame may split a line.
 		message: Bytes,
 	},
 	/// Payload demuxed from the stderr stream (frame stream type 2).

--- a/internal/libpod/types/volume.rs
+++ b/internal/libpod/types/volume.rs
@@ -37,7 +37,7 @@ mod tests;
 ///
 /// **This is the only endpoint that knows a volume's size.** The volume list
 /// carries no size field at all, so answering "how big is this volume" means
-/// asking libpod to account for every image, container and volume it owns —
+/// asking libpod to account for every image, container and volume it owns,
 /// measured at 1.2 s against 10 ms for the plain list on a host with 46
 /// volumes. That cost is why the column is opt-in rather than default.
 #[derive(serde::Deserialize, Default)]
@@ -56,7 +56,7 @@ pub struct VolumeDiskUsage {
 	/// Bytes the volume occupies.
 	#[serde(rename = "Size", default)]
 	pub size: u64,
-	/// Bytes that would be freed by removing it — zero while a container still
+	/// Bytes that would be freed by removing it: zero while a container still
 	/// links the volume, which is what makes it worth showing next to the size
 	/// rather than instead of it.
 	#[serde(rename = "ReclaimableSize", default)]

--- a/internal/libpod/validate.rs
+++ b/internal/libpod/validate.rs
@@ -2,7 +2,7 @@
 //!
 //! libpod validates a handful of fields when a `SpecGenerator` arrives over
 //! the create endpoint and when a build query string arrives at the build
-//! endpoint. The validators are scattered across the libpod source — namespaces
+//! endpoint. The validators are scattered across the libpod source: namespaces
 //! via `ParseNamespace`, `device_cgroup_rule` access strings via
 //! `parseLinuxResourcesDeviceAccess`, and a handful of others (build-arg keys,
 //! label keys) rejected by the buildkit-fronted parser. When libpod rejects
@@ -39,8 +39,8 @@ const CGROUP_FIELD: &str = "cgroup";
 /// `ipc` alone, and `keep-id`/`auto`/`nomap` for `userns_mode` alone. The
 /// per-slot extras live in [`IPC_EXTRA_MODES`] and [`USERNS_EXTRA_MODES`].
 ///
-/// The measurement distinguishes a mode podman refuses to *parse* — it says
-/// "unrecognized namespace mode" — from one that parses and then fails to
+/// The measurement distinguishes a mode podman refuses to *parse* (it says
+/// "unrecognized namespace mode") from one that parses and then fails to
 /// apply. On a rootless host `--userns=auto` reports "not enough unused IDs in
 /// user namespace" and `--userns=private` wants a UID mapping; both are valid
 /// modes that this host cannot satisfy, and neither belongs in a syntax
@@ -49,7 +49,7 @@ const CGROUP_FIELD: &str = "cgroup";
 /// `container:<id>` joins another container's namespace (compose's
 /// `container:NAME` and `service:NAME` forms; podup rewrites service→container
 /// before this list sees it). The `ns:<path>` form joins a namespace by an
-/// absolute filesystem path — directly user-facing on the compose side, so it
+/// absolute filesystem path, directly user-facing on the compose side, so it
 /// has to be allowed.
 ///
 /// `network_mode` is intentionally **not** validated here: the engine
@@ -63,7 +63,7 @@ const CGROUP_FIELD: &str = "cgroup";
 const NS_MODES: &[&str] = &["host", "private", "pod"];
 
 /// `ipc` takes two modes the other slots reject. `shareable` is the one
-/// compose files actually reach for — it is what lets a second container join
+/// compose files actually reach for: it is what lets a second container join
 /// this one's IPC namespace later, and podup used to refuse it outright.
 const IPC_EXTRA_MODES: &[&str] = &["none", "shareable"];
 
@@ -74,7 +74,7 @@ const IPC_EXTRA_MODES: &[&str] = &["none", "shareable"];
 const USERNS_EXTRA_MODES: &[&str] = &["keep-id", "auto", "nomap"];
 
 /// `container:` is not a value in the allow-list; it must carry an id.
-/// `ns:` is not a value either — it must carry a path. The presence of the
+/// `ns:` is not a value either; it must carry a path. The presence of the
 /// prefix is the test; the suffix is whatever the user typed.
 const NS_PREFIX_MODES: &[&str] = &["container:", "ns:"];
 
@@ -235,7 +235,7 @@ where
 /// Truncate a value for inclusion in a `Field` error so a huge or binary value
 /// does not flood the rendered message. Multi-line values are collapsed onto
 /// one line so the message stays single-line. The threshold is generous
-/// (256 chars) — long enough for any realistic compose value, short enough
+/// (256 chars), long enough for any realistic compose value, short enough
 /// to keep the error readable.
 pub(crate) fn render_value(value: &str) -> String {
 	let mut s = String::with_capacity(value.len().min(256));

--- a/internal/main.rs
+++ b/internal/main.rs
@@ -1,4 +1,4 @@
-//! `podup` — docker-compose to Podman translator CLI.
+//! `podup` is the docker-compose to Podman translator CLI.
 
 // The binary carries no `unsafe`; deny it so any future addition is caught.
 #![deny(unsafe_code)]
@@ -73,7 +73,7 @@ fn run_to_exit() {
 	// Shut the runtime down without waiting for its blocking pool. An
 	// interactive exec/run always leaves one stdin read in flight there
 	// (tokio's stdin reads on a blocking thread), and a plain drop waits for
-	// it — so a session that ended with code 0 hung until the next keypress,
+	// it, so a session that ended with code 0 hung until the next keypress,
 	// while any other code left through `process::exit` below and never
 	// noticed (#1161). Everything user-visible is written and flushed by the
 	// time `block_on` returns.
@@ -150,7 +150,7 @@ fn down_by_label_path(command: &Commands, project: Option<&str>, compose_present
 }
 
 /// Orchestrate one CLI invocation: parse args, then short-circuit the commands
-/// that need neither a compose file nor (for some) Podman — `completions`,
+/// that need neither a compose file nor (for some) Podman: `completions`,
 /// `update`, `ls`, `ps`, and `config`. Otherwise resolve and parse the compose
 /// file(s), settle the project name and base directory (validating the name at
 /// the trust boundary), acquire the per-project lock, and dispatch the
@@ -229,7 +229,7 @@ async fn run() -> podup::Result<()> {
 		// The compose-only global value-flags (--socket/--profile/--env-file/
 		// --project-directory) never reach the binary-only self-update, so accepting
 		// them silently is a misleading no-op. Reject any that were passed on the
-		// command line (env-sourced values are left alone — they are not a misuse).
+		// command line (env-sourced values are left alone; they are not a misuse).
 		if let Some(flag) = misused_update_global() {
 			use clap::CommandFactory;
 			Cli::command()
@@ -361,7 +361,7 @@ async fn run() -> podup::Result<()> {
 	let compose_files = resolve_compose_files(&cli.file);
 
 	// `down -p NAME` must tear a running project down purely from its
-	// `podup.project` label when no compose file is present — matching `docker
+	// `podup.project` label when no compose file is present, matching `docker
 	// compose -p NAME down`. The startup flow otherwise parses the compose file
 	// before dispatch, so a label-only teardown by project name fails on the
 	// missing file. Handle it here, before that parse, but only when an explicit
@@ -420,7 +420,7 @@ async fn run() -> podup::Result<()> {
 		}
 	);
 	// `events` and `ps` are scoped purely by the `podup.project` label and never
-	// read service definitions, so — like `docker compose -p NAME events`/`ps` —
+	// read service definitions, so, like `docker compose -p NAME events`/`ps`,
 	// they must work against a running project even when no compose file is
 	// present. Tolerate a missing file for these label-only commands by falling
 	// back to an empty compose model; any other parse error (a malformed file
@@ -565,7 +565,7 @@ async fn run() -> podup::Result<()> {
 
 	// `autostart` manages a rootless `systemctl --user` unit that brings the stack
 	// up at boot. Like `generate` it works from the compose file alone and never
-	// contacts Podman — except `uninstall --purge`, which tears the stack's volumes
+	// contacts Podman, except `uninstall --purge`, which tears the stack's volumes
 	// down and so connects only in that branch.
 	if let Commands::Autostart { kind } = &cli.command {
 		let env = autostart_cmd::AutostartEnv {

--- a/internal/main_tests.rs
+++ b/internal/main_tests.rs
@@ -1,5 +1,5 @@
 /// 130 is 128 + SIGINT, and it is what `docker compose up` returns for
-/// SIGTERM too — measured against v5.1.3 rather than derived from the signal
+/// SIGTERM too, measured against v5.1.3 rather than derived from the signal
 /// number, which would have said 143. podup returned 0 for both, so a
 /// cancelled CI job reported success.
 #[test]

--- a/internal/podman/mod.rs
+++ b/internal/podman/mod.rs
@@ -19,7 +19,7 @@ const DEFAULT_PIPE: &str = "//./pipe/podman-machine-default";
 ///
 /// Priority:
 /// 1. `socket_path` if provided.
-/// 2. The first existing platform default — on Linux the rootful or
+/// 2. The first existing platform default: on Linux the rootful or
 ///    per-user runtime socket, on macOS the host-side socket exposed by
 ///    `podman machine`, on Windows the `podman machine` named pipe.
 /// 3. The conventional path for this platform, so a failed connection

--- a/internal/ports_tests.rs
+++ b/internal/ports_tests.rs
@@ -59,7 +59,7 @@ fn ipv6_bracketed() {
 #[test]
 fn ipv6_bracketed_container_only_has_no_host_port() {
 	// `[ip]:container` (no published host port) binds the IPv6 address and
-	// lets Podman assign the host port — the no-host-port arm of parse_with_ip.
+	// lets Podman assign the host port, the no-host-port arm of parse_with_ip.
 	let ports = parse_one_short("[::1]:80");
 	assert_eq!(ports.len(), 1);
 	assert_eq!(ports[0].container_port, 80);

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -7,7 +7,7 @@
 //! instead of a long-running `podup` process.
 //!
 //! This is an additive export path, not a replacement for the runner. It
-//! maps the common compose fields and warns — loudly, never silently — for
+//! maps the common compose fields and warns, loudly and never silently, for
 //! every field that is set but has no Quadlet equivalent yet, so generated
 //! units never quietly drop configuration.
 

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -114,7 +114,7 @@ pub(super) fn render_volume(vol: &VolumeMount, project: &str, declared_volumes: 
 /// If `vol` is a long-form `type: tmpfs` mount, render it as a Quadlet `Tmpfs=`
 /// value (`target[:size=…,mode=…]`); otherwise return `None` so the caller emits
 /// a normal `Volume=`. A tmpfs mount written as `Volume=` would create a
-/// persistent named/anonymous volume instead of an in-memory filesystem — a
+/// persistent named/anonymous volume instead of an in-memory filesystem, a
 /// silent semantic inversion. Size/mode mirror the runtime mount options.
 pub(super) fn render_tmpfs_mount(vol: &VolumeMount) -> Option<String> {
 	let VolumeMount::Long {
@@ -254,8 +254,8 @@ fn key_is_arg_line(key: &str) -> bool {
 ///
 /// * systemd specifiers (`%h`, `%U`, …) are passed through literally by doubling
 ///   `%` to `%%`, instead of being expanded at unit-activation time;
-/// * a value ending in a backslash — which would otherwise fold the next
-///   physical line (and the directive on it) into this value — is quoted and the
+/// * a value ending in a backslash, which would otherwise fold the next
+///   physical line (and the directive on it) into this value, is quoted and the
 ///   backslash escaped, closing the line-continuation hole;
 /// * for word-split keys (`Environment`, `Label`, …) a value containing
 ///   whitespace is double-quoted so systemd keeps it as one value rather than
@@ -282,8 +282,8 @@ pub(super) fn escape_unit_value(key: &str, value: &str) -> String {
 /// Build the project-prefixed unit-file stem for a resource, e.g. service `web`
 /// in project `proj` → `proj-web`. Generated unit files share a single systemd
 /// directory across projects, so the stem (and every in-unit cross-reference to
-/// it) carries the project name — matching the project-scoped resource names
-/// inside the units — so two projects' `web` services do not clobber each other.
+/// it) carries the project name, matching the project-scoped resource names
+/// inside the units, so two projects' `web` services do not clobber each other.
 pub(super) fn unit_stem(project: &str, name: &str) -> String {
 	safe_unit_stem(&format!("{project}-{name}"))
 }

--- a/internal/quadlet/render_tests.rs
+++ b/internal/quadlet/render_tests.rs
@@ -253,8 +253,8 @@ fn escape_word_split_value_with_whitespace_is_quoted() {
 
 #[test]
 fn escape_trailing_backslash_is_quoted_and_escaped() {
-	// A value ending in a backslash would otherwise continue onto — and
-	// swallow — the next directive line; it must be quoted and escaped.
+	// A value ending in a backslash would otherwise continue onto, and
+	// swallow, the next directive line; it must be quoted and escaped.
 	let out = escape_unit_value("Environment", "WINPATH=C:\\tmp\\");
 	assert!(!out.ends_with('\\') || out.ends_with("\\\""));
 	assert_eq!(out, "\"WINPATH=C:\\\\tmp\\\\\"");

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -402,7 +402,7 @@ services:
 
 #[test]
 fn long_form_tmpfs_mount_renders_as_tmpfs_not_volume() {
-	// A long-form `type: tmpfs` mount must become `Tmpfs=`, not `Volume=` —
+	// A long-form `type: tmpfs` mount must become `Tmpfs=`, not `Volume=`;
 	// the latter would persist it as a volume instead of an in-memory fs.
 	let yaml = r#"
 services:
@@ -431,7 +431,7 @@ services:
 /// #1091: `EnvironmentFile=` is resolved by podman-systemd.unit(5) against the
 /// unit file's own directory, not the compose file's. Units land in
 /// `~/.config/containers/systemd`, so a relative entry emitted verbatim points
-/// at a file that is not there — and `--env-file` on a missing path is fatal, so
+/// at a file that is not there, and `--env-file` on a missing path is fatal, so
 /// the container never starts. Every relative entry must come out absolute
 /// against the compose base directory; an already-absolute one is untouched.
 #[test]
@@ -453,7 +453,7 @@ services:
 	let out = generate_at(&file, "p", base);
 	let c = &unit_named(&out, "p-app.container").contents;
 	// `abs_against` joins with the OS separator, so build the expectations the
-	// same way rather than as POSIX literals — these render tests are not
+	// same way rather than as POSIX literals; these render tests are not
 	// Unix-gated and would otherwise fail on Windows.
 	for rel in [".env", "config/extra.env", "../shared/team.env"] {
 		let needle = format!("EnvironmentFile={}", base.join(rel).display());

--- a/internal/quadlet/tests/fields_logging.rs
+++ b/internal/quadlet/tests/fields_logging.rs
@@ -45,7 +45,7 @@ services:
 	);
 }
 
-/// An explicit `logging:` block overrides the default — the rendered unit
+/// An explicit `logging:` block overrides the default: the rendered unit
 /// carries the user's driver and options, not the default (#1354).
 #[test]
 fn logging_user_override_replaces_the_default() {

--- a/internal/quadlet/tests/health.rs
+++ b/internal/quadlet/tests/health.rs
@@ -9,7 +9,7 @@ use crate::quadlet::generate_at;
 
 /// #1095: the `x-podman-on-failure` extension reaches the Quadlet unit as
 /// `HealthOnFailure=`, so `generate quadlet` and `autostart --mode quadlet`
-/// carry it too — not just the live `up` path.
+/// carry it too, not just the live `up` path.
 #[test]
 fn health_on_failure_extension_reaches_the_quadlet_unit() {
 	let yaml = r#"
@@ -28,7 +28,7 @@ services:
 
 /// An invalid value warns instead of being emitted. Quadlet drops the whole unit
 /// at daemon-reload on an unrecognised key, which is a far worse failure than
-/// the key being absent — and generation has no error channel to refuse in.
+/// the key being absent, and generation has no error channel to refuse in.
 #[test]
 fn an_invalid_health_on_failure_warns_rather_than_emitting() {
 	let yaml = r#"

--- a/internal/quadlet/tests/units.rs
+++ b/internal/quadlet/tests/units.rs
@@ -107,7 +107,7 @@ services:
 	assert!(build.contents.contains("[Build]"));
 	assert!(build.contents.contains("ImageTag=app:latest"));
 	// `abs_context` joins with the OS separator, so build the expected path the
-	// same way — `/srv/app/src` on Unix, `/srv/app\src` on Windows — rather than a
+	// same way (`/srv/app/src` on Unix, `/srv/app\src` on Windows) rather than a
 	// POSIX literal that fails the render tests (which are not Unix-gated) on Windows.
 	let expected_ctx = format!(
 		"SetWorkingDirectory={}",
@@ -193,8 +193,8 @@ services:
 }
 
 /// #1092: `env_file: [{path, required: false}]` says a missing file is fine.
-/// Quadlet cannot express that — `EnvironmentFile=` becomes `--env-file`, which
-/// is fatal on a missing path — so the entry is emitted anyway and the container
+/// Quadlet cannot express that: `EnvironmentFile=` becomes `--env-file`, which
+/// is fatal on a missing path, so the entry is emitted anyway and the container
 /// refuses to start. That is the only behaviour available; what must not happen
 /// is emitting it silently.
 #[test]
@@ -216,7 +216,7 @@ services:
 		joined.contains("env_file") && joined.contains("required: false"),
 		"expected a warning naming the unmappable `required: false`, got:\n{joined}"
 	);
-	// The entry is still emitted — dropping it would lose configuration the user
+	// The entry is still emitted; dropping it would lose configuration the user
 	// asked for whenever the file does exist. Built with `join` so the separator
 	// matches the host (this test is not Unix-gated).
 	let c = &unit_named(&out, "p-s.container").contents;

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -14,7 +14,7 @@ use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
 ///
 /// The systemd generator runs a `.build` unit with no working directory of its
 /// own, resolving a relative `SetWorkingDirectory` against the unit file's own
-/// directory (`~/.config/containers/systemd`) — where there is no Dockerfile. So
+/// directory (`~/.config/containers/systemd`), where there is no Dockerfile. So
 /// the context, which compose interprets relative to the compose file, must be
 /// made absolute against that base directory here.
 ///
@@ -33,7 +33,7 @@ pub(crate) fn build_unit_filename(project: &str, name: &str) -> String {
 	format!("{}.build", unit_stem(project, name))
 }
 
-/// Whether `service` yields a `.build` unit — it declares `build:` and that
+/// Whether `service` yields a `.build` unit: it declares `build:` and that
 /// build is expressible as Quadlet (an inline Dockerfile is not). Used by the
 /// container unit to decide whether `Image=` should reference the `.build`.
 pub(crate) fn emits_build_unit(service: &Service) -> bool {
@@ -48,7 +48,7 @@ pub(crate) fn emits_build_unit(service: &Service) -> bool {
 
 /// Build the `.build` unit for `service`, or `None` when the service has no
 /// `build:` block or its build can't be expressed as a Quadlet `.build` unit
-/// (an inline Dockerfile, which Quadlet does not support — a warning is pushed).
+/// (an inline Dockerfile, which Quadlet does not support; a warning is pushed).
 ///
 /// `ImageTag=` is the service's `image:` when set, else `<project>-<service>`,
 /// so the generated container's `Image=<stem>.build` resolves to a concrete tag.
@@ -88,7 +88,7 @@ pub(crate) fn build_unit(
 				// without the source would build the wrong thing. Skip and warn.
 				warnings.push(format!(
 					"{name}: build.dockerfile_inline has no Quadlet `.build` equivalent; \
-					 no .build unit emitted — build the image first and set `image`"
+					 no .build unit emitted; build the image first and set `image`"
 				));
 				return None;
 			}

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -29,7 +29,7 @@ pub(crate) struct UnitContext<'a> {
 	pub declared_networks: &'a [&'a str],
 	/// Top-level `secrets:` definitions, for resolving a service's secret refs.
 	pub secrets: &'a IndexMap<String, SecretConfig>,
-	/// Directory compose resolves relative paths against — the compose file's
+	/// Directory compose resolves relative paths against: the compose file's
 	/// own directory, not the unit's. See [`abs_against`].
 	pub base_dir: &'a std::path::Path,
 	/// Every service in the file, so a `depends_on` condition can be judged
@@ -150,7 +150,7 @@ pub(crate) fn container_unit(
 
 	// Ports are validated (range, format) before generation, so parsing succeeds
 	// here. A malformed/out-of-range mapping is rejected at the command boundary
-	// rather than re-emitted verbatim as an invalid `PublishPort=` — emitting the
+	// rather than re-emitted verbatim as an invalid `PublishPort=`; emitting the
 	// raw string would produce a unit Quadlet/Podman would reject anyway.
 	//
 	// In pod mode the pod owns every published port (the container's own
@@ -238,7 +238,7 @@ pub(crate) fn container_unit(
 	// `EnvironmentFile=` is resolved by podman-systemd.unit(5) against the unit
 	// file's own directory, not the compose file's. Units are installed to
 	// `~/.config/containers/systemd`, so `env_file: .env` would render to a unit
-	// looking for `~/.config/containers/systemd/.env` — and `--env-file` on a
+	// looking for `~/.config/containers/systemd/.env`, and `--env-file` on a
 	// missing path is fatal, so the container never starts. Resolve against the
 	// compose base directory, the same way the build context is.
 	for entry in service.env_file.to_entries() {
@@ -336,7 +336,7 @@ pub(crate) fn container_unit(
 	// `service:X` reuses a *sibling service's* netns, which Quadlet expresses as
 	// `Network={X}.container` (the `.container` unit dependency). `container:X`
 	// reuses an *existing* container's netns by id/name and maps to podman's
-	// `Network=container:X` join form — not a `.container` unit, which would name
+	// `Network=container:X` join form, not a `.container` unit, which would name
 	// a non-existent dependency and fail to start. Other modes (bridge:, custom,
 	// …) have no key and are reported by collect_warnings.
 	match service.network_mode.as_deref() {
@@ -526,7 +526,7 @@ pub(crate) fn container_unit(
 /// Render a resolved [`LogConfig`] onto a Quadlet `[Container]` section.
 ///
 /// Quadlet units run through the podman CLI, which reads rotation from
-/// `--log-opt max-size=` — not from the typed `size` field the libpod API
+/// `--log-opt max-size=`, not from the typed `size` field the libpod API
 /// takes. #1417 moved `max-size` out of `options` into that typed field for
 /// the live path, and rendering `options` alone here dropped rotation from
 /// every generated unit: measured before this helper, a default project

--- a/internal/quadlet/unit/health.rs
+++ b/internal/quadlet/unit/health.rs
@@ -38,7 +38,7 @@ pub(super) fn render_healthcheck(
 			// Tell systemd the unit is not up until the healthcheck passes.
 			// Quadlet renders this as `--sdnotify=healthy`, and without it
 			// systemd calls the service started the moment the container is
-			// created — so `After=`/`Requires=` order the *creation*, not the
+			// created, so `After=`/`Requires=` order the *creation*, not the
 			// readiness, and a dependant starts against a service that is not
 			// serving yet.
 			//
@@ -46,7 +46,7 @@ pub(super) fn render_healthcheck(
 			// pass: `systemctl start` on the unit itself returned after 11s
 			// rather than immediately, and a second unit with
 			// `After=`/`Requires=` on it started 10s in. That second number is
-			// the one that matters — it is `depends_on: service_healthy`
+			// the one that matters: it is `depends_on: service_healthy`
 			// actually being honoured.
 			//
 			// Only emitted alongside a command. `--sdnotify=healthy` with
@@ -70,7 +70,7 @@ pub(super) fn render_healthcheck(
 	// The `x-podman-on-failure` extension. An invalid value is warned about
 	// rather than emitted: generation has no error channel here, and writing an
 	// unrecognised `HealthOnFailure=` would make Quadlet drop the whole unit at
-	// daemon-reload — a far worse failure than the key being absent. The live
+	// daemon-reload, a far worse failure than the key being absent. The live
 	// `up` path rejects the same value outright, where it can.
 	match hc.podman_on_failure() {
 		Ok(Some(action)) => container.add("HealthOnFailure", action.as_str().to_string()),

--- a/internal/quadlet/unit/health_tests.rs
+++ b/internal/quadlet/unit/health_tests.rs
@@ -22,7 +22,7 @@ fn no_healthcheck_emits_nothing() {
 fn disabled_healthcheck_emits_none() {
 	let (body, warnings) = render("image: x\nhealthcheck:\n  disable: true\n");
 	assert!(body.contains("HealthCmd=none"));
-	// A disabled check short-circuits — no timing keys follow.
+	// A disabled check short-circuits, so no timing keys follow.
 	assert!(!body.contains("HealthInterval"));
 	assert!(warnings.is_empty());
 }

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -28,7 +28,7 @@ use super::QuadletUnit;
 /// unit.
 ///
 /// This is deliberately separate from the `Label=podup.project=<project>`
-/// line each unit also carries (kept for runtime scoping — Podman uses it for
+/// line each unit also carries (kept for runtime scoping, since Podman uses it for
 /// container/secret lookups). A compose service's user-supplied `labels:` are
 /// rendered into the same section as that `Label=` line, in the same
 /// `Key=Value` shape, so a service declaring `labels: {podup.project: other}`
@@ -44,14 +44,14 @@ fn owner_marker(project: &str) -> String {
 /// Resolve a compose-relative path against the compose base directory.
 ///
 /// Compose interprets a relative path against the compose file's directory.
-/// systemd interprets one against **the unit file's** directory — units are
+/// systemd interprets one against **the unit file's** directory: units are
 /// installed under `~/.config/containers/systemd`, which is not where the
 /// project lives. Any path a generated unit carries must therefore be made
 /// absolute here, or it silently resolves somewhere else once installed.
 ///
 /// An already-absolute path is returned untouched, and `.` means the base
 /// directory itself. A leading `./` is stripped so the result stays clean
-/// (`/base/src`, not `/base/./src`) — cosmetic, both resolve identically.
+/// (`/base/src`, not `/base/./src`), cosmetic since both resolve identically.
 fn abs_against(base_dir: &std::path::Path, path: &str) -> String {
 	let p = std::path::Path::new(path);
 	if p.is_absolute() {

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -16,7 +16,7 @@ pub(super) fn secret_field(value: &str) -> String {
 }
 
 /// Whether a top-level secret definition is an inline `content:`/`environment:`
-/// source — the kind `up` materialises as a project-scoped native Podman secret.
+/// source, the kind `up` materialises as a project-scoped native Podman secret.
 /// `external:` wins (never created by podup) and a bare `file:`/empty def is a
 /// bind/host source kept under its compose name.
 pub(super) fn is_inline_secret(def: Option<&SecretConfig>) -> bool {

--- a/internal/quadlet/unit/security_tests.rs
+++ b/internal/quadlet/unit/security_tests.rs
@@ -167,7 +167,7 @@ fn maps_mask_and_unmask() {
 #[test]
 fn unknown_label_warns_and_emits_no_key() {
 	let (body, warnings) = map_one("label=bogus");
-	// Only the section header — no key added.
+	// Only the section header, with no key added.
 	assert_eq!(body, "[Container]\n");
 	assert_eq!(warnings.len(), 1);
 	assert!(warnings[0].contains("label=bogus"));

--- a/internal/quadlet/warnings.rs
+++ b/internal/quadlet/warnings.rs
@@ -61,7 +61,7 @@ pub(super) fn collect_warnings(
 	// healthcheck: that service's unit carries `Notify=healthy`, so systemd
 	// does not call it started until the probe passes, and `After=`/`Requires=`
 	// then order against readiness rather than creation. Measured on podman
-	// 5.7.0 — a dependant started 10s into a dependency whose probe took 10s.
+	// 5.7.0: a dependant started 10s into a dependency whose probe took 10s.
 	//
 	// So the warning is now about the cases that really cannot work: a
 	// `service_healthy` naming a service with no healthcheck to wait on, and
@@ -93,7 +93,7 @@ pub(super) fn collect_warnings(
 	// `env_file: [{path, required: false}]` means a missing file is not an error.
 	// Quadlet has no way to say that: `EnvironmentFile=` becomes
 	// `podman run --env-file`, which is fatal on a missing path. So an entry the
-	// compose file marks optional becomes a container that refuses to start —
+	// compose file marks optional becomes a container that refuses to start,
 	// and this is the deployment-local override pattern (a `.env.production`
 	// deliberately absent from the repo), so it fails exactly where the file is
 	// meant to be missing.

--- a/internal/resolve.rs
+++ b/internal/resolve.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use podup::ComposeError;
 
 /// Validate an explicit `--project-directory`: it must exist and be a directory.
-/// A `None` (unset) directory is always fine — it is derived from the compose
+/// A `None` (unset) directory is always fine: it is derived from the compose
 /// file's location. Matches `docker compose`, which errors on a missing working
 /// directory instead of silently accepting it.
 pub(crate) fn validate_project_directory(dir: Option<&Path>) -> podup::Result<()> {
@@ -61,7 +61,7 @@ pub(crate) fn resolve_compose_files(explicit: &[PathBuf]) -> Vec<PathBuf> {
 }
 
 /// Override-file names, in the compose-spec precedence order. Only the first one
-/// present is used — docker compose does not merge two overrides.
+/// present is used; docker compose does not merge two overrides.
 const OVERRIDE_FILE_CANDIDATES: [&str; 4] = [
 	"compose.override.yaml",
 	"compose.override.yml",
@@ -75,7 +75,7 @@ const OVERRIDE_FILE_CANDIDATES: [&str; 4] = [
 /// Base file plus `docker-compose.override.yml` is how nearly every repository
 /// separates dev from prod, and docker compose merges it automatically whenever
 /// no explicit `-f` is given. podup ran the base alone and said nothing: wrong
-/// image tags, wrong published ports, missing dev bind mounts, exit 0 — about a
+/// image tags, wrong published ports, missing dev bind mounts, exit 0, about a
 /// file the user never named on the command line, so nothing in the invocation
 /// hinted at what went wrong.
 ///
@@ -96,7 +96,7 @@ fn override_for(base: &Path) -> Option<PathBuf> {
 /// The label is read back by `ls` from a different working directory than the
 /// one the project was started in, so a relative path there would be
 /// meaningless. Falls back to the path as given when the filesystem cannot
-/// resolve it — a best-effort label must never fail the command that sets it.
+/// resolve it; a best-effort label must never fail the command that sets it.
 pub(crate) fn absolute(path: &Path) -> PathBuf {
 	std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/internal/resolve_tests.rs
+++ b/internal/resolve_tests.rs
@@ -68,7 +68,7 @@ fn defaults_to_compose_file_parent() {
 #[test]
 fn bare_filename_resolves_to_current_dir() {
 	// A bare filename has no directory component, so the base directory must
-	// fall back to the working directory — never an empty path, which would
+	// fall back to the working directory, never an empty path, which would
 	// leave a relative `file:` source to be resolved against the Podman
 	// service's working directory ($HOME) instead of the project directory.
 	let base = resolve_base_dir(None, Path::new("docker-compose.yml"));
@@ -141,7 +141,7 @@ fn auto_discovery_picks_up_the_override_file() {
 	assert_eq!(found, Some(dir.path().join("compose.override.yaml")));
 }
 
-/// Only the first override in precedence order is used — docker compose does
+/// Only the first override in precedence order is used; docker compose does
 /// not merge two of them.
 #[test]
 fn only_the_highest_precedence_override_is_used() {

--- a/internal/startup/config_normalize.rs
+++ b/internal/startup/config_normalize.rs
@@ -1,7 +1,7 @@
 //! Output-fidelity normalizers for the `config` render path: resolving relative
 //! bind-mount sources to absolute paths, and quoting YAML 1.1 boolean-like
 //! scalars. Split out of `config_render` so each file stays within the source
-//! line limit. None of this changes runtime behaviour — it only shapes the
+//! line limit. None of this changes runtime behaviour; it only shapes the
 //! rendered `config` output to match `docker compose config`.
 
 use std::path::{Component, Path, PathBuf};
@@ -10,7 +10,7 @@ use podup::compose::types::{ComposeFile, VolumeMount, VolumeType};
 
 /// Rewrite each service's relative bind-mount source to an absolute path,
 /// resolved against the project directory (matching `docker compose config`).
-/// Only `.`-prefixed host paths are resolved — absolute paths, `~`, named
+/// Only `.`-prefixed host paths are resolved: absolute paths, `~`, named
 /// volumes, and Windows drive paths are left untouched, mirroring how the engine
 /// classifies a short-form source. Mount semantics are unchanged; this only
 /// affects the rendered output's source field.
@@ -41,7 +41,7 @@ pub(super) fn resolve_bind_sources(file: &mut ComposeFile, base_dir: &Path) {
 /// Resolve the source of a short-form `source:target[:options]` bind mount,
 /// returning the rewritten spec when the source is a relative host path. A spec
 /// with no `:` separator is a single in-container target (anonymous volume), and
-/// a non-`.` source is absolute or a named volume — both are left as-is.
+/// a non-`.` source is absolute or a named volume; both are left as-is.
 fn rewrite_short_bind(spec: &str, base_dir: &Path) -> Option<String> {
 	let (src, rest) = spec.split_once(':')?;
 	let abs = absolute_bind_source(src, base_dir)?;

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -45,7 +45,7 @@ pub(crate) fn render_config(
 	// config-time validation (non-empty services, image-or-build, service-name
 	// charset, port ranges, undefined volume/network references, and an acyclic
 	// dependency graph) before the `--quiet`/projection short-circuits, so
-	// validate-only (`--quiet`) actually validates — matching `docker compose config`.
+	// validate-only (`--quiet`) actually validates, matching `docker compose config`.
 	podup::validate_config(file)?;
 	// Surface the active host-binding / privilege-escalation modes for every
 	// service at the default log level (`warn`), so CI logs picking up
@@ -110,7 +110,7 @@ pub(crate) fn render_config(
 	// not re-trigger the same warning. `x-*` extensions are kept.
 	redacted.strip_ignored_unknown_keys();
 	// Resolve relative bind-mount sources to absolute paths against the project
-	// directory, like `docker compose config`. Runtime mounting is unaffected —
+	// directory, like `docker compose config`. Runtime mounting is unaffected;
 	// this only normalizes the rendered output.
 	resolve_bind_sources(&mut redacted, base_dir);
 	redacted.redact_inline_content();
@@ -224,12 +224,12 @@ fn prune_json_nulls(v: &mut serde_json::Value) {
 
 /// `preserve_nulls` keeps null leaves at the current mapping level. It is set for
 /// the value under an `environment:` key so a map-form host-passthrough var
-/// (`MYVAR:` → null) is not stripped from the output — it is forwarded at runtime,
+/// (`MYVAR:` → null) is not stripped from the output: it is forwarded at runtime,
 /// so `config` must show it, matching docker compose (which never drops the key).
 ///
 /// It is set for `networks:` for the same reason: a null value there means
 /// "attach with default options", not "nothing". Dropping it removed a network
-/// the service is genuinely on — visible once merging could produce a map mixing
+/// the service is genuinely on, visible once merging could produce a map mixing
 /// a configured network with a bare one (#1078).
 fn prune_json(v: &mut serde_json::Value, preserve_nulls: bool) {
 	match v {
@@ -307,7 +307,7 @@ fn is_empty_yaml(v: &serde_yaml::Value) -> bool {
 /// Walk every service and emit one `tracing::warn!` per active host-binding
 /// mode. The warning is the same line the live `up` engine emits, so an
 /// operator reading `config` output before running `up` sees the same set of
-/// flags. `config` does not honour `--no-warn` for this surface — the whole
+/// flags. `config` does not honour `--no-warn` for this surface: the whole
 /// point of the command is to surface what is about to run.
 fn surface_host_modes(file: &podup::compose::types::ComposeFile) {
 	podup::surface_host_modes(file);

--- a/internal/startup/config_render_tests.rs
+++ b/internal/startup/config_render_tests.rs
@@ -15,7 +15,7 @@ fn prune_json_drops_nulls_and_empty_then_collapses() {
 	});
 	prune_json_nulls(&mut v);
 	// null fields and the section emptied by its own nulls are gone, but an
-	// explicit empty array (`command: []`) survives — it overrides the image.
+	// explicit empty array (`command: []`) survives; it overrides the image.
 	assert_eq!(v, serde_json::json!({ "image": "nginx", "command": [] }));
 }
 
@@ -237,7 +237,7 @@ fn render_config_strips_ignored_unknown_keys() {
 
 /// #1078: a null value under `networks:` means "attach with default
 /// options", not "nothing". It used to be pruned like any other empty leaf,
-/// which silently removed a network the service is genuinely on — reachable
+/// which silently removed a network the service is genuinely on, reachable
 /// once merging could produce a map mixing a configured network with a bare
 /// one.
 #[test]

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -56,7 +56,7 @@ pub(crate) fn validate_project_name(project: &str) -> podup::Result<()> {
 
 /// Whether a command is scoped purely by the `podup.project` label and never
 /// reads service definitions, so it can run against a project with no compose
-/// file present — matching `docker compose -p NAME events`/`ps`. These commands
+/// file present, matching `docker compose -p NAME events`/`ps`. These commands
 /// tolerate a missing compose file at startup instead of erroring `FileNotFound`.
 pub(crate) fn is_label_only(command: &Commands) -> bool {
 	matches!(command, Commands::Events { .. } | Commands::Ps { .. })
@@ -133,9 +133,9 @@ pub(crate) fn internal_error_notice() -> String {
 ///
 /// The match is anchored to the exact prefix the standard library uses, because
 /// a bare substring search over the panic text is far too wide: it exits 0 for
-/// **any** panic whose message happens to mention a broken pipe — an
+/// **any** panic whose message happens to mention a broken pipe (an
 /// `.expect()` on an unrelated io error, or a Podman error quoting a downstream
-/// EPIPE — and with `panic = "abort"` this hook is the only thing between a
+/// EPIPE) and with `panic = "abort"` this hook is the only thing between a
 /// panic and the exit status, so a real crash would report success and print
 /// nothing. Pure so it can be unit-tested.
 pub(crate) fn is_broken_pipe_panic(msg: &str) -> bool {
@@ -151,7 +151,7 @@ pub(crate) fn is_broken_pipe_panic(msg: &str) -> bool {
 
 /// Initialize the global tracing subscriber, written to stderr in the
 /// `podup: <level>: <msg>` format so stdout stays a clean pipe. `default_level`
-/// is the floor used when `RUST_LOG` is unset — `warn` for most commands (so the
+/// is the floor used when `RUST_LOG` is unset: `warn` for most commands (so the
 /// forward-compat "unknown field" notices are never silently dropped), `info`
 /// for interactive long-running ones like `watch` that should surface their
 /// per-action progress. `RUST_LOG` always overrides.
@@ -195,7 +195,7 @@ pub(crate) fn run_overrides_for(command: &Commands) -> podup::RunOverrides {
 /// Whether `run` was given `-T/--no-TTY`.
 ///
 /// Carried on the engine rather than on `RunOverrides`, which is public and not
-/// `#[non_exhaustive]` — a new field there is a breaking change, which is what
+/// `#[non_exhaustive]`, where a new field is a breaking change, which is what
 /// cargo-semver-checks reported when the field was tried there.
 pub(crate) fn run_no_tty_for(command: &Commands) -> bool {
 	matches!(command, Commands::Run { no_tty, .. } if *no_tty)
@@ -218,7 +218,7 @@ pub(crate) fn run_labels_for(command: &Commands) -> Vec<String> {
 ///
 /// Split from the two call sites so the choice is testable: both arms used to
 /// live inside `parse_cli`, which calls `process::exit` and so cannot be
-/// exercised by a unit test at all — the coloured arm was unreachable from the
+/// exercised by a unit test at all: the coloured arm was unreachable from the
 /// suite, and adding it dropped coverage below the gate.
 ///
 /// Which sink to ask about is the caller's business and differs between them:
@@ -248,7 +248,7 @@ fn help_for(root: clap::Command, args: impl Iterator<Item = String>) -> clap::bu
 	// Build first. An unbuilt tree has not propagated the binary name or the
 	// global options down to its subcommands, so a subcommand plucked out of it
 	// renders `Usage: generate <COMMAND>` instead of
-	// `Usage: podup generate [OPTIONS] <COMMAND>` — the same text `--help` on
+	// `Usage: podup generate [OPTIONS] <COMMAND>`, the same text `--help` on
 	// that group already produces.
 	let mut cmd = root;
 	cmd.build();
@@ -321,7 +321,7 @@ pub(crate) fn parse_cli() -> Cli {
 			}
 			// `MissingSubcommand` is the same situation wearing a different hat.
 			// `arg_required_else_help` only fires when there are NO arguments at
-			// all, and an env-sourced one counts — so with `COMPOSE_PROJECT_NAME`
+			// all, and an env-sourced one counts, so with `COMPOSE_PROJECT_NAME`
 			// or `PODMAN_SOCKET` exported, which is the normal state of a real
 			// deployment, bare `podup` printed a wall of forty-five subcommand
 			// names instead of its help. Same user, same mistake, worse answer,
@@ -336,7 +336,7 @@ pub(crate) fn parse_cli() -> Cli {
 				// Coloured the same way the `--help` branch above is, but gated on
 				// *stderr* since that is where this goes. Bare `podup` is the first
 				// screen anyone sees after installing, and it was the one help path
-				// that rendered plain — so podup looked like a tool with no colour
+				// that rendered plain, so podup looked like a tool with no colour
 				// while every other screen had it.
 				// Rendered from the command, not from the error: a
 				// `MissingSubcommand` error renders as a one-line complaint plus
@@ -345,7 +345,7 @@ pub(crate) fn parse_cli() -> Cli {
 				//
 				// From the command the user actually reached, not always the root.
 				// `generate` and `autostart` declare `subcommand_required`, so bare
-				// `podup generate` lands here — and rendering the root told them
+				// `podup generate` lands here, and rendering the root told them
 				// about the whole tool while withholding the one thing they needed,
 				// which is what `generate` accepts. Their own `--help` already
 				// answers that correctly; this path did not.
@@ -357,8 +357,8 @@ pub(crate) fn parse_cli() -> Cli {
 			// arg, bad value. Bypass `e.exit()` so the output carries the
 			// `podup:` prefix that `exit_status::print_error` and the
 			// `tracing` formatter both use. `e.exit()` would also write
-			// clap's own (unprefixed) version to stderr — printing the same
-			// complaint twice — so we render it once via
+			// clap's own (unprefixed) version to stderr, printing the same
+			// complaint twice, so we render it once via
 			// `format_clap_error` and exit with the same code clap would have
 			// used.
 			_ => {
@@ -372,7 +372,7 @@ pub(crate) fn parse_cli() -> Cli {
 /// Render a clap error with the binary's `podup: error:` prefix so an argument
 /// typo on the command line looks the same as every other failure path.
 /// clap's own formatter emits a bare `error:` line that doesn't match
-/// `exit_status::print_error` or the `tracing` formatter — a typo reached the
+/// `exit_status::print_error` or the `tracing` formatter: a typo reached the
 /// user as a one-liner while every other error came out bold-red and prefixed.
 ///
 /// The clap-rendered text (which includes the usage block for argument
@@ -387,7 +387,7 @@ fn format_clap_error(err: &clap::error::Error) -> String {
 		render = style.render(),
 		reset = style.render_reset()
 	);
-	// clap's own rendered text starts with the literal "error: " — strip it
+	// clap's own rendered text starts with the literal "error: ", so strip it
 	// and re-emit with our prefix so the bold-red label matches the rest of
 	// the binary. The usage block below is left unchanged.
 	let body = err.to_string();

--- a/internal/startup/tests.rs
+++ b/internal/startup/tests.rs
@@ -96,7 +96,7 @@ mod render_help_tests {
 	}
 
 	/// And the coloured arm actually differs, rather than being a no-op nobody
-	/// noticed — which is what a plain `assert!(out.contains("Usage"))` on both
+	/// noticed, which is what a plain `assert!(out.contains("Usage"))` on both
 	/// arms would have failed to catch.
 	#[test]
 	fn with_colour_the_text_still_reads_the_same() {
@@ -235,7 +235,7 @@ mod startup_tests {
 
 	/// `podup logs --wrong-flag` reaches `format_clap_error` with an
 	/// `UnknownArgument` error and the rendered output must lead with the
-	/// binary's `podup:` prefix and the bold-red `error:` label — matching
+	/// binary's `podup:` prefix and the bold-red `error:` label, matching
 	/// `exit_status::print_error` and the `tracing` formatter. The clap usage
 	/// block follows, unprefixed, so a script that greps `podup:` knows what
 	/// category the failure is.
@@ -267,7 +267,7 @@ mod startup_tests {
 		);
 	}
 
-	/// `podup scale` requires a `SERVICE=N` positional — omitting it is a
+	/// `podup scale` requires a `SERVICE=N` positional, so omitting it is a
 	/// `MissingRequiredArgument`. The error must read the same as any other:
 	/// `podup: error: …`, not a bare clap line.
 	#[test]

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -145,7 +145,7 @@ pub fn build_vars_with_env_files(dir: &Path, extra: &[String]) -> HashMap<String
 ///
 /// An explicitly-passed `--env-file` that is missing, unreadable, or malformed
 /// is a hard error (matching docker compose, which fails on a not-found env
-/// file) rather than being silently skipped — a typo'd path must not fall back
+/// file) rather than being silently skipped: a typo'd path must not fall back
 /// to process-env/defaults and exit 0.
 pub fn build_vars_with_env_files_strict(
 	dir: &Path,
@@ -156,7 +156,7 @@ pub fn build_vars_with_env_files_strict(
 
 /// The first control character in `value` that is never legitimate in an
 /// env-file value, or `None` if there is none. Tab, newline and carriage return
-/// are allowed — dotenv escapes (`\t`, `\n`, `\r`) and multi-line quoted values
+/// are allowed: dotenv escapes (`\t`, `\n`, `\r`) and multi-line quoted values
 /// produce them legitimately, and post-parse interpolation stores them verbatim
 /// as scalar data. Everything else in the C0/C1 ranges (NUL, ESC, …) is
 /// rejected. Pure so it is unit-tested.
@@ -205,7 +205,7 @@ fn build_vars_with_env_files_inner(
 			// interpolated verbatim into a compose scalar, where it is meaningless
 			// at best and corrupts the container's config at worst. Reject it here,
 			// at load time, with an error that names the originating env file and
-			// key — instead of letting it surface later as a compose-file parse
+			// key, instead of letting it surface later as a compose-file parse
 			// error at a meaningless post-substitution offset. Only the explicit
 			// (strict) `--env-file`/`env_file:` path errors; the lenient `.env`
 			// fallback keeps its historical pass-through behaviour.

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -32,17 +32,17 @@ pub(super) fn collect_var_name(chars: &mut std::iter::Peekable<std::str::Chars<'
 #[derive(Debug)]
 pub(super) enum Modifier {
 	None,
-	/// `${VAR:-default}` — use default if unset or empty
+	/// `${VAR:-default}`: use default if unset or empty
 	DefaultIfUnsetOrEmpty(String),
-	/// `${VAR-default}` — use default if unset (empty value is OK)
+	/// `${VAR-default}`: use default if unset (empty value is OK)
 	DefaultIfUnset(String),
-	/// `${VAR:+value}` — use value if set and non-empty
+	/// `${VAR:+value}`: use value if set and non-empty
 	AltIfSetAndNonEmpty(String),
-	/// `${VAR+value}` — use value if set (even if empty)
+	/// `${VAR+value}`: use value if set (even if empty)
 	AltIfSet(String),
-	/// `${VAR:?error}` — error if unset or empty
+	/// `${VAR:?error}`: error if unset or empty
 	ErrorIfUnsetOrEmpty(String),
-	/// `${VAR?error}` — error if unset
+	/// `${VAR?error}`: error if unset
 	ErrorIfUnset(String),
 }
 

--- a/internal/substitute/parse_tests.rs
+++ b/internal/substitute/parse_tests.rs
@@ -167,7 +167,7 @@ fn parse_braced_var_underscore_name_is_valid() {
 #[test]
 fn parse_unterminated_modifier_is_error() {
 	// `${TAG:-latest` (no closing `}`) must not swallow the rest of the input as
-	// the default value — it is reported as a malformed substitution.
+	// the default value; it is reported as a malformed substitution.
 	let mut it = peekable("TAG:-latest\nmore: data\n");
 	let err = parse_braced_var(&mut it).expect_err("missing close brace must error");
 	assert!(

--- a/internal/substitute/tests.rs
+++ b/internal/substitute/tests.rs
@@ -309,7 +309,7 @@ fn load_dotenv_bare_key_is_not_set_to_empty() {
 	// A bare key (no `=`) no longer becomes an empty string. In `.env` it
 	// resolves from the host, but `load_dotenv` already drops host-present
 	// keys (process env wins), so either way a bare key never lands in the map
-	// as `""` — it's host-provided for interpolation or absent.
+	// as `""`; it's host-provided for interpolation or absent.
 	std::env::set_var("PODUP_DOTENV_ENV_PRESENT", "h");
 	std::env::remove_var("PODUP_DOTENV_ENV_ABSENT");
 	let dir = tempfile::tempdir().unwrap();
@@ -446,7 +446,7 @@ fn first_disallowed_control_char_allows_tab_newline_cr() {
 fn strict_build_vars_errors_on_control_char_value_naming_file_and_key() {
 	let dir = tempfile::tempdir().unwrap();
 	// A NUL in an env-file value is rejected at load time, before any compose
-	// parse, with an error that names the originating env file and key — not a
+	// parse, with an error that names the originating env file and key, not a
 	// misattributed parse offset into the post-substitution document (#885).
 	std::fs::write(dir.path().join("bad.env"), "SECRET=ab\0cd\n").unwrap();
 	let err = build_vars_with_env_files_strict(dir.path(), &["bad.env".to_string()]).unwrap_err();

--- a/internal/timestamp/mod.rs
+++ b/internal/timestamp/mod.rs
@@ -1,8 +1,8 @@
 //! RFC 3339 timestamps, as libpod puts them on the wire.
 //!
 //! podup has no date library and does not want one. The three fields that need
-//! this — a container's `Created`, a volume's `CreatedAt`, and an image's
-//! `Created` from the inspect endpoint — all arrive as RFC 3339 strings, and
+//! this (a container's `Created`, a volume's `CreatedAt`, and an image's
+//! `Created` from the inspect endpoint) all arrive as RFC 3339 strings, and
 //! everything else libpod reports (`StartedAt`, the event feed) is already Unix
 //! seconds.
 //!
@@ -150,7 +150,7 @@ const fn days_in_month(year: i64, month: i64) -> i64 {
 /// Days since the Unix epoch for a civil date.
 ///
 /// The exact inverse of [`civil_from_days`]. Both shift the epoch to 0000-03-01
-/// so February — the month whose length varies — lands last and the leap-day
+/// so February, the month whose length varies, lands last and the leap-day
 /// case needs no branch of its own. Round-tripping one through the other is the
 /// test that matters here: for both to agree and both be wrong, they would have
 /// to be wrong in the same direction.
@@ -201,7 +201,7 @@ fn civil_from_days(days: i64) -> (i64, i64, i64) {
 /// The offset is resolved per instant rather than once, so an event from July
 /// and one from January render correctly wherever daylight saving applies. When
 /// the platform cannot say what the offset is, the value is rendered in UTC and
-/// labelled `Z` — an unlabelled guess is the failure this replaced.
+/// labelled `Z`; an unlabelled guess is the failure this replaced.
 pub(crate) fn format_local(unix_secs: i64) -> String {
 	render_with_offset(unix_secs, local_offset_seconds(unix_secs))
 }
@@ -211,7 +211,7 @@ pub(crate) fn format_local(unix_secs: i64) -> String {
 ///
 /// Two things follow from the split, and both are why it exists. The `None`
 /// branch is unreachable through [`format_local`] on any machine whose libc
-/// resolves a zone — mutations deleting it survived every test that went in the
+/// resolves a zone: mutations deleting it survived every test that went in the
 /// front door, which is what an untestable control looks like from outside. And
 /// the rendered string stops depending on the machine's own zone, so it can be
 /// pinned exactly instead of only by shape.
@@ -265,8 +265,8 @@ fn local_offset_seconds(unix_secs: i64) -> Option<i64> {
 
 /// Build a Win32 `SYSTEMTIME` from Unix seconds.
 ///
-/// Lives here rather than in the Windows module so it is compiled — and
-/// therefore type-checked and unit-tested — on every platform. A conversion
+/// Lives here rather than in the Windows module so it is compiled, and
+/// therefore type-checked and unit-tested, on every platform. A conversion
 /// that only builds on the one machine nobody develops on is a conversion
 /// nobody has checked.
 #[cfg(windows)]

--- a/internal/timestamp/offset_unix.rs
+++ b/internal/timestamp/offset_unix.rs
@@ -25,15 +25,15 @@ pub(super) fn local_offset_seconds(unix_secs: i64) -> Option<i64> {
 	//
 	// The known hazard with this family is `tzset`, which reads the `TZ`
 	// environment variable and races a concurrent `setenv`. podup never sets an
-	// environment variable at runtime — the only writes are in test processes,
-	// and no test calls this — so the race has no second party. A returned null
+	// environment variable at runtime (the only writes are in test processes,
+	// and no test calls this) so the race has no second party. A returned null
 	// means libc could not resolve a zone at all and is handled rather than
 	// assumed away.
 	let result = unsafe { libc::localtime_r(&time, &mut tm) };
 	// Deleting this check survives the whole suite, and that is a statement
 	// about reach rather than about the tests: `localtime_r` returns null only
-	// when libc cannot resolve a zone at all — a missing or corrupt
-	// `/etc/localtime`, or a `TZ` it cannot parse — and no in-process test can
+	// when libc cannot resolve a zone at all (a missing or corrupt
+	// `/etc/localtime`, or a `TZ` it cannot parse) and no in-process test can
 	// produce that without replacing libc. The branch it guards is reachable in
 	// production and is exercised from the caller side instead:
 	// `render_with_offset(_, None)` has its own test, so what happens when the

--- a/internal/timestamp/tests.rs
+++ b/internal/timestamp/tests.rs
@@ -14,7 +14,7 @@ fn the_two_shapes_libpod_really_sends_both_parse() {
 	// A running container, from `containers/json`. Written at -05:00, so its
 	// UTC instant is five hours later than the wall clock in the string:
 	// 2026-08-03 00:58:45Z. Both constants here were checked against an
-	// independent parser rather than worked out by hand — the first version of
+	// independent parser rather than worked out by hand: the first version of
 	// this one was an hour off, and the code was right.
 	assert_eq!(
 		parse_rfc3339("2026-08-02T19:58:45.39802971-05:00"),
@@ -40,7 +40,7 @@ fn the_offset_moves_the_instant_the_right_way() {
 }
 
 /// Round-trip through the formatter that lives beside this parser. The two are
-/// inverses — days-from-civil here, civil-from-days there — so for both to agree
+/// inverses (days-from-civil here, civil-from-days there) so for both to agree
 /// and both be wrong they would have to be wrong in the same direction.
 ///
 /// **Zone-independent on purpose.** `format_local` renders the reader's wall

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -1,4 +1,4 @@
-//! Terminal styling — the single place that decides whether to colour output and
+//! Terminal styling: the single place that decides whether to colour output and
 //! holds the palette, so colour stays consistent and always honours `--ansi`,
 //! `NO_COLOR`, and whether the target stream is a TTY.
 //!
@@ -79,7 +79,7 @@ static PROGRESS_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::Atom
 /// `logs` prefixes lines with the project-stripped `web-1`; `ps` prints the full
 /// container name `proj-web-1`; the progress lines print the full name too.
 /// Hashing whatever string each site happens to hold gives the same container a
-/// different colour in each command — which defeats the point of a stable
+/// different colour in each command, which defeats the point of a stable
 /// palette. Stripping the project first makes one container one colour.
 static PROJECT: std::sync::RwLock<String> = std::sync::RwLock::new(String::new());
 
@@ -95,7 +95,7 @@ static PROJECT_PREFIX: std::sync::RwLock<String> = std::sync::RwLock::new(String
 /// Record the project name for identity colouring. Set once per invocation
 /// per project: two `Engine` values alive in one process must each register
 /// their own project name, and the last `set_project` wins for the global
-/// `PROJECT` — but every project's services live under its own key in the
+/// `PROJECT`, but every project's services live under its own key in the
 /// service registry, so neither evicts the other.
 pub fn set_project(name: &str) {
 	if let Ok(mut slot) = PROJECT.write() {
@@ -133,7 +133,7 @@ static SERVICES: std::sync::RwLock<
 /// same project this is a no-op: registration has no project key to live
 /// under. Every CLI command and the engine call site already calls
 /// [`set_project`] first. Without any registration every label falls back
-/// to the per-label hash, which still works — it just cannot promise two
+/// to the per-label hash, which still works; it just cannot promise two
 /// services differ.
 pub fn set_services(names: &[String]) {
 	let project = match PROJECT.read() {
@@ -160,7 +160,7 @@ pub fn set_services(names: &[String]) {
 /// The stable identity colour for a container or service label, keyed on the
 /// label with the project prefix removed.
 ///
-/// Callers pass whatever they display — `proj-web-1`, `web-1`, `web` — and get
+/// Callers pass whatever they display (`proj-web-1`, `web-1`, `web`) and get
 /// the same colour for the same container, which is what makes `ps`, `logs`,
 /// `stats` and the progress lines agree.
 pub fn identity_style(label: &str) -> Style {
@@ -171,7 +171,7 @@ pub fn identity_style(label: &str) -> Style {
 /// this exists as its own, unrendered step.
 ///
 /// First tries every project registered in [`SERVICES`], stripping each
-/// project's `"{name}-"` prefix in turn — a label from a project whose
+/// project's `"{name}-"` prefix in turn, so a label from a project whose
 /// [`set_project`] was overwritten by another engine in the same process
 /// still resolves correctly (#1517). If no project matched, falls back to
 /// the legacy [`PROJECT_PREFIX`]-stripped lookup so `proj-web-1` and
@@ -196,7 +196,7 @@ pub(crate) fn identity_slot(label: &str) -> usize {
 	}
 	// No project's services matched. Strip the currently-set project prefix
 	// (cached in PROJECT_PREFIX so the per-call `format!` is not re-paid)
-	// and look up the bare key — the legacy single-engine behaviour that
+	// and look up the bare key, the legacy single-engine behaviour that
 	// `every_spelling_of_one_container_gets_one_colour` pins (#1364).
 	let prefix = PROJECT_PREFIX
 		.read()
@@ -279,7 +279,7 @@ pub fn progress_line(kind: &str, name: &str, action: &str) {
 /// Write one progress line to stderr, with no board routing.
 ///
 /// Split out of [`progress_line`] because the plain sink has to emit exactly
-/// this and cannot go back through the routing that sent it here — that would
+/// this and cannot go back through the routing that sent it here; that would
 /// be a loop. It is also the reason the two sinks cannot drift: there is one
 /// line format, used by both.
 pub(crate) fn write_progress_line(kind: &str, name: &str, action: &str) {
@@ -299,16 +299,16 @@ pub(crate) fn write_progress_line(kind: &str, name: &str, action: &str) {
 
 /// The colour band for a lifecycle verb.
 ///
-/// Every verb used to be the same green, so `Volume data Removed` — which
-/// destroys data and cannot be undone — was styled exactly like `Started`. The
+/// Every verb used to be the same green, so `Volume data Removed`, which
+/// destroys data and cannot be undone, was styled exactly like `Started`. The
 /// bands say what kind of thing happened: something now exists (green),
 /// something stopped but survives (yellow), something is gone (red), nothing
 /// changed (dim).
 fn action_style(action: &str) -> Style {
 	let a = action.to_ascii_lowercase();
 	// `unpaused` is checked before `paus` on purpose. It reaches the green arm
-	// either way — a container resuming is a thing becoming active, which is what
-	// green means here — but only by falling through, and adding `unpause` to the
+	// either way (a container resuming is a thing becoming active, which is what
+	// green means here) but only by falling through, and adding `unpause` to the
 	// yellow arm's prefixes would silently invert it. Naming it pins the intent.
 	// `fail` joins the red arm so a row closing with verb "Failed" reads as a
 	// failure in colour, not just in word (#1347).
@@ -339,13 +339,13 @@ pub fn progress_note(msg: &str) {
 	let _ = writeln!(anstream::stderr(), "{msg}");
 }
 
-/// Print a result line to stdout — used by `run -d` to echo the started
+/// Print a result line to stdout, used by `run -d` to echo the started
 /// container's name so scripts capturing stdout get the id, matching
 /// `docker compose run -d`. A no-op unless [`set_progress`] enabled progress
 /// output, so embedders and machine paths stay silent.
 ///
 /// The result line is the one thing scripts capture from stdout, so a failed
-/// write is a real error (exit non-zero), not something to swallow — except a
+/// write is a real error (exit non-zero), not something to swallow, except a
 /// broken pipe, which follows the process-wide quiet-exit convention.
 pub fn result_line(msg: &str) -> std::io::Result<()> {
 	use std::io::Write;
@@ -361,8 +361,8 @@ pub fn result_line(msg: &str) -> std::io::Result<()> {
 /// Print a `label: value` line where the label is scaffolding and the value
 /// carries the meaning.
 ///
-/// `autostart status` is the densest meaning-per-line surface in the CLI — six
-/// consecutive yes/no answers — and it was entirely monochrome, so finding the
+/// `autostart status` is the densest meaning-per-line surface in the CLI, six
+/// consecutive yes/no answers, and it was entirely monochrome, so finding the
 /// one line that answers "is it running?" meant reading all six. The label is
 /// dimmed and the value tinted by its own status meaning, which covers systemd's
 /// vocabulary as well as Podman's.
@@ -375,7 +375,7 @@ pub fn print_labelled(label: &str, value: &str) {
 
 /// [`print_labelled`] with the value's meaning stated rather than inferred.
 ///
-/// Some values are prose, not a state word — `XDG_RUNTIME_DIR unset (systemctl
+/// Some values are prose, not a state word: `XDG_RUNTIME_DIR unset (systemctl
 /// --user needs a user session)` is the answer to a yes/no question written as a
 /// sentence. `Some(true)`/`Some(false)` colours it green/red; `None` falls back
 /// to reading the text.
@@ -405,7 +405,7 @@ pub fn print_labelled_with(label: &str, value: &str, good: Option<bool>) {
 ///
 /// `autostart status` needed it: with no unit file on disk, systemd's
 /// `is-enabled` answers `not-found`, which the status vocabulary reads as an
-/// error and paints red — while the `installed: no` line directly above it says
+/// error and paints red, while the `installed: no` line directly above it says
 /// the same thing about the same unit and was dim. Two colours for one fact, and
 /// the alarming one belonged to the case where nothing is wrong.
 ///
@@ -426,7 +426,7 @@ pub fn print_labelled_neutral(label: &str, value: &str) {
 	);
 }
 
-/// Bold — table headers and emphasis.
+/// Bold, for table headers and emphasis.
 pub fn bold() -> Style {
 	Style::new().bold()
 }
@@ -445,7 +445,7 @@ pub fn print_bold_header(cols: &str) {
 	);
 }
 
-/// Print a bold header tinted with its identity colour — used where a block is
+/// Print a bold header tinted with its identity colour, used where a block is
 /// headed by a container name rather than by column titles.
 pub fn print_identity_header(name: &str) {
 	use std::io::Write;
@@ -458,7 +458,7 @@ pub fn print_identity_header(name: &str) {
 	);
 }
 
-/// Bold red — the `error:` label.
+/// Bold red, for the `error:` label.
 pub fn error_style() -> Style {
 	Style::new().bold().fg_color(Some(AnsiColor::Red.into()))
 }
@@ -491,7 +491,7 @@ const SERVICE_PALETTE: [AnsiColor; 6] = [
 /// Looks up `name` in every project's services registered in [`SERVICES`],
 /// first match wins. Two `Engine` values alive in one process own separate
 /// maps under separate project keys, so neither evicts the other (#1517).
-/// Falls back to the per-label hash when nothing is registered — the same
+/// Falls back to the per-label hash when nothing is registered, the same
 /// fallback [`palette::colour_for`] has always used for an undeclared label.
 ///
 /// Split out so a routing regression can be asserted on the slot itself: the
@@ -525,7 +525,7 @@ pub fn service_style(name: &str) -> Style {
 /// it would pass or fail on test scheduling.
 ///
 /// The narrow branch takes a slot assigned against the WIDE palette's size, so
-/// it must wrap again — indexing a six-element array with a slot up to 19 is
+/// it must wrap again: indexing a six-element array with a slot up to 19 is
 /// the out-of-bounds bug the old hash's `assert!` used to guard.
 fn slot_to_style(slot: usize, wide: bool) -> Style {
 	if wide {
@@ -540,7 +540,7 @@ fn slot_to_style(slot: usize, wide: bool) -> Style {
 ///
 /// The `pub(crate)` counterpart to [`identity_style`]/[`service_style`] for a
 /// caller that needs to resolve its *own* slot (e.g. the log-prefix module,
-/// which must never let its routing collapse into a raw per-label hash — see
+/// which must never let its routing collapse into a raw per-label hash; see
 /// `engine::query::log_prefix::prefix_slot`) rather than one of the two
 /// label-keyed lookups here.
 pub(crate) fn style_for_slot(slot: usize) -> Style {
@@ -550,8 +550,8 @@ pub(crate) fn style_for_slot(slot: usize) -> Style {
 /// Whether an `Exited (N)` / `exited(N)` label reports a clean finish.
 ///
 /// A container that ran to completion is not a failure, and colouring it red
-/// says it is. One-shot services — migrations, seeds, a `command` that simply
-/// ends — spend their whole life in this state, so red here is not a rare
+/// says it is. One-shot services (migrations, seeds, a `command` that simply
+/// ends) spend their whole life in this state, so red here is not a rare
 /// cosmetic slip but the normal reading of a healthy project.
 fn is_clean_exit(lower: &str) -> bool {
 	// `exited (0)` and `exited(0)`, but not `exited (07)` or `exited (10)`.
@@ -639,7 +639,7 @@ pub fn action_or_status_style(word: &str) -> Option<Style> {
 ///
 /// `ls` reports a project as `running(1), exited(1)`, and styling that as one
 /// string made the first matching substring win: `exit` came first, so a project
-/// with a service up rendered **entirely red** — visually identical to one that
+/// with a service up rendered **entirely red**, visually identical to one that
 /// is completely dead. Splitting first means each state carries its own colour
 /// and the mixed case reads as mixed.
 ///

--- a/internal/ui/mod_tests.rs
+++ b/internal/ui/mod_tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests for the `ui` styling surface — split out to keep the module
+//! Unit tests for the `ui` styling surface, split out to keep the module
 //! within the source line limit, the same `tests.rs` split `autostart`, the
 //! libpod client and `stats` already use.
 
@@ -6,7 +6,7 @@ use super::*;
 use std::collections::HashMap;
 
 /// The bug this exists to stop: `ls` reports `running(1), exited(1)`, and
-/// styling it as one string let the first matching substring win — `exit`
+/// styling it as one string let the first matching substring win: `exit`
 /// came first, so a project with a service up rendered entirely red,
 /// indistinguishable from one that is completely dead.
 #[test]
@@ -20,8 +20,8 @@ fn a_mixed_project_is_not_painted_as_one_state() {
 	);
 }
 
-/// A container that ran to completion is not a failure. One-shot services —
-/// migrations, seeds, a `command` that simply ends — live in this state.
+/// A container that ran to completion is not a failure. One-shot services
+/// (migrations, seeds, a `command` that simply ends) live in this state.
 #[test]
 fn a_clean_exit_is_not_red() {
 	let red = Style::new().fg_color(Some(AnsiColor::Red.into()));
@@ -73,7 +73,7 @@ fn paint_gates_on_enabled() {
 
 #[test]
 fn colour_choice_resolution() {
-	// Pure resolution — never touches the process-global choice, so it can't
+	// Pure resolution: never touches the process-global choice, so it can't
 	// race the production code (LinePrefixer/status_cell) that reads it.
 	temp_env::with_var_unset("NO_COLOR", || {
 		assert!(!colored_with(ColorChoice::Never, true));
@@ -100,7 +100,7 @@ fn status_style_is_semantic() {
 }
 
 /// The verb bands are what colour a progress line as it closes. A row that
-/// closes with `Failed` previously fell through to the default green — the same
+/// closes with `Failed` previously fell through to the default green, the same
 /// default that paints `Created`, so a failed row read as a successful one
 /// except for the word. The fix is one prefix on the existing red arm (#1347).
 #[test]
@@ -118,7 +118,7 @@ fn a_failed_progress_verb_is_red() {
 		red.render().to_string(),
 		"failed (lower) must share the red band"
 	);
-	// The verbs that were already red stay red — the change is additive.
+	// The verbs that were already red stay red; the change is additive.
 	assert_eq!(
 		action_style("Removed").render().to_string(),
 		red.render().to_string()
@@ -146,7 +146,7 @@ fn status_cell_pads_and_keeps_status() {
 }
 
 /// The whole point of the shared key: `ps` prints `proj-web-1`, `logs`
-/// prefixes `web-1`, and the progress lines print `proj-web-1` — all three
+/// prefixes `web-1`, and the progress lines print `proj-web-1`; all three
 /// must resolve to one colour, or the palette is not stable at all.
 #[test]
 fn every_spelling_of_one_container_gets_one_colour() {
@@ -175,7 +175,7 @@ fn an_unprefixed_label_is_keyed_on_itself() {
 /// `SERVICES` is one static for the whole process, so two tests calling
 /// `set_services` on different threads race and each can read the other's
 /// registration. That would make both flaky, and a flaky test is a defect
-/// rather than noise — so every test that writes the registry takes this
+/// rather than noise, so every test that writes the registry takes this
 /// first. Tests that only build a local `HashMap` do not need it.
 ///
 /// The lock is poison-tolerant on purpose: a panic in one of these tests must
@@ -217,8 +217,8 @@ fn set_services_makes_registered_names_distinct() {
 /// 1`, since `assign` itself wraps at the wide palette's size), and must wrap
 /// that again to index the six-entry `SERVICE_PALETTE` safely.
 ///
-/// Calls `slot_to_style` itself — the real narrow-branch code, not a
-/// reimplementation of its modulo — for every slot the assignment can
+/// Calls `slot_to_style` itself (the real narrow-branch code, not a
+/// reimplementation of its modulo) for every slot the assignment can
 /// produce, on both the wide and narrow branches. Confirmed this fails: with
 /// the `% SERVICE_PALETTE.len()` removed from `slot_to_style`'s narrow arm,
 /// this test panics with an index-out-of-bounds on slot 6 (`index out of
@@ -235,7 +235,7 @@ fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
 /// Two projects in one process coexist: the first project's colours survive
 /// the second project's registration.
 ///
-/// Inversion of the defect pinned in #1518 — `SERVICES` was a single
+/// Inversion of the defect pinned in #1518: `SERVICES` was a single
 /// process-wide static and `set_services` replaced it rather than merging,
 /// so with two `Engine` values alive in one process (helmly-agent's shape,
 /// a fleet of projects) the second registration dropped the first project's
@@ -247,7 +247,7 @@ fn every_wide_palette_slot_indexes_the_narrow_palette_safely() {
 ///
 /// The two name sets are chosen so the registered slot and the hash fallback
 /// disagree; the second assertion guards that the fixture can actually
-/// discriminate — without it the first assertion would hold whether or not
+/// discriminate: without it the first assertion would hold whether or not
 /// the fix were in place, the vacuous shape this file already carries a
 /// warning about elsewhere.
 #[test]

--- a/internal/ui/palette.rs
+++ b/internal/ui/palette.rs
@@ -59,7 +59,7 @@ pub(crate) fn supports_wide_palette(
 /// Read once and cached: the environment does not change under a running
 /// command, and every styled cell would otherwise pay two `var_os` calls.
 ///
-/// The Windows argument is `cfg!(windows)` — the target, not a runtime probe of
+/// The Windows argument is `cfg!(windows)`, the target, not a runtime probe of
 /// virtual-terminal processing. That is sufficient because this is only ever
 /// consulted after the colour gate has decided to emit colour at all, which
 /// already required a terminal and a permitting `--ansi`/`NO_COLOR`; and on a
@@ -85,7 +85,7 @@ use std::collections::HashMap;
 /// Give each name its own palette slot, walking them in sorted order.
 ///
 /// Sequential rather than hashed: a hash does not know how many services exist,
-/// so it collides well before the palette is full — measured on a four-service
+/// so it collides well before the palette is full: measured on a four-service
 /// project, two came out the same colour, and over twenty colours five services
 /// still collide about 42% of the time.
 ///
@@ -108,7 +108,7 @@ pub(crate) fn assign(names: &[String]) -> HashMap<String, usize> {
 /// never registered.
 ///
 /// The fallback matters for anything podup renders but did not resolve from the
-/// compose file — an orphan container, a project listed by `ls`. A stable wrong
+/// compose file: an orphan container, a project listed by `ls`. A stable wrong
 /// colour reads better than no colour at all, and the hash is what guarantees
 /// the same label always lands on the same slot.
 pub(crate) fn colour_for(label: &str, map: &HashMap<String, usize>) -> usize {

--- a/internal/ui/palette_tests.rs
+++ b/internal/ui/palette_tests.rs
@@ -235,8 +235,8 @@ fn assignment_ignores_the_order_names_arrive_in() {
 	assert_eq!(assign(&forward), assign(&backward));
 }
 
-/// A label podup never resolved from the compose file — an orphan container,
-/// say — still gets a stable colour rather than none.
+/// A label podup never resolved from the compose file (an orphan container,
+/// say) still gets a stable colour rather than none.
 #[test]
 fn an_unregistered_service_still_gets_a_stable_colour() {
 	let map = assign(&["web".to_string()]);
@@ -249,7 +249,7 @@ fn an_unregistered_service_still_gets_a_stable_colour() {
 }
 
 /// `colour_for` must answer from the registry, not the hash, once a label is
-/// registered — otherwise `set_services` would be a no-op and every label
+/// registered; otherwise `set_services` would be a no-op and every label
 /// would still collide exactly as before this task. `"db"` is chosen because
 /// its registered slot (1, from sorting alongside `web`/`cache`/`worker`/
 /// `queue`) provably differs from its own unregistered hash (11 against a

--- a/internal/ui/progress/board.rs
+++ b/internal/ui/progress/board.rs
@@ -4,8 +4,8 @@
 //! Pure: no terminal, no clock reading of its own, no I/O. A renderer asks it
 //! what to draw and it answers; that is what makes the state machine testable
 //! without a tty, which matters because the two things most likely to be wrong
-//! here — a row that never leaves `Working`, and a count that disagrees with the
-//! rows — are invisible in a screenshot.
+//! here (a row that never leaves `Working`, and a count that disagrees with the
+//! rows) are invisible in a screenshot.
 
 use std::time::{Duration, Instant};
 
@@ -216,7 +216,7 @@ impl Board {
 	}
 
 	/// Mark a resource as finished. Also tolerates a resource that was never
-	/// seeded or started — most of the 21 existing call sites report only an
+	/// seeded or started: most of the 21 existing call sites report only an
 	/// ending, so this has to work without a matching `start`.
 	pub fn finish(&mut self, kind: Kind, name: &str, verb: &str, now: Instant) {
 		let idx = self.index_of(kind, name).unwrap_or_else(|| {
@@ -240,7 +240,7 @@ impl Board {
 	///
 	/// Only a contiguous run from the front is eligible. A finished row with an
 	/// unfinished one before it has to stay in the live region, or the permanent
-	/// history would print out of order — which is exactly the record `up` exists
+	/// history would print out of order, which is exactly the record `up` exists
 	/// to leave behind.
 	pub fn take_completed_prefix(&mut self) -> Vec<Row> {
 		let mut out = Vec::new();
@@ -274,7 +274,7 @@ impl Board {
 		&self.rows[self.flushed.min(self.rows.len())..]
 	}
 
-	/// How many resources have finished, and how many there are in total — the
+	/// How many resources have finished, and how many there are in total: the
 	/// `3/6` in the summary line.
 	pub fn tally(&self) -> (usize, usize) {
 		(

--- a/internal/ui/progress/board_tests.rs
+++ b/internal/ui/progress/board_tests.rs
@@ -40,8 +40,8 @@ fn a_finish_without_a_start_still_lands() {
 	assert_eq!(b.tally(), (1, 3));
 }
 
-/// A resource the seed did not predict — an implicit network, a `--scale`
-/// override — is appended rather than dropped. Losing the row is worse than a
+/// A resource the seed did not predict (an implicit network, a `--scale`
+/// override) is appended rather than dropped. Losing the row is worse than a
 /// board that grows by one.
 #[test]
 fn an_unseeded_resource_is_appended_not_dropped() {

--- a/internal/ui/progress/live.rs
+++ b/internal/ui/progress/live.rs
@@ -31,7 +31,7 @@ fn cursor_up(n: usize) -> String {
 /// Which stream a region draws on.
 ///
 /// Not always stderr. The lifecycle board goes there so stdout stays a clean
-/// pipe, but `stats` *is* its output — its table is the thing a user redirects —
+/// pipe, but `stats` *is* its output (its table is the thing a user redirects)
 /// so its region belongs on stdout. Getting this wrong would put cursor moves in
 /// one stream and the content in the other.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -58,14 +58,14 @@ impl Target {
 /// A tail region being repainted on a real terminal.
 ///
 /// Owns the count of rows it last painted, which is the only state the repaint
-/// arithmetic needs — and the reason every line handed to it must already be
+/// arithmetic needs, and the reason every line handed to it must already be
 /// truncated to the terminal width. A line that wraps makes the terminal count
 /// two rows where this counted one, and from then on every repaint erases the
 /// wrong lines.
 ///
 /// Deliberately knows nothing about what it is drawing. It takes two blocks of
 /// finished text: lines that become permanent scrollback, and lines that are
-/// erased on the next call. That is what lets the board and `stats` share it —
+/// erased on the next call. That is what lets the board and `stats` share it:
 /// they disagree about everything except needing a block of text repainted in
 /// place.
 pub struct Region {
@@ -138,7 +138,7 @@ impl Drop for Region {
 /// `Drop` covers a command that ends on its own, and nothing else: Rust's
 /// default SIGINT handling terminates the process without unwinding, so
 /// Ctrl-C out of a region left the caret hidden until the user ran `reset`.
-/// Measured on a 100x30 pty before the fix — one `\e[?25l`, zero `\e[?25h`.
+/// Measured on a 100x30 pty before the fix: one `\e[?25l`, zero `\e[?25h`.
 ///
 /// `stats` is where it bit hardest, because Ctrl-C is the *normal* way to leave
 /// it rather than an error path, but a long `up` interrupted part-way had the
@@ -146,8 +146,8 @@ impl Drop for Region {
 ///
 /// Exits 130 (128 + SIGINT), the shell convention this binary already documents
 /// for an interrupted command. Installed per region rather than globally, so it
-/// cannot disturb the commands that handle their own interrupt — attached `up`,
-/// `exec`, `watch` — none of which open one.
+/// cannot disturb the commands that handle their own interrupt (attached `up`,
+/// `exec`, `watch`) none of which open one.
 fn restore_cursor_on_interrupt(target: Target) {
 	if !claim_install() {
 		return;
@@ -164,8 +164,8 @@ fn restore_cursor_on_interrupt(target: Target) {
 
 /// Take the right to install the interrupt handler, once per process.
 ///
-/// Two regions in one invocation — a `stats` after an `up` inside an embedding
-/// crate — must not stack handlers, since each would race to call
+/// Two regions in one invocation (a `stats` after an `up` inside an embedding
+/// crate) must not stack handlers, since each would race to call
 /// `process::exit`. Split out of the installer so the latch is testable without
 /// spawning anything.
 fn claim_install() -> bool {

--- a/internal/ui/progress/live_tests.rs
+++ b/internal/ui/progress/live_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 /// The interrupt handler is claimed once per process, however many regions a
-/// run opens. Two in one invocation — a `stats` after an `up` inside an
-/// embedding crate — must not stack handlers, since each would race to call
+/// run opens. Two in one invocation (a `stats` after an `up` inside an
+/// embedding crate) must not stack handlers, since each would race to call
 /// `process::exit`.
 ///
 /// The only test in the crate that may call this: the latch is

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -5,7 +5,7 @@
 //! colour choice, never from the command: `up` on a tty repaints a tail region,
 //! `up` in a pipe emits the same events as plain append-only lines. **Animation
 //! in a CI log is a defect**, and so is a CI log that says less than the
-//! terminal did — both renderers see every event, including the intermediate
+//! terminal did: both renderers see every event, including the intermediate
 //! transitions the old output dropped entirely.
 //!
 //! Everything goes to stderr. stdout stays a clean pipe, which is what lets
@@ -43,7 +43,7 @@ const TICK: std::time::Duration = std::time::Duration::from_millis(100);
 /// Process-global for the same reason the colour choice is: one CLI invocation
 /// runs one lifecycle command, and threading a handle through every engine call
 /// site would change 21 signatures to say something none of them decides. A
-/// library embedder never gets one — [`begin`] is a no-op unless the CLI turned
+/// library embedder never gets one; [`begin`] is a no-op unless the CLI turned
 /// progress on.
 static SESSION: Mutex<Option<Session>> = Mutex::new(None);
 
@@ -148,7 +148,7 @@ pub fn begin(resources: impl IntoIterator<Item = (Kind, String)>) {
 	// The flag goes up *after* the session is installed: a `finish` racing the
 	// install sees either no session (`SESSION_OPEN` false → no lock taken) or
 	// a fully-built session. The reverse order would let `finish` take the
-	// lock only to find an empty session and return false — same result, more
+	// lock only to find an empty session and return false: same result, more
 	// work.
 	SESSION_OPEN.store(true, std::sync::atomic::Ordering::Release);
 	if live {
@@ -387,7 +387,7 @@ enum Sink {
 /// Hand a recorded event to whichever renderer owns it.
 ///
 /// The plain sink writes the same line the tree has always written, through
-/// [`super::write_progress_line`] rather than `progress_line` — going back
+/// [`super::write_progress_line`] rather than `progress_line`, because going back
 /// through the routing that sent the event here would be a loop, and it is what
 /// made a piped `up` print nothing at all the first time this was wired up: the
 /// board swallowed every line and no renderer put one back.
@@ -551,7 +551,7 @@ pub fn end() {
 	#[cfg(test)]
 	capture::record_end();
 	if !SESSION_OPEN.swap(false, std::sync::atomic::Ordering::AcqRel) {
-		// No board was ever opened — the flag is the single source of truth
+		// No board was ever opened; the flag is the single source of truth
 		// for that. Drop it first so a racing `finish` doesn't take the lock
 		// just to find an empty session (#1364).
 		buffer_drain();
@@ -612,7 +612,7 @@ fn repaint() {
 		return;
 	};
 	// Re-read the width every repaint, so a resize mid-command does not leave
-	// every later line wrapping — and wrapping is what breaks the arithmetic.
+	// every later line wrapping, and wrapping is what breaks the arithmetic.
 	// Only the width is re-read; the terminal+colour decision is cached at
 	// `begin` (#1364).
 	let width = live_width().unwrap_or(0);

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -20,7 +20,7 @@ pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦"
 const DONE_MARK: &str = "✔";
 
 /// Marker for a row that finished in error. Distinct from [`DONE_MARK`] so a
-/// failed row cannot be mistaken for a successful one at a glance — the verb
+/// failed row cannot be mistaken for a successful one at a glance: the verb
 /// already says "Failed", but the row before the user shows the green checkmark
 /// of a row that closed cleanly, which is the contradiction #1347 introduced
 /// when the missing-close sites started sending `"Failed"` as the closing verb.
@@ -60,7 +60,7 @@ const MIN_NAME_WIDTH: usize = 1;
 /// now exists, a pending one is dim because nothing has happened to it. The name
 /// beside it keeps its identity colour, which is why the marker must not reuse
 /// that palette. A failed row breaks the green-equals-success tie by carrying
-/// the verb "Failed" — the marker reads it too, so a failure and a success do
+/// the verb "Failed"; the marker reads it too, so a failure and a success do
 /// not share a glyph.
 fn marker(row: &Row, frame: usize) -> (&'static str, Style) {
 	match &row.state {

--- a/internal/ui/progress/row_tests.rs
+++ b/internal/ui/progress/row_tests.rs
@@ -88,7 +88,7 @@ fn the_summary_line_never_exceeds_the_measured_width() {
 	}
 }
 
-/// A width of zero means "do not truncate" — the caller could not read the
+/// A width of zero means "do not truncate": the caller could not read the
 /// terminal size. The line is still produced rather than collapsing to nothing.
 #[test]
 fn width_zero_leaves_the_line_intact() {
@@ -116,8 +116,8 @@ fn each_state_gets_its_own_marker() {
 }
 
 /// A row that closed with the verb "Failed" is not a successful row. The marker
-/// is the first thing the eye lands on, so a failure without `✘` — a row that
-/// says "Failed" with a green `✔` — is the same contradiction the missing-close
+/// is the first thing the eye lands on, so a failure without `✘` (a row that
+/// says "Failed" with a green `✔`) is the same contradiction the missing-close
 /// fix (#1347) introduced: the verb now says "Failed", and the marker has to
 /// match.
 #[test]

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -11,7 +11,7 @@ const ELLIPSIS: char = '…';
 /// Fit `cell` into exactly `width` display columns: when it overflows, keep the
 /// leading `width - 1` chars and append an ellipsis; otherwise left-pad with
 /// spaces. Counts `char`s (not bytes) so multi-byte cells truncate on a char
-/// boundary and stay aligned. A `width` of 0 returns the cell unchanged — used
+/// boundary and stay aligned. A `width` of 0 returns the cell unchanged, used
 /// for the trailing column, which is never padded or truncated.
 pub fn fit_cell(cell: &str, width: usize) -> String {
 	let cell = &sanitize_cell(cell);
@@ -31,8 +31,8 @@ pub fn fit_cell(cell: &str, width: usize) -> String {
 ///
 /// Cell contents are not ours: an image tag, a container name, a volume driver
 /// and a process `argv` all come from outside podup. A raw `\x1b[` in one of
-/// them repaints the caller's terminal, and — now that columns carry colour of
-/// their own — desynchronises podup's own resets, so the rest of the table
+/// them repaints the caller's terminal and, now that columns carry colour of
+/// their own, desynchronises podup's own resets, so the rest of the table
 /// inherits whatever the injected sequence set.
 ///
 /// Escaping happens before padding, so the width the column reserves is the
@@ -74,7 +74,7 @@ pub struct Table {
 	caps: Vec<Option<usize>>,
 	/// The column (if any) whose cells are colourised by container status.
 	status_col: Option<usize>,
-	/// The column (if any) carrying an identity — a service or container name —
+	/// The column (if any) carrying an identity, a service or container name,
 	/// tinted with that identity's stable colour.
 	identity_col: Option<usize>,
 	/// The column (if any) holding a yes/no answer where `yes` is the one worth
@@ -125,8 +125,8 @@ impl Table {
 	/// Tint column `col` with each row's stable identity colour, so the same
 	/// service or container is the same colour in every command that lists it.
 	///
-	/// The palette deliberately excludes red, green and yellow — those carry
-	/// status meaning — so an identity colour can never be misread as a state.
+	/// The palette deliberately excludes red, green and yellow, which carry
+	/// status meaning, so an identity colour can never be misread as a state.
 	pub fn identity_col(mut self, col: usize) -> Self {
 		self.identity_col = Some(col);
 		self
@@ -137,7 +137,7 @@ impl Table {
 	///
 	/// Deliberately not [`Table::status_col`], which would paint `yes` green.
 	/// Green means healthy/up everywhere else in this CLI, and the column this
-	/// was written for — `volumes`' `EXTERNAL` — is not reporting health. It
+	/// was written for (`volumes`' `EXTERNAL`) is not reporting health. It
 	/// reports the one volume podup will refuse to delete, so a `down -v` that
 	/// leaves something standing is explicable. That is a caution, and yellow is
 	/// already the band this CLI uses for *survives*.
@@ -151,8 +151,8 @@ impl Table {
 	/// For a table where most columns are scaffolding and one or two carry the
 	/// answer. `top` is the case: eight columns of process bookkeeping around the
 	/// command line, which is the reason anyone runs it. Dimming is not a
-	/// meaning — unlike the status and caution colours it says nothing about the
-	/// value — so it composes with them rather than competing.
+	/// meaning: unlike the status and caution colours it says nothing about the
+	/// value, so it composes with them rather than competing.
 	pub fn dim_cols(mut self, cols: &[usize]) -> Self {
 		self.dim_cols = cols.to_vec();
 		self
@@ -171,7 +171,7 @@ impl Table {
 	/// The two differ where the column shows something longer than the identity:
 	/// `ps` prints the full container name `proj-web-1` while `logs` prefixes the
 	/// project-stripped `web-1`. Keying both on `web-1` is what makes one
-	/// container the same colour in both commands — which is the entire point of
+	/// container the same colour in both commands, which is the entire point of
 	/// a stable palette.
 	pub fn push_keyed(&mut self, cells: Vec<String>, key: String) {
 		self.rows.push(cells);
@@ -258,7 +258,7 @@ impl Table {
 	}
 
 	/// Render the table as plain (uncoloured) lines: the header first, then one
-	/// line per row, columns aligned and over-cap cells truncated. Pure — used by
+	/// line per row, columns aligned and over-cap cells truncated. Pure, used by
 	/// the unit tests and shared with [`Table::print`].
 	pub fn render(&self) -> Vec<String> {
 		let widths = self.widths();
@@ -277,8 +277,8 @@ impl Table {
 		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
 		// Every column marker that can tint a cell has to appear here, or a table
 		// that uses only that marker renders plain. `caution_col` was added
-		// without being listed, and it went unnoticed because its first caller —
-		// `volumes` — also sets `identity_col`, so the gate happened to be open.
+		// without being listed, and it went unnoticed because its first caller,
+		// `volumes`, also sets `identity_col`, so the gate happened to be open.
 		let colour = self.colours_any_column() && super::stdout_colored();
 		for (i, row) in self.rows.iter().enumerate() {
 			let key = self.keys.get(i).and_then(Option::as_deref);

--- a/internal/ui/table_tests.rs
+++ b/internal/ui/table_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// Cell contents come from outside podup — an image tag, a container name, a
+/// Cell contents come from outside podup: an image tag, a container name, a
 /// volume driver, a process argv. A raw escape sequence in one repaints the
 /// caller's terminal and desynchronises podup's own colour resets, so every
 /// row after it inherits whatever was injected.
@@ -21,7 +21,7 @@ fn a_cell_cannot_drive_the_terminal() {
 #[test]
 fn caution_style_distinguishes_yes_from_no() {
 	assert_ne!(caution_style("yes"), caution_style("no"));
-	// Padding must not change the answer — cells reach it already padded.
+	// Padding must not change the answer; cells reach it already padded.
 	assert_eq!(caution_style("yes  "), caution_style("yes"));
 }
 
@@ -45,7 +45,7 @@ fn caution_col_survives_rendering() {
 
 /// A table whose only marker is `caution_col` still colours. The gate in
 /// `print` listed `status_col` and `identity_col` only, and the first caution
-/// caller set `identity_col` too — so the omission was invisible.
+/// caller set `identity_col` too, so the omission was invisible.
 #[test]
 fn a_caution_only_table_still_colours() {
 	let t = Table::new(&["NAME", "EXTERNAL"]).caution_col(1);
@@ -68,7 +68,7 @@ fn a_printable_cell_passes_through() {
 }
 
 /// Escaping happens before padding, so the width a column reserves is the
-/// width actually printed — otherwise an escaped cell overflows its column
+/// width actually printed; otherwise an escaped cell overflows its column
 /// and breaks alignment on every row.
 #[test]
 fn escaping_happens_before_padding() {

--- a/internal/units/bytes.rs
+++ b/internal/units/bytes.rs
@@ -20,7 +20,7 @@ const BINARY_UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
 /// Decimal units, largest exponent last. `EB` is 1000^6; `u64::MAX` is a little
 /// over 18 of them, so this ladder covers the whole input type too.
 ///
-/// `kB` with a lowercase k, which is the SI prefix for kilo — `K` is kelvin.
+/// `kB` with a lowercase k, which is the SI prefix for kilo; `K` is kelvin.
 /// This is not pedantry about the standard: it is what the tools this table is
 /// compared against print. `podman images` rendered `805 kB` on Podman 5.7.0,
 /// and every other prefix from mega up is uppercase in the same output.
@@ -59,13 +59,13 @@ pub(crate) enum SizeShape {
 	/// `805kB`, `1.01GB`.
 	///
 	/// This is what podman and docker print, measured on Podman 5.7.0 and
-	/// docker compose v5.1.3 rather than assumed — `podman images` rendered
+	/// docker compose v5.1.3 rather than assumed: `podman images` rendered
 	/// `1.01 GB`, `101 MB` and `103 MB`, and `docker compose images` rendered
 	/// `98.2MB`, all three digits wide. A fixed decimal count cannot express it:
 	/// `98.23MB` and `8.71MB` disagree about how many decimals the reference
 	/// uses because the reference is not counting decimals at all.
 	///
-	/// The digit count is also what keeps the column from breathing — every
+	/// The digit count is also what keeps the column from breathing: every
 	/// value is three digits plus its unit, whatever its magnitude.
 	Significant { digits: usize },
 	/// Up to `parts` whole components, largest first, zeros skipped:
@@ -73,7 +73,7 @@ pub(crate) enum SizeShape {
 	///
 	/// No caller yet: the surfaces that want it are `ps --size` and the volume
 	/// accounting in #1304. Exercised by this module's tests meanwhile, which is
-	/// what the allow covers — it is scoped to the three composite items rather
+	/// what the allow covers; it is scoped to the three composite items rather
 	/// than the module, so anything else going dead here still warns.
 	#[allow(dead_code)]
 	Composite { parts: usize },
@@ -138,7 +138,7 @@ impl SizeFormat {
 	/// means should not have to learn a second rule for `1GB 512MB 200kB`.
 	///
 	/// This is the default *component count*, not a floor on the output. A value
-	/// with fewer components than that still renders only the ones it has —
+	/// with fewer components than that still renders only the ones it has:
 	/// three is what a caller gets when it does not choose, never padding.
 	///
 	/// [`DurationFormat::default_parts`]: super::DurationFormat::default_parts
@@ -164,7 +164,7 @@ enum Precision {
 impl Precision {
 	/// Decimal places for a value already reduced onto its unit.
 	///
-	/// Callers hand over a value of at least one — unit selection guarantees it,
+	/// Callers hand over a value of at least one; unit selection guarantees it,
 	/// since a rung is only taken once the value reaches it. A smaller value is
 	/// still answered rather than underflowing, counting the leading zero as the
 	/// one digit before the point.
@@ -235,7 +235,7 @@ fn single(bytes: u64, base: SizeBase, precision: Precision) -> String {
 	let mut value = bytes as f64 / divisor as f64;
 	let mut decimals = precision.decimals_for(value);
 	// Rounding can carry the value onto the next rung: 1048575 bytes is
-	// 1023.999 KiB, which prints as `1024.00KiB` — right arithmetic, and the
+	// 1023.999 KiB, which prints as `1024.00KiB`: right arithmetic, and the
 	// same unit-boundary artefact the ladder exists to avoid. Promote once,
 	// which is enough: the value was below `step` before rounding, so it cannot
 	// land more than one rung high. At the top rung there is nowhere to go, so

--- a/internal/units/bytes_tests.rs
+++ b/internal/units/bytes_tests.rs
@@ -12,7 +12,7 @@ fn both_ladders_cover_the_whole_input_type() {
 }
 
 /// The regression the ladder was extended for: stopping at `TiB` rendered a
-/// petabyte as `1024.0TiB` — right arithmetic, wrong unit, and nine digits in a
+/// petabyte as `1024.0TiB`: right arithmetic, wrong unit, and nine digits in a
 /// column sized for five.
 #[test]
 fn a_petabyte_does_not_saturate_into_terabytes() {
@@ -97,7 +97,7 @@ fn a_value_that_rounds_onto_the_next_unit_is_promoted() {
 /// makes the test above a promotion rather than an off-by-one.
 #[test]
 fn a_value_that_does_not_round_up_stays_on_its_rung() {
-	// 1048000 bytes is 1023.4KiB, which rounds to 1023.44 — still KiB.
+	// 1048000 bytes is 1023.4KiB, which rounds to 1023.44, still KiB.
 	assert_eq!(format_bytes(1_048_000, &SizeFormat::binary()), "1023.44KiB");
 }
 
@@ -124,7 +124,7 @@ fn the_decimal_count_is_configurable() {
 /// read off a real tool on 2026-08-03: `docker compose` v5.1.3 printed `98.2MB`
 /// for `redis:8-alpine`, and `podman images` printed `1.01 GB`, `101 MB` and
 /// `805 kB` on the same host. Three digits in all of them, which a fixed decimal
-/// count cannot produce — `98.2` has one decimal and `8.71` has two.
+/// count cannot produce: `98.2` has one decimal and `8.71` has two.
 #[test]
 fn significant_digits_match_what_podman_and_docker_print() {
 	let fmt = SizeFormat::decimal().with_significant(3);
@@ -136,7 +136,7 @@ fn significant_digits_match_what_podman_and_docker_print() {
 
 /// The digit count holds across every magnitude, which is the property that
 /// keeps the column from breathing as rows scroll past. A fixed decimal count
-/// gives `1.00GB` and `999.00MB` — four characters apart.
+/// gives `1.00GB` and `999.00MB`, four characters apart.
 #[test]
 fn significant_digits_keep_a_constant_width() {
 	let fmt = SizeFormat::decimal().with_significant(3);
@@ -156,7 +156,7 @@ fn significant_digits_keep_a_constant_width() {
 
 /// A promotion changes the value's magnitude, so the digit count has to be
 /// recomputed for the new rung. Without that, 999999 bytes rounds to `1000kB`
-/// and then renders as `1kB` — the promotion applied and the decimals did not.
+/// and then renders as `1kB`: the promotion applied and the decimals did not.
 #[test]
 fn significant_digits_are_recomputed_after_a_promotion() {
 	let fmt = SizeFormat::decimal().with_significant(3);
@@ -175,7 +175,7 @@ fn significant_digits_do_not_reach_below_a_byte() {
 }
 
 /// A zero-digit request still shows a digit, because `{:.0}` prints one
-/// whatever it is handed. Nothing in the formatter enforces this — it is a
+/// whatever it is handed. Nothing in the formatter enforces this; it is a
 /// property of the format machinery, and it is pinned here so a future clamp
 /// added "to be safe" has something to justify itself against.
 #[test]
@@ -186,7 +186,7 @@ fn a_zero_digit_request_still_renders_a_digit() {
 
 /// Tested one level below `format_bytes` on purpose. Unit selection guarantees
 /// the value handed over is at least one, so the sub-one branch cannot be
-/// reached through the public entry point — a mutation deleting the clamp that
+/// reached through the public entry point: a mutation deleting the clamp that
 /// used to sit here survived every test that went in the front door, which is
 /// what dead defensive code looks like from outside. The clamp is gone; this
 /// pins what the arithmetic actually does, including where it is weak.
@@ -200,7 +200,7 @@ fn the_decimal_count_is_pinned_below_its_public_entry_point() {
 	assert_eq!(Precision::Fixed(4).decimals_for(805.0), 4);
 	// Sub-one values count their leading zero as the digit before the point.
 	// That means one significant digit of 0.5 asks for no decimals and renders
-	// `0` — a real weakness, and unreachable, so it is recorded rather than
+	// `0`, a real weakness, and unreachable, so it is recorded rather than
 	// fixed. If a caller ever hands this a fraction, fix it then.
 	assert_eq!(Precision::Significant(3).decimals_for(0.5), 2);
 	assert_eq!(Precision::Significant(1).decimals_for(0.5), 0);
@@ -226,7 +226,7 @@ fn composite_skips_empty_components() {
 }
 
 /// Asking for more components than the value has yields only the ones that
-/// exist — no `1KiB 0B` padding.
+/// exist: no `1KiB 0B` padding.
 #[test]
 fn composite_stops_when_the_value_runs_out() {
 	let fmt = SizeFormat::binary().with_parts(7);

--- a/internal/units/duration.rs
+++ b/internal/units/duration.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 /// The two do not divide evenly, and that is visible: 364 days reads `12mo 4d`
 /// while 365 reads `1y`. Twelve thirty-day months are 360 days, not a year. The
 /// alternative is a fractional month (365/12 = 30.4167 days), which no reader
-/// can check by hand — the seam is preferred over the arithmetic nobody can
+/// can check by hand: the seam is preferred over the arithmetic nobody can
 /// verify.
 ///
 /// No week. Unlike a month it has no conventional length in a duration context
@@ -45,7 +45,7 @@ pub(crate) enum DurationFormat {
 	///
 	/// The component count is fixed; which units fill it is not. A span that
 	/// just started shows `5s`, one running an hour shows `1h 5m 3s`, and one
-	/// past a year shows `1y 2mo 3d` — the window slides up the ladder as the
+	/// past a year shows `1y 2mo 3d`: the window slides up the ladder as the
 	/// span grows, so the same width always carries the three units that matter
 	/// at that magnitude.
 	Parts(usize),
@@ -53,7 +53,7 @@ pub(crate) enum DurationFormat {
 	/// For machine reading, or when the reader wants to compare two durations
 	/// rather than skim one.
 	///
-	/// No caller yet — the benchmark aggregation is where it lands, and that is
+	/// No caller yet: the benchmark aggregation is where it lands, and that is
 	/// Python today (`bench/aggregate.py`). Exercised by this module's tests
 	/// meanwhile; the allow is on this variant alone so anything else going dead
 	/// here still warns.

--- a/internal/units/mod.rs
+++ b/internal/units/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! Both are configurable, and the defaults belong to the caller rather than to
 //! this module: a table cell has a width budget a summary line does not, and
-//! the right base depends on what the reader is comparing against — podman and
+//! the right base depends on what the reader is comparing against: podman and
 //! docker print decimal, while `free` and `htop` are binary.
 
 mod bytes;

--- a/internal/update/github.rs
+++ b/internal/update/github.rs
@@ -2,7 +2,7 @@
 //!
 //! Talks to GitHub over HTTPS only (rustls + webpki roots via `ureq`). TLS
 //! guards transport, but the downloaded bytes are trusted only after the
-//! Ed25519 signature check in [`super::verify`] — a compromised endpoint cannot
+//! Ed25519 signature check in [`super::verify`]: a compromised endpoint cannot
 //! produce a binary that passes that check.
 
 use std::io::Read;
@@ -30,7 +30,7 @@ const CONNECT_TIMEOUT_SECS: u64 = 30;
 const TOTAL_TIMEOUT_SECS: u64 = 300;
 
 /// Transport failures are retried this many times in total, with exponential
-/// backoff (1s, 2s) between attempts. HTTP 4xx responses are not retried —
+/// backoff (1s, 2s) between attempts. HTTP 4xx responses are not retried;
 /// they are deterministic, not transient.
 const ATTEMPTS: u32 = 3;
 
@@ -67,7 +67,7 @@ impl GitHubSource {
 		}
 	}
 
-	/// Construct with overridden host bases — test seam for the transport-error
+	/// Construct with overridden host bases: test seam for the transport-error
 	/// path (point at a closed local port to force a connection failure).
 	#[cfg(test)]
 	fn with_bases(repo: impl Into<String>, api_base: &str, dl_base: &str) -> Self {
@@ -156,7 +156,7 @@ impl ReleaseSource for GitHubSource {
 
 	fn fetch(&self, asset: &str) -> crate::Result<Vec<u8>> {
 		// Pinned to the latest release; `ureq` follows GitHub's redirect to the
-		// asset host. Always HTTPS — the URL is a compile-time constant scheme.
+		// asset host. Always HTTPS; the URL is a compile-time constant scheme.
 		let url = format!(
 			"{}/{}/releases/latest/download/{asset}",
 			self.dl_base, self.repo

--- a/internal/update/github_tests.rs
+++ b/internal/update/github_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// A reader that yields zero bytes forever — used to exercise the cap.
+/// A reader that yields zero bytes forever, used to exercise the cap.
 struct Endless;
 impl Read for Endless {
 	fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
@@ -69,7 +69,7 @@ fn latest_version_maps_transport_error() {
 	// https so the request reaches a socket. Port 1 is closed, so the failure
 	// is a connection refusal: offline, deterministic, and genuinely the
 	// transport path this test is named for. An http base would never get
-	// that far — the agent rejects the scheme first, which is what this test
+	// that far: the agent rejects the scheme first, which is what this test
 	// used to measure while claiming to measure the socket.
 	use crate::update::ReleaseSource;
 	let src = GitHubSource::with_bases(REPO, "https://127.0.0.1:1", "https://127.0.0.1:1");

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -155,8 +155,8 @@ pub(crate) fn restore_from_backup(target: &Path, backup: &Path) -> crate::Result
 
 /// How long to keep retrying a spawn that reports ETXTBSY.
 ///
-/// The window is short by nature — it lasts only as long as some other process
-/// holds a write descriptor to the file across its own exec — so a second is
+/// The window is short by nature (it lasts only as long as some other process
+/// holds a write descriptor to the file across its own exec) so a second is
 /// generous. Bounded on purpose: a binary that is genuinely unrunnable must
 /// reach the rollback, not wedge the updater retrying forever.
 #[cfg(unix)]
@@ -165,7 +165,7 @@ const TEXT_FILE_BUSY_BUDGET: std::time::Duration = std::time::Duration::from_sec
 /// Spawn `target --version`, retrying while the kernel says the file is still
 /// open for writing somewhere.
 ///
-/// ETXTBSY is not a property of the binary — it means another process holds a
+/// ETXTBSY is not a property of the binary: it means another process holds a
 /// write descriptor to it across its own `exec`, and `O_CLOEXEC` does not close
 /// that window. Treating it as a failed self-test rolls back a signed, verified,
 /// perfectly good update over a race that resolves in milliseconds, and tells
@@ -260,7 +260,7 @@ pub(crate) fn self_test(target: &Path, expected_version: &str) -> crate::Result<
 	if !reported_matches {
 		return Err(ComposeError::Update(format!(
 			"updated binary reports {:?} instead of the resolved release version \
-			 {expected_version} — possible release-metadata tampering (rollback)",
+			 {expected_version}; possible release-metadata tampering (rollback)",
 			out.trim()
 		)));
 	}
@@ -314,8 +314,8 @@ pub(crate) fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::
 		//
 		// **Neither flag is reachable from a test, and that is a property of what
 		// they guard rather than a gap.** The `remove_file` above already unlinks
-		// any symlink planted beforehand — measured: after it, the link is gone
-		// and its victim is untouched — so what is left for these flags is the
+		// any symlink planted beforehand (measured: after it, the link is gone
+		// and its victim is untouched) so what is left for these flags is the
 		// window *between* that unlink and this open. Closing a race is exactly
 		// the thing an in-process test cannot enter. Mutations removing either
 		// one survive the suite; the third property of this call, the 0600 mode,
@@ -390,7 +390,7 @@ pub(crate) fn swap_into_place(tmp: &Path, target: &Path) -> crate::Result<()> {
 		std::fs::rename(target, &backup).map_err(|e| rename_error(e, target))?;
 	}
 	if let Err(e) = std::fs::rename(tmp, target) {
-		// Roll back so the user is not left without a binary — but only when
+		// Roll back so the user is not left without a binary, but only when
 		// we created the backup in this call. A pre-existing `.old` (the L5
 		// swap path) is the caller's responsibility to restore.
 		if target_existed {

--- a/internal/update/install/tests.rs
+++ b/internal/update/install/tests.rs
@@ -40,8 +40,8 @@ fn install_at_replaces_contents() {
 ///
 /// `write_temp` copies the target's permissions so an install keeps whatever
 /// mode the operator chose, and masks with `& 0o777` on the way. Without the
-/// mask, a target that had been made setuid — by tampering, or by an
-/// operator who did it on purpose once — would hand the freshly installed
+/// mask, a target that had been made setuid (by tampering, or by an
+/// operator who did it on purpose once) would hand the freshly installed
 /// podup the same bit, on a binary that has just been fetched over the
 /// network. That is a privilege-escalation footgun, and it is the one
 /// property of this function a test can actually observe.
@@ -134,7 +134,7 @@ fn install_at_fails_when_target_dir_is_missing() {
 	assert!(!missing.exists(), "must not create the missing parent dir");
 }
 /// #1360 (L5): the L5 swap window. The previous in-memory `Vec<u8>` backup
-/// was one-shot — a kill between the swap and the self-test dropped the
+/// was one-shot: a kill between the swap and the self-test dropped the
 /// in-memory copy and the user was left without a working binary. The
 /// fix is `move_target_aside` before the swap: the `.old` sibling survives
 /// any kill in the window, so the self-test has a recoverable copy on disk.
@@ -192,7 +192,7 @@ fn restore_from_backup_round_trips_the_old_binary() {
 fn move_target_aside_is_a_no_op_when_the_target_does_not_exist() {
 	let dir = tempfile::tempdir().unwrap();
 	let target = dir.path().join("podup");
-	// No target to begin with — the move-aside must still return a
+	// No target to begin with, so the move-aside must still return a
 	// backup path (the caller always has a place to roll back to / from).
 	let backup = move_target_aside(&target).expect("the move-aside must succeed");
 	assert!(
@@ -207,7 +207,7 @@ fn move_target_aside_is_a_no_op_when_the_target_does_not_exist() {
 /// target is replaced atomically. The L5 swap path adds a `move_target_aside`
 /// *before* `install_at`, but the public surface (`install_at`) is the
 /// building block tested here. The new `.old` sibling should not leak
-/// to a directory that did not previously have one — the `.old` belongs
+/// to a directory that did not previously have one: the `.old` belongs
 /// to the L5 caller, not to `install_at`.
 #[test]
 fn install_at_does_not_leave_an_old_sibling() {
@@ -218,7 +218,7 @@ fn install_at_does_not_leave_an_old_sibling() {
 	let old_sibling = dir.path().join("podup.old");
 	assert!(
 		!old_sibling.exists(),
-		"install_at must not create a .old sibling — that is the L5 caller's job"
+		"install_at must not create a .old sibling; that is the L5 caller's job"
 	);
 }
 /// #1367 (L5): the chmod-0000 case the issue's test plan calls out. A binary
@@ -244,7 +244,7 @@ fn install_binary_rolls_back_when_the_target_is_unreadable() {
 	std::fs::write(&target, b"the new binary").unwrap();
 	std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-	// Spawning a chmod-0000 file is a hard PermissionDenied — the self-test
+	// Spawning a chmod-0000 file is a hard PermissionDenied: the self-test
 	// must surface that as a failure, and the rollback must restore the
 	// previous binary. Mirrors the real `install_binary` failure path.
 	let err = self_test(&target, "9.9.9").expect_err("a chmod-0000 binary must fail its self-test");
@@ -292,16 +292,16 @@ fn self_test_passes_for_a_zero_exit_and_fails_otherwise() {
 }
 /// The classification that silently did not work.
 ///
-/// A real executable held open for writing cannot be run — the kernel
-/// returns ETXTBSY — so this produces the genuine errno rather than a
+/// A real executable held open for writing cannot be run (the kernel
+/// returns ETXTBSY) so this produces the genuine errno rather than a
 /// hand-built error, and asserts the predicate the retry depends on. The
 /// previous version of this check ran on an error already formatted into a
 /// `String`, where the errno no longer exists: it returned false every time,
 /// the retry never fired, and the flake it was written to prevent stayed.
 ///
 /// Linux only, deliberately. Whether a given kernel refuses to exec a file
-/// held open for writing — and for a script, whether the check lands on the
-/// script or on its interpreter — is that kernel's business, verified on
+/// held open for writing, and for a script whether the check lands on the
+/// script or on its interpreter, is that kernel's business, verified on
 /// Linux. Asserting it elsewhere tests the platform rather than the
 /// classifier, and writing the test so it passes vacuously where ETXTBSY
 /// never fires would repeat the mistake this whole change is about. The
@@ -337,7 +337,7 @@ fn a_binary_open_for_writing_is_classified_as_text_file_busy() {
 fn self_test_rejects_a_version_mismatch() {
 	let dir = tempfile::tempdir().unwrap();
 	// A genuinely-signed but *older* replayed release exits 0 yet reports the
-	// wrong version — the rollback gate must reject it.
+	// wrong version, so the rollback gate must reject it.
 	let p = write_stub(
 		dir.path(),
 		"older",

--- a/internal/update/mod.rs
+++ b/internal/update/mod.rs
@@ -5,7 +5,7 @@
 //! `SHA256SUMS` manifest. The manifest's Ed25519 signature is verified against
 //! the public keys embedded in this binary (`verify::RELEASE_PUBKEYS`); only
 //! then is the binary's digest checked against the manifest and the running
-//! executable atomically replaced. Every step fails closed — a missing key,
+//! executable atomically replaced. Every step fails closed: a missing key,
 //! bad signature, or checksum mismatch aborts before anything is written.
 
 mod github;

--- a/internal/update/mod_tests.rs
+++ b/internal/update/mod_tests.rs
@@ -93,7 +93,7 @@ fn newer_release_with_real_install_path() {
 	};
 
 	// The manifest is internally consistent but signed with a throwaway key,
-	// not the embedded release key — verification must fail closed, proving
+	// not the embedded release key, so verification must fail closed, proving
 	// the gate rejects anything not signed by the real key.
 	let err = run_with(&src, "0.6.0", UpdateOptions::default()).unwrap_err();
 	assert!(matches!(err, ComposeError::Update(_)));

--- a/internal/update/pkg.rs
+++ b/internal/update/pkg.rs
@@ -23,7 +23,7 @@ use crate::ComposeError;
 /// Both path checks can be wrong in one direction only, which is the direction
 /// that matters. A layout that merely looks like Homebrew's or Scoop's makes
 /// podup refuse to self-update and send the user to a package manager that does
-/// not own it — wrong, visible, and recoverable by hand. The opposite mistake,
+/// not own it: wrong, visible, and recoverable by hand. The opposite mistake,
 /// missing a managed install, silently rewrites a file whose manager still
 /// believes it knows the contents. These heuristics are shaped to fail the
 /// first way.
@@ -49,9 +49,9 @@ pub fn managing_package_manager() -> Option<&'static str> {
 /// Homebrew installs every formula under `<prefix>/Cellar/<name>/<version>/`
 /// and links a symlink into `<prefix>/bin`, so the caller's `canonicalize`
 /// resolves into the Cellar whichever of the two the user invoked. The prefix
-/// itself moves — `/opt/homebrew` on Apple silicon, `/usr/local` on Intel,
-/// `/home/linuxbrew/.linuxbrew` on Linux, anywhere at all for a custom install
-/// — but the `Cellar` component does not, which is what makes it the thing to
+/// itself moves (`/opt/homebrew` on Apple silicon, `/usr/local` on Intel,
+/// `/home/linuxbrew/.linuxbrew` on Linux, anywhere at all for a custom install)
+/// but the `Cellar` component does not, which is what makes it the thing to
 /// match rather than any of the prefixes.
 fn homebrew_owns(path: &Path) -> bool {
 	path.components()
@@ -73,7 +73,7 @@ fn scoop_owns(path: &Path) -> bool {
 
 /// The body of [`scoop_owns`] with the root passed in rather than read from the
 /// environment, so the configured-root branch can be tested without mutating
-/// `SCOOP` — which in a parallel test binary is a race against every other test
+/// `SCOOP`, which in a parallel test binary is a race against every other test
 /// in the process rather than a fixture.
 fn scoop_owns_under(path: &Path, root: Option<&Path>) -> bool {
 	if let Some(root) = root {
@@ -96,7 +96,7 @@ fn scoop_owns_under(path: &Path, root: Option<&Path>) -> bool {
 /// The primary check is `dpkg-query -S <path>`. Crucially this must not *fail
 /// open*: if the helper cannot be spawned (missing, not executable, or denied)
 /// we do not fall back to scanning dpkg's on-disk file lists directly
-/// (`/var/lib/dpkg/info/*.list`) — that directory is owned by another package
+/// (`/var/lib/dpkg/info/*.list`): that directory is owned by another package
 /// and we have no guarantee of its mode, ownership, or the validity of its
 /// contents. Reading it opens a window where a tampered target file's path
 /// could be planted inside the listing directory to make self-update refuse
@@ -154,7 +154,7 @@ pub(crate) enum GlyndorAutoUpdate {
 /// **And a third way to be stuck.** `Package-Blacklist` vetoes by name, so an
 /// allowed origin is not sufficient on its own.
 ///
-/// The origin match is deliberately loose — any entry mentioning `Glyndor`
+/// The origin match is deliberately loose: any entry mentioning `Glyndor`
 /// counts, rather than `Glyndor:stable` exactly. An operator who allowed a
 /// different Glyndor suite has thought about this and does not need telling;
 /// the machine worth warning is the one whose configuration has never heard of

--- a/internal/update/pkg_tests.rs
+++ b/internal/update/pkg_tests.rs
@@ -28,7 +28,7 @@ fn the_configuration_our_keyring_writes_reads_as_permitted() {
 
 /// The case the first draft of this check would have got wrong. The package's
 /// own README documents `Allowed-Origins` **or** `Origins-Pattern`, so an
-/// operator using the second is covered — and a check that knew only about
+/// operator using the second is covered, and a check that knew only about
 /// the first would have told them nothing will ever update them while their
 /// machine updated itself fine.
 #[test]
@@ -200,7 +200,7 @@ fn test_binary_is_not_package_managed() {
 /// #1360 (L10): `dpkg-query` is the only source of truth for whether apt
 /// owns the running binary. The previous implementation fell back to
 /// reading `/var/lib/dpkg/info/*.list` directly when `dpkg-query` could
-/// not be spawned — a directory owned by another package, with no mode
+/// not be spawned: a directory owned by another package, with no mode
 /// or ownership guarantees. The fix is fail-closed: when `dpkg-query` is
 /// unavailable, report `false` and skip the scan entirely. We exercise
 /// the `Err` arm by removing `dpkg-query` from PATH via

--- a/internal/update/verify.rs
+++ b/internal/update/verify.rs
@@ -1,4 +1,4 @@
-//! Verification primitives for self-update — the security core.
+//! Verification primitives for self-update: the security core.
 //!
 //! Trust anchor is the set of Ed25519 public keys embedded in this binary
 //! ([`RELEASE_PUBKEYS`]), not the download domain or TLS. A release is accepted
@@ -11,11 +11,11 @@ use sha2::{Digest, Sha256};
 
 use crate::ComposeError;
 
-/// Accepted Ed25519 release public keys — at most two. Slot 0 holds the active
+/// Accepted Ed25519 release public keys, at most two. Slot 0 holds the active
 /// release key (`GLYNDOR_RELEASE_ED25519_KEY`); slot 1 is the empty rotation
 /// slot, populated only during a key rotation (see below). A signature is
 /// trusted if it validates under either non-zero slot. The keys are public by
-/// design — their integrity comes from being baked into the signed,
+/// design: their integrity comes from being baked into the signed,
 /// build-provenance-attested binary, so an attacker cannot swap them without
 /// invalidating the binary itself.
 ///
@@ -35,8 +35,8 @@ use crate::ComposeError;
 ///    Every binary from step 1 trusts `new`, so the old key is retired and all
 ///    installs converge on the new key.
 ///
-/// If the outgoing private key is LOST, step 1 is impossible — no release can be
-/// signed by the old key — so fielded self-updaters cannot migrate in-band and
+/// If the outgoing private key is LOST, step 1 is impossible (no release can be
+/// signed by the old key) so fielded self-updaters cannot migrate in-band and
 /// must be re-installed out-of-band (rotated `install.sh` / apt). That happened
 /// here: the key below is a fresh key with no relationship to any previously
 /// embedded key, and slot 1 starts zeroed (the normal steady state) rather than
@@ -47,7 +47,7 @@ pub const RELEASE_PUBKEYS: [[u8; 32]; 2] = [
 		28, 91, 251, 190, 14, 69, 9, 142, 216, 200, 165, 3, 108, 152, 90, 65, 39, 193, 245, 38,
 		232, 36, 100, 155, 148, 155, 69, 108, 185, 139, 31, 51,
 	],
-	// Empty rotation slot — populate during the next key rotation.
+	// Empty rotation slot; populate during the next key rotation.
 	[0u8; 32],
 ];
 
@@ -126,7 +126,7 @@ fn verify_with_keys(keys: &[VerifyingKey], message: &[u8], signature: &[u8]) -> 
 		Ok(())
 	} else {
 		Err(ComposeError::Update(
-			"signature verification failed — release may be tampered or unsigned".to_string(),
+			"signature verification failed; release may be tampered or unsigned".to_string(),
 		))
 	}
 }
@@ -139,7 +139,7 @@ pub fn verify_signature(message: &[u8], signature: &[u8]) -> crate::Result<()> {
 }
 
 /// Verify `signature` against the embedded key using an explicitly supplied key
-/// — test seam so the signature path is exercised without the placeholder guard.
+/// Test seam so the signature path is exercised without the placeholder guard.
 #[cfg(test)]
 pub fn verify_signature_with(
 	key: &VerifyingKey,
@@ -229,7 +229,7 @@ mod tests;
 /// The release key is embedded in four places in this repository, and it has
 /// to be: a consumer that downloaded the key it verifies with would be
 /// handing the decision to whoever controls the download. Duplication is the
-/// correct design here, so the risk is not that copies exist — it is that a
+/// correct design here, so the risk is not that copies exist; it is that a
 /// rotation updates some and misses others.
 ///
 /// A miss is silent. `install.sh` would hand out a binary the self-updater

--- a/internal/update/verify_tests.rs
+++ b/internal/update/verify_tests.rs
@@ -43,7 +43,7 @@ fn embedded_key_is_configured_and_rejects_garbage() {
 #[test]
 fn zeroed_key_would_fail_closed() {
 	// Defence in depth: an all-zero key is a valid curve point, so the
-	// explicit guard in `release_pubkeys` — not the curve math — is what
+	// explicit guard in `release_pubkeys`, not the curve math, is what
 	// refuses to trust an unverifiable release if every key is zeroed.
 	assert!(VerifyingKey::from_bytes(&[0u8; 32]).is_ok());
 	let is_placeholder = |key: [u8; 32]| key == [0u8; 32];

--- a/scripts/verify-release-assets.py
+++ b/scripts/verify-release-assets.py
@@ -3,8 +3,8 @@
 disk, in the staging directory, immediately before the release is published.
 
 This is the substance half of the installer contract. `installer-contract.yml`
-answers a different question — "do `install.sh` and `release.yml` agree on the
-asset *names*?" — by reading both files. That is a cross-reference between two
+answers a different question, "do `install.sh` and `release.yml` agree on the
+asset *names*?", by reading both files. That is a cross-reference between two
 declarations, and reading YAML is the right way to answer it. It cannot answer
 "does the release actually produce these files", because nothing in a workflow
 file is evidence that a step ran.
@@ -21,7 +21,7 @@ matrix outputs in a later step and passed to `gh release create` as an argument,
 so it can never appear as a matrix entry. The check was therefore unpassable by
 construction: failing it was the normal state of a correct release workflow, and
 the only way to pass was to declare a matrix entry named `SHA256SUMS` without
-producing one — the exact lie the check existed to prevent. Measured on
+producing one, the exact lie the check existed to prevent. Measured on
 2026-08-17: no repository in the org declared that asset, podup was the gate's
 only consumer and was still pinned to a tag from before the clause, so the check
 had never run green anywhere. Its first contact with a real repository (the pin
@@ -47,8 +47,8 @@ downloads verifiable.
 
 Conscious non-goals: this does not verify signatures (release.yml already
 re-verifies every `.sig` against the keys consumers embed), does not check file
-contents, and does not talk to GitHub. It answers one question — are the files
-the installer will ask for present — and fails closed on anything it cannot
+contents, and does not talk to GitHub. It answers one question, whether the files
+the installer will ask for are present, and fails closed on anything it cannot
 parse, because an unparsed installer is not evidence of a good release.
 """
 
@@ -59,7 +59,7 @@ import re
 import sys
 from pathlib import Path
 
-# `download "${BASE_URL}/<name>" "<dest>"` — the only shape the install scripts
+# `download "${BASE_URL}/<name>" "<dest>"`, the only shape the install scripts
 # use to pull a file out of the release. Anything fetched from another host
 # (the apt keyring, for example) does not go through BASE_URL and is correctly
 # invisible here.
@@ -100,8 +100,8 @@ def artifact_names_sh(text: str, path: Path) -> set[str]:
 
 
 def artifact_names_ps1(text: str, path: Path) -> set[str]:
-    """Expand install.ps1's $Artifact template. The OS is usually a literal —
-    there being only one Windows — but an interpolation is accepted too."""
+    """Expand install.ps1's $Artifact template. The OS is usually a literal,
+    there being only one Windows, but an interpolation is accepted too."""
     template = PS_ARTIFACT_RE.search(text)
     if not template:
         fail(f'no $Artifact = "..." in {path}.')
@@ -207,7 +207,7 @@ def main() -> None:
             f"{listed}\n"
             f"staged in {args.workdir}: {sorted(p.name for p in args.workdir.iterdir())}\n"
             "Add them to the step that builds the release, not to the workflow's "
-            "asset declarations — this check reads the directory, not the YAML."
+            "asset declarations; this check reads the directory, not the YAML."
         )
 
     print(f"OK: all {len(required)} files the install scripts fetch are staged.")

--- a/tests/build_contract.rs
+++ b/tests/build_contract.rs
@@ -20,7 +20,7 @@ use tempfile::tempdir;
 /// on stderr.
 ///
 /// It used `print!`, contradicting the documented promise that stdout stays
-/// pipeable — the one thing a caller redirecting `podup build > log` relies on,
+/// pipeable, the one thing a caller redirecting `podup build > log` relies on,
 /// and the same promise `config` and `generate quadlet` are built around.
 #[tokio::test]
 async fn build_writes_the_image_id_to_stdout() {

--- a/tests/cli_aliases.rs
+++ b/tests/cli_aliases.rs
@@ -75,7 +75,7 @@ fn help_and_version_are_blank_line_framed() {
 }
 
 /// `-t/--timeout` (shutdown grace) is accepted by every command that stops
-/// containers — up, down, stop, restart — matching docker compose.
+/// containers (up, down, stop, restart) matching docker compose.
 #[test]
 fn timeout_flag_is_accepted_by_stop_commands() {
 	for cmd in ["up", "down", "stop", "restart"] {
@@ -180,7 +180,7 @@ fn run_no_rm_parses_and_is_documented() {
 /// docker-compose is inconsistent with itself here: `docker compose run` spells
 /// the long form `--no-TTY` while `docker compose exec` spells it `--no-tty`.
 /// A script copied from either command has to work, so podup accepts both on
-/// both — a superset of docker rather than a guess at which one is canonical.
+/// both: a superset of docker rather than a guess at which one is canonical.
 #[test]
 fn no_tty_accepts_both_spellings_on_run_and_exec() {
 	for cmd in ["run", "exec"] {

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -1,6 +1,6 @@
 //! CLI-level checks for diagnostic surfacing: forward-compat warnings must be
 //! visible with no `RUST_LOG` set, must go to stderr, and must carry the
-//! `podup:` program prefix — while stdout stays a clean YAML pipe for `config`.
+//! `podup:` program prefix, while stdout stays a clean YAML pipe for `config`.
 
 use std::fs;
 use std::path::PathBuf;
@@ -16,7 +16,7 @@ fn bin() -> &'static str {
 ///
 /// The directory must be unique **per call**, not per process: cargo runs the
 /// tests in one binary as threads, so a path keyed on the pid is shared by every
-/// test in this file. Two tests writing the same compose file then race —
+/// test in this file. Two tests writing the same compose file then race:
 /// `fs::write` truncates before it writes, so a concurrent reader can see an
 /// empty file and fail validation. Returning the [`TempDir`] hands the caller
 /// the directory's lifetime: hold it for the length of the test, and it is
@@ -64,7 +64,7 @@ fn config_warns_on_stderr_with_clean_stdout_and_no_rust_log() {
 		"warning names the unknown key; got stderr:\n{stderr}"
 	);
 
-	// stdout is the resolved YAML only — no diagnostics interleaved.
+	// stdout is the resolved YAML only, with no diagnostics interleaved.
 	assert!(stdout.contains("services:"), "stdout carries the YAML");
 	assert!(
 		!stdout.contains("warning"),
@@ -214,8 +214,8 @@ fn create_rejects_no_recreate_with_force_recreate() {
 		"conflicting recreate flags must be rejected"
 	);
 	// Which rejection, not just that one happened. A non-zero exit here is
-	// satisfied by any failure — a missing compose file, an unreachable Podman,
-	// a panic — none of which exercise the flag conflict this test is named for.
+	// satisfied by any failure (a missing compose file, an unreachable Podman,
+	// a panic) none of which exercise the flag conflict this test is named for.
 	let err = String::from_utf8_lossy(&output.stderr);
 	assert!(
 		err.contains("--no-recreate") && err.contains("--force-recreate"),
@@ -287,7 +287,7 @@ fn config_no_interpolate_skips_required_var_error() {
 /// `update` only rewrites the podup binary, so the compose-only global value
 /// flags (--socket/--profile/--env-file/--project-directory) cannot affect it.
 /// Passing one on the command line is rejected as a usage error rather than
-/// silently accepted as a no-op — and the rejection happens before any network
+/// silently accepted as a no-op, and the rejection happens before any network
 /// access, so the test never reaches GitHub.
 ///
 /// Gated on the `update` feature: package-manager builds (Debian/apt) compile
@@ -322,7 +322,7 @@ fn update_rejects_compose_only_global_flags() {
 /// The `-f -` form enforces the same 16 MiB read cap the file path does.
 ///
 /// The cap exists so a pathological compose document cannot exhaust memory, and
-/// the generic reader that implements it is unit-tested — but with an explicit
+/// the generic reader that implements it is unit-tested, but with an explicit
 /// limit passed in. **Nothing checked that the stdin call site passes
 /// `MAX_FILE_BYTES` rather than something larger**, which a mutation replacing it
 /// with `u64::MAX` proved by surviving the whole suite.
@@ -405,8 +405,8 @@ fn stdin_just_under_the_cap_is_accepted() {
 /// A compose file past the 16 MiB cap is refused, the same as stdin.
 ///
 /// The cap is a bound on what a single trusted-but-unbounded input can make
-/// podup allocate. `read_capped_from` implements it and is unit-tested — with an
-/// explicit limit passed in — so **what was untested is that the real call sites
+/// podup allocate. `read_capped_from` implements it and is unit-tested, with an
+/// explicit limit passed in, so **what was untested is that the real call sites
 /// pass `MAX_FILE_BYTES`**. A mutation raising the constant to a terabyte left
 /// the whole lib and bins suite green, which is what a control nothing exercises
 /// looks like from outside.

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -252,7 +252,7 @@ fn missing_subcommand_exits_non_zero() {
 	);
 	// The group's own usage, not the root's. Until #1293 this printed
 	// `Usage: podup [OPTIONS] <COMMAND>` and listed every top-level command,
-	// withholding the one thing the user needed — what `generate` accepts —
+	// withholding the one thing the user needed, what `generate` accepts,
 	// which its own `--help` had been answering correctly all along.
 	let gen_err = String::from_utf8_lossy(&gen.stderr);
 	assert!(
@@ -383,10 +383,10 @@ fn config_projections_render_lists() {
 /// that a script written against docker compose runs unchanged. Docker declares
 /// it as a bare boolean; podup declared it as one that demands a value, so
 /// `docker compose attach --sig-proxy web` came back as a usage error and exit
-/// 2 — a no-op flag rejecting the command it was supposed to tolerate.
+/// 2, a no-op flag rejecting the command it was supposed to tolerate.
 ///
 /// Asserted as "not a clap error": these never reach Podman, so the run fails
-/// later on the missing compose file, which is exactly the point — parsing got
+/// later on the missing compose file, which is exactly the point: parsing got
 /// past the flag.
 #[test]
 fn sig_proxy_accepts_dockers_bare_form_and_an_explicit_value() {
@@ -405,14 +405,14 @@ fn sig_proxy_accepts_dockers_bare_form_and_an_explicit_value() {
 }
 
 /// Bare `podup` is the first screen anyone sees after installing, and it was
-/// the one help path that rendered without colour — every other screen had it,
+/// the one help path that rendered without colour, while every other screen had it,
 /// so podup looked like a tool that does not colourise at all.
 ///
 /// This checks the piped side, which is what a test harness can observe: the
 /// help must reach **stderr** (it is a usage error, not output), carry no
 /// escape codes when stderr is not a terminal, and stay on exit 2. The coloured
 /// side is verified by running it under a pty, which no `Command::output()`
-/// test can do — 50 escapes against 0 before.
+/// test can do: 50 escapes against 0 before.
 #[test]
 fn bare_podup_prints_help_to_stderr_and_stays_plain_when_piped() {
 	let out = Command::new(bin())
@@ -440,7 +440,7 @@ fn bare_podup_prints_help_to_stderr_and_stays_plain_when_piped() {
 /// of podup's env-backed globals.
 ///
 /// `arg_required_else_help` only fires when there are NO arguments at all, and
-/// an env-sourced one counts — so with `COMPOSE_PROJECT_NAME` or
+/// an env-sourced one counts, so with `COMPOSE_PROJECT_NAME` or
 /// `PODMAN_SOCKET` exported, which is the normal state of a real deployment,
 /// bare `podup` printed a wall of forty-five subcommand names instead of its
 /// help. This is how CI found it: the runner had one of them set and my first
@@ -475,7 +475,7 @@ fn bare_podup_prints_the_same_help_with_env_globals_set() {
 /// colour in the test harness anyway, so a weaker version of this test would
 /// pass without proving anything. Only stdout is checked: a connection
 /// failure prints its `error:` banner to stderr, which is a human diagnostic
-/// and is allowed to be coloured like any other podup error — the guarantee
+/// and is allowed to be coloured like any other podup error; the guarantee
 /// under test is about the machine-parseable stream, not every byte podup
 /// writes.
 #[test]

--- a/tests/dependabot_covers_every_lockfile.rs
+++ b/tests/dependabot_covers_every_lockfile.rs
@@ -58,7 +58,7 @@ fn directories_needing_an_entry() -> Vec<String> {
 
 	// Anchored to the `[workspace]` table on purpose. `Cargo.toml` carries a
 	// second `exclude`, under `[package]`, listing what `cargo package` leaves
-	// out of the crate archive — and the file says so in a comment right above
+	// out of the crate archive, and the file says so in a comment right above
 	// it: "Not to be confused with `[workspace] exclude`". Matching the first
 	// `exclude` in the file finds that one, whose entries are not crates, so the
 	// derived list comes back as just `/` and the coverage test passes by having
@@ -118,11 +118,11 @@ fn every_cargo_lockfile_has_a_dependabot_entry() {
 	// least the entry for it.
 	assert!(
 		present.contains(&"/".to_string()),
-		"no workspace entry derived — the scanner is reading the wrong tree: {present:?}"
+		"no workspace entry derived; the scanner is reading the wrong tree: {present:?}"
 	);
 	// The floor that matters, and the one the first version of this test did not
 	// have. `Cargo.toml` excludes two crates, so a derived list of just `/` means
-	// the parser broke rather than that there is nothing to cover — and with
+	// the parser broke rather than that there is nothing to cover, and with
 	// nothing to cover, the comparison below passes while checking nothing. That
 	// is exactly how the first version passed against the wrong `exclude` key.
 	assert!(
@@ -133,14 +133,14 @@ fn every_cargo_lockfile_has_a_dependabot_entry() {
 	);
 	assert!(
 		declared.contains(&"/".to_string()),
-		"no cargo entry for / — the parser is not reading dependabot.yml: {declared:?}"
+		"no cargo entry for /; the parser is not reading dependabot.yml: {declared:?}"
 	);
 
 	let missing: Vec<&String> = present.iter().filter(|d| !declared.contains(d)).collect();
 	assert!(
 		missing.is_empty(),
 		"these crates are excluded from the workspace, so they carry their own Cargo.lock, \
-		 and no Dependabot cargo entry names them — nothing ever updates them: {missing:?}. \
+		 and no Dependabot cargo entry names them, so nothing ever updates them: {missing:?}. \
 		 Declared: {declared:?}"
 	);
 }

--- a/tests/docs_flags.rs
+++ b/tests/docs_flags.rs
@@ -1,7 +1,7 @@
 //! `docs/commands.md` must document every flag the CLI actually accepts.
 //!
 //! The command reference was written per command by hand and drifted every time
-//! a flag landed — #1084 counted fourteen commands with missing flags and one
+//! a flag landed: #1084 counted fourteen commands with missing flags and one
 //! precedence rule that was simply false. Fixing the text once only resets the
 //! clock; this test is what stops it recurring, by diffing `--help` against the
 //! document rather than trusting either.
@@ -12,14 +12,14 @@
 //! message ambiguous.
 //!
 //! The match is scoped to the command's own `###` section. Searching the whole
-//! document — which this did until #1132 — means a flag documented anywhere
+//! document (which this did until #1132) means a flag documented anywhere
 //! satisfies every command, so eight flags sat undocumented in their own tables
 //! while the test stayed green. Scoping it is also the honest reading of what
 //! the test claims to check: that a reader looking up `create` finds `--pull`
 //! under `create`, not somewhere else entirely.
 //!
 //! It still checks names, never descriptions. A row can say the opposite of
-//! what the code does and this will not notice — `exec`'s pseudo-TTY shipped
+//! what the code does and this will not notice: `exec`'s pseudo-TTY shipped
 //! next to "podup never allocates one" (#1079), and `commit --pause` documented
 //! a default of off while the code defaults it on (#1132).
 
@@ -72,7 +72,7 @@ const COMMANDS: [&str; 29] = [
 /// The lines of `docs/commands.md` documenting one command: from its `###`
 /// heading to the next heading of any level.
 ///
-/// Headings carry their positional arguments — ``### `cp <SRC> <DST>` `` — so a
+/// Headings carry their positional arguments (``### `cp <SRC> <DST>` ``) so a
 /// command matches when the first backticked word of the heading is its name.
 /// `pause` and `unpause` share one heading, which the `/`-separated form covers.
 fn section_for(docs: &str, cmd: &str) -> Option<String> {
@@ -102,7 +102,7 @@ fn every_cli_flag_is_documented() {
 		.expect("read docs/commands.md");
 
 	// clap marks the compose-wide options `global`, so every command's `--help`
-	// reprints them — but they are documented once, in the global table, not in
+	// reprints them, but they are documented once, in the global table, not in
 	// each command's own. Subtract them or the per-command check demands that
 	// `--socket` be listed under all twenty-nine.
 	let global = Command::new(bin())
@@ -164,7 +164,7 @@ fn every_global_flag_is_documented() {
 /// The CLI names the open standard, not another vendor's product.
 ///
 /// `podup` implements the **Compose Spec**, which is a published standard with
-/// its own name — so saying "Compose" is both brand-free and more accurate than
+/// its own name, so saying "Compose" is both brand-free and more accurate than
 /// naming a particular implementation of it.
 ///
 /// The one allowed exception is a literal filename. `docker-compose.yaml` is

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -2,7 +2,7 @@
 //!
 //! All tests skip gracefully when Podman is not reachable, so they are safe to
 //! run on a machine without it. Set `PODUP_REQUIRE_PODMAN=1` where Podman is
-//! guaranteed — the nested-virt lane does — and an unreachable Podman becomes a
+//! guaranteed (the nested-virt lane does) and an unreachable Podman becomes a
 //! hard failure rather than a suite that reports `ok` having run nothing.
 //!
 //! The test bodies are split across the `engine_integration/` submodules to
@@ -22,7 +22,7 @@ use podup::{parse_files_with_env_files, parse_str, Client, Engine};
 /// `tracing` is a facade: a `warn!` with no subscriber installed in the process
 /// is discarded silently. `main` installs one, but every integration test runs
 /// in a process that never calls `main`, so the instrumentation compiled, passed
-/// review, merged — and emitted nothing on the lane, which is the one place it
+/// review, merged, and emitted nothing on the lane, which is the one place it
 /// was written to answer a question.
 ///
 /// libtest captures output and prints it only for tests that fail, which is
@@ -51,13 +51,13 @@ async fn podman() -> Option<Client> {
 		};
 	// Skipping is the right default: these tests must not fail on a developer
 	// machine without Podman. But a silent skip reports `ok` for a test that
-	// executed nothing, and libtest counts it as passed — so an environment
+	// executed nothing, and libtest counts it as passed, so an environment
 	// where Podman never came up looks identical to a clean run. Somewhere that
 	// Podman is guaranteed (the nested-virt lane), set PODUP_REQUIRE_PODMAN and
 	// the skip becomes a hard failure instead of a green lie.
 	assert!(
 		!(connected.is_none() && std::env::var_os("PODUP_REQUIRE_PODMAN").is_some()),
-		"PODUP_REQUIRE_PODMAN is set but Podman is unreachable — refusing to report this suite as passing without running it"
+		"PODUP_REQUIRE_PODMAN is set but Podman is unreachable; refusing to report this suite as passing without running it"
 	);
 	connected
 }
@@ -74,7 +74,7 @@ fn bin() -> &'static str {
 
 /// Run the built `podup` and hand back whatever it did, checking nothing.
 ///
-/// For calls whose outcome the test does not depend on — teardown, mostly. When
+/// For calls whose outcome the test does not depend on, teardown mostly. When
 /// a later assertion depends on this command having worked, use [`run_ok`].
 #[allow(dead_code)]
 fn run(args: &[&str]) -> std::process::Output {
@@ -88,7 +88,7 @@ fn run(args: &[&str]) -> std::process::Output {
 ///
 /// Setting a test up with [`run`] and then asserting on the effect throws away
 /// the evidence of what went wrong. `create_makes_containers_without_starting_them`
-/// discarded an `up -d` and reported `left: 0, right: 1` — true, and unable to
+/// discarded an `up -d` and reported `left: 0, right: 1`: true, and unable to
 /// say whether `up` failed or whether it worked and the container died (#1340).
 ///
 /// The failure is invisible while the environment is healthy and surfaces

--- a/tests/engine_integration/autostart_quadlet.rs
+++ b/tests/engine_integration/autostart_quadlet.rs
@@ -1,12 +1,12 @@
 //! Quadlet-mode autostart against real Podman **and real systemd `--user`**.
 //!
-//! The install/uninstall/rebuild flow shipped covered by unit tests only — a
-//! fake `SystemCtl` plus the pure renderer tests — so nothing exercised the part
+//! The install/uninstall/rebuild flow shipped covered by unit tests only (a
+//! fake `SystemCtl` plus the pure renderer tests) so nothing exercised the part
 //! that actually breaks: units written to the systemd directory, generated,
 //! started, and the containers coming up. #1091 is what that gap costs. Its bug
 //! (a relative `EnvironmentFile=` resolving against the unit directory once
 //! installed) is invisible to every renderer test, because the rendered text was
-//! exactly what the test expected — it only fails when systemd reads it.
+//! exactly what the test expected; it only fails when systemd reads it.
 //!
 //! **These tests touch the caller's real systemd.** `systemd --user` reads
 //! `XDG_CONFIG_HOME` from the manager process, set at login, so a test process
@@ -17,7 +17,7 @@
 //! * every test uses a per-process project name, so a run cannot collide with
 //!   another run, with the developer's own stacks, or with a sibling test;
 //! * cleanup runs from `Drop`, so a panic mid-test cannot leave an enabled unit
-//!   behind. That is not tidiness — a leaked quadlet unit starts its container
+//!   behind. That is not tidiness: a leaked quadlet unit starts its container
 //!   on the user's next boot.
 //!
 //! They skip when Podman or `systemd --user` is unreachable, which is every
@@ -100,7 +100,7 @@ fn fixture(tag: &str) -> (tempfile::TempDir, PathBuf) {
 }
 
 /// Install writes the units, systemd generates and starts them, and uninstall
-/// leaves nothing behind — the whole round trip, through the real generator.
+/// leaves nothing behind: the whole round trip, through the real generator.
 #[tokio::test]
 async fn quadlet_autostart_installs_starts_and_uninstalls() {
 	if super::podman().await.is_none() || !systemd_user_available() {
@@ -128,7 +128,7 @@ async fn quadlet_autostart_installs_starts_and_uninstalls() {
 	assert!(unit.is_file(), "unit not written to {}", unit.display());
 
 	// The generator runs on `daemon-reload`, so the service exists only if the
-	// unit it produced was valid — a unit Quadlet rejects silently yields no
+	// unit it produced was valid: a unit Quadlet rejects silently yields no
 	// service at all, which is the failure mode a renderer test cannot see.
 	let service = format!("{project}-web.service");
 	let mut active = false;
@@ -152,8 +152,8 @@ async fn quadlet_autostart_installs_starts_and_uninstalls() {
 ///
 /// This is the one the renderer could not catch. The generated
 /// `EnvironmentFile=` was exactly the string the unit tests asserted; it was
-/// systemd resolving it against the unit's own directory — not the compose
-/// file's — that made `--env-file` fatal on a path that does not exist there, so
+/// systemd resolving it against the unit's own directory, not the compose
+/// file's, that made `--env-file` fatal on a path that does not exist there, so
 /// the container never started.
 #[tokio::test]
 async fn quadlet_autostart_resolves_a_relative_env_file() {
@@ -197,7 +197,7 @@ async fn quadlet_autostart_resolves_a_relative_env_file() {
 	}
 	assert!(
 		active,
-		"{service} never became active — a relative env_file that resolves against \
+		"{service} never became active: a relative env_file that resolves against \
 		 the unit directory makes --env-file fatal, so the container cannot start"
 	);
 

--- a/tests/engine_integration/build_images.rs
+++ b/tests/engine_integration/build_images.rs
@@ -15,7 +15,7 @@ async fn build_with_target_stage() {
 		None => return,
 	};
 	let dir = tempfile::tempdir().unwrap();
-	// Multi-stage Dockerfile — build with target: base covers build.rs L77.
+	// Multi-stage Dockerfile: build with target: base covers build.rs L77.
 	// Each stage leaves its name on disk, so which one was built is readable from
 	// inside the container. With `RUN echo` alone both stages produce an image
 	// that looks the same from outside, and a build that ignored `target:`
@@ -74,7 +74,7 @@ async fn build_with_args_and_extra_tags() {
 	engine.up(&file).await.unwrap();
 	// Two separate problems, both of which made the old version unfalsifiable.
 	// `RUN echo` leaves nothing in the image, so a build that dropped the arg
-	// produced a byte-identical result — hence writing the value to a file. And
+	// produced a byte-identical result, hence writing the value to a file. And
 	// the `$$` is load-bearing: compose substitutes `$VERSION` in the YAML before
 	// the Dockerfile is ever assembled, so the single-dollar form the old test
 	// used reached the build as an empty string and the ARG was never exercised
@@ -253,8 +253,8 @@ async fn explicit_network_created() {
 
 	engine.up(&file).await.unwrap();
 	// These two are NOT mutation-proved, and the reason is worth keeping. Both
-	// mutations I tried — never creating declared networks, and creating them
-	// under a different name — take `up` itself down, because the container
+	// mutations I tried (never creating declared networks, and creating them
+	// under a different name) take `up` itself down, because the container
 	// references a network that is then missing. So the old `up().unwrap()` did
 	// already cover "the network exists under the name the container expects".
 	//
@@ -317,7 +317,7 @@ async fn secret_long_form_ref() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	// `cat` alone only proves the path exists — it exits 0 on an empty or wrong
+	// `cat` alone only proves the path exists: it exits 0 on an empty or wrong
 	// file, and says nothing about the `mode:`/`uid:` the compose file asks for.
 	// Check the content and the permissions the long form actually requested.
 	let read = engine
@@ -436,7 +436,7 @@ async fn external_secret_injected_into_container() {
 	let proj = proj("insec");
 	let secret_name = format!("{proj}-tok");
 
-	// Create the backing Podman secret out-of-band — the external-secret idiom.
+	// Create the backing Podman secret out-of-band, the external-secret idiom.
 	// Skip the test if the podman CLI is unavailable (socket alone is not enough).
 	let dir = tempfile::tempdir().unwrap();
 	let secret_src = dir.path().join("tok");
@@ -497,7 +497,7 @@ async fn remove_orphans_removes_container() {
 	.unwrap();
 	engine.up(&file_svc1).await.unwrap();
 
-	// file_svc2 only declares svc2 — svc1 becomes an orphan
+	// file_svc2 only declares svc2, so svc1 becomes an orphan
 	let file_svc2 = parse_str(
 		"services:\n  svc2:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
 	)
@@ -522,7 +522,7 @@ async fn remove_orphans_removes_container() {
 
 // ---------------------------------------------------------------------------
 
-/// The image ID a tag currently resolves to, via the podman CLI — the same
+/// The image ID a tag currently resolves to, via the podman CLI, the same
 /// out-of-band check the sibling tests in this file use to observe state podup
 /// itself reports on. Empty when the tag is absent.
 fn image_id(tag: &str) -> String {
@@ -536,7 +536,7 @@ fn image_id(tag: &str) -> String {
 /// #1094: `up` must not rebuild a service whose image is already present.
 ///
 /// It used to rebuild unconditionally, *with* the cache, so the rebuild could
-/// resolve to an older layer chain and retag the image backwards — silently
+/// resolve to an older layer chain and retag the image backwards, silently
 /// discarding a `build --no-cache` that had just run. That breaks the ordinary
 /// deploy shape: build explicitly, then start.
 ///

--- a/tests/engine_integration/build_resources.rs
+++ b/tests/engine_integration/build_resources.rs
@@ -25,7 +25,7 @@ async fn file_config_bound() {
 	engine.up(&file).await.unwrap();
 	// Read the config from inside the container. Asserting only that `up` and
 	// `down` succeed passes just as happily when the config is missing, empty or
-	// unreadable — the mount is not the effect, the content is.
+	// unreadable: the mount is not the effect, the content is.
 	let read = engine
 		.exec_with_options(
 			&file,
@@ -171,7 +171,7 @@ async fn named_volume_with_driver_opts() {
 
 	engine.up(&file).await.unwrap();
 	// The `:z` relabel is not optional. This volume binds a host directory, and
-	// on an SELinux-enforcing host the container is denied the write without it —
+	// on an SELinux-enforcing host the container is denied the write without it,
 	// which is what reddened the Podman 5 leg of pull request #1278 while passing
 	// on my machine, where SELinux is not enabled. The same trap is recorded in
 	// .github/podman-known-failures-5 for run_flags::engine_run_applies_volume_
@@ -179,8 +179,8 @@ async fn named_volume_with_driver_opts() {
 	//
 	// The driver_opts bind the volume to this temp directory, so a file written
 	// at /cache in the container has to appear on the host here. Without the opts
-	// taking effect the container would still get a working /cache — an ordinary
-	// local volume — and `up` would return Ok either way, which is exactly what
+	// taking effect the container would still get a working /cache (an ordinary
+	// local volume) and `up` would return Ok either way, which is exactly what
 	// this test used to check.
 	engine
 		.test_exec_capture(

--- a/tests/engine_integration/cli_commands.rs
+++ b/tests/engine_integration/cli_commands.rs
@@ -93,7 +93,7 @@ async fn cli_push_to_unreachable_registry_errors() {
 	// Which failure, not just that one happened. A non-zero exit is satisfied by
 	// a missing compose file or an unreachable Podman, neither of which reaches
 	// the registry. #1076 is the reason this matters: a failed pull used to be
-	// reported as success, and push shares that in-band-error shape — a test that
+	// reported as success, and push shares that in-band-error shape: a test that
 	// only reads the exit code cannot tell a real registry failure from podup
 	// falling over before it tried.
 	let err = String::from_utf8_lossy(&push.stderr);

--- a/tests/engine_integration/cli_flags.rs
+++ b/tests/engine_integration/cli_flags.rs
@@ -488,7 +488,7 @@ async fn cli_config_resolve_image_digests_pins_digest() {
 }
 
 /// #1184: `config` left `env_file` unresolved, so a service taking its whole
-/// environment from a file rendered with no `environment:` at all — the one
+/// environment from a file rendered with no `environment:` at all: the one
 /// command you use to ask what will actually run pointed away from the answer.
 /// docker compose materialises it and drops the key; measured against
 /// docker compose v5.1.3 on this exact input.

--- a/tests/engine_integration/cli_lifecycle.rs
+++ b/tests/engine_integration/cli_lifecycle.rs
@@ -105,7 +105,7 @@ async fn cli_ps_subcommand() {
 	//
 	// This used to look for the bare word `running`. STATUS reports the uptime
 	// now (`Up 4s`), matching what podman and docker compose print, so the check
-	// moved to that shape — and it is stricter than the old one rather than
+	// moved to that shape, and it is stricter than the old one rather than
 	// looser: an empty STATUS has no `Up`, so #590 would still turn this red.
 	let out = String::from_utf8_lossy(&ps.stdout);
 	let row = out
@@ -125,7 +125,7 @@ async fn cli_ps_subcommand() {
 	);
 	// CREATED sits between the image and STATUS. It is only ever filled by
 	// parsing the RFC 3339 string libpod really sends, so a blank here is the
-	// parser failing against the live server — which no unit test can see,
+	// parser failing against the live server, which no unit test can see,
 	// because every fixture it has was written by hand. Since #1699 the cell
 	// is a phrase, `3 seconds ago` or `Less than a second ago`, so it spans
 	// several cells: everything between the image and `Up`.
@@ -411,7 +411,7 @@ async fn cli_kill_subcommand() {
 		.unwrap();
 }
 
-/// #758: `down` on a defined-but-never-created project is a clean, quiet no-op —
+/// #758: `down` on a defined-but-never-created project is a clean, quiet no-op:
 /// it must not synthesize predicted container names and leak a raw 404 / "could
 /// not stop" warning.
 #[tokio::test]
@@ -483,7 +483,7 @@ async fn cli_wait_on_never_created_is_quiet_noop() {
 }
 
 /// #876: `stop` on a Created (never-started) container must not claim it was
-/// "stopped" — it is a harmless no-op, so no "stopped" line is logged.
+/// "stopped": it is a harmless no-op, so no "stopped" line is logged.
 #[tokio::test]
 async fn cli_stop_on_created_does_not_report_stopped() {
 	if super::podman().await.is_none() {

--- a/tests/engine_integration/cli_output.rs
+++ b/tests/engine_integration/cli_output.rs
@@ -98,7 +98,7 @@ async fn cli_top_covers_every_replica_of_a_scaled_service() {
 }
 
 /// `logs_with_stderr_output` names the stderr path and cannot read it. Measured
-/// while writing this: podup keeps the streams apart — the container's stdout
+/// while writing this: podup keeps the streams apart, so the container's stdout
 /// reaches podup's stdout and its stderr reaches podup's stderr, both carrying
 /// the service prefix. That separation is the contract, and it is finer than
 /// "the line appears somewhere": folding stderr into stdout would satisfy a
@@ -204,7 +204,7 @@ async fn cli_attached_up_carries_the_container_output() {
 	let compose = dir.path().join("docker-compose.yml");
 	let proj = format!("t{}-attach", std::process::id());
 	// The command exits on its own, so the attached `up` returns without needing
-	// a signal — no timeout standing in for synchronisation.
+	// a signal, with no timeout standing in for synchronisation.
 	fs::write(
 		&compose,
 		"services:\n  chatty:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo attached-output; sleep 2\"]\n",

--- a/tests/engine_integration/commands_networking.rs
+++ b/tests/engine_integration/commands_networking.rs
@@ -174,7 +174,7 @@ async fn engine_images_lists_service_images() {
 /// `Engine::port` returns `Result<()>` and writes the binding to stdout, so this
 /// can only assert that a published port resolves without error. The binding
 /// itself is checked where it is observable, in
-/// `stats_flags::cli_port_prints_the_published_binding` — this test used to be
+/// `stats_flags::cli_port_prints_the_published_binding`; this test used to be
 /// named for a return value the API does not have.
 #[tokio::test]
 async fn engine_port_resolves_a_published_port() {
@@ -249,7 +249,7 @@ async fn engine_cp_to_container_uploads_file() {
 	let src = local_file.to_str().unwrap().to_string();
 	let dst = "web:/tmp".to_string();
 	let result = engine.cp(&file, &src, &dst).await;
-	// `cp` reporting success is not the same as the file arriving — that exact
+	// `cp` reporting success is not the same as the file arriving: that exact
 	// false success is what #1097 was on Podman 6, where libpod accepted the
 	// archive, closed the connection without a response, and podup called it done.
 	// Read the copy back out of the container before tearing anything down.
@@ -321,7 +321,7 @@ async fn restart_scaled_service_all_replicas() {
 	);
 }
 
-/// Unassertable here, and — unlike `top` and `images` — **not covered anywhere
+/// Unassertable here and, unlike `top` and `images`, **not covered anywhere
 /// else either**. `logs` on a scaled service prints, so the library returns
 /// nothing to check, and no CLI test drives a scaled project through it. The
 /// claim in the name, that every replica is included, is currently unverified.
@@ -365,8 +365,8 @@ async fn top_scaled_service_all_replicas() {
 	engine.down(&file).await.unwrap();
 }
 
-/// #1250: a project where one service has already run to completion — a
-/// `migrate` that exits 0 is the everyday shape — used to abort `top` on the
+/// #1250: a project where one service has already run to completion (a
+/// `migrate` that exits 0 is the everyday shape) used to abort `top` on the
 /// stopped container, losing the services it had not reached yet and exiting
 /// non-zero. Measured against `docker compose top` v5.1.3 on the same Podman
 /// socket: it omits the stopped service, prints the rest and exits 0.
@@ -386,7 +386,7 @@ async fn top_skips_a_stopped_service_and_reports_the_rest() {
 	engine.up(&file).await.unwrap();
 
 	// `migrate` has to have actually exited before `top` runs, or this passes for
-	// the wrong reason — `up` returns once the container is started, not once it
+	// the wrong reason: `up` returns once the container is started, not once it
 	// is done, so without this the test could exercise two running services and
 	// prove nothing. `wait` blocks until it stops, which is deterministic where
 	// a sleep is not.
@@ -418,8 +418,8 @@ async fn exec_scaled_service_targets_first_replica() {
 
 	engine.up(&file).await.unwrap();
 	// Leave a mark instead of echoing, and read it from BOTH replicas. "targets
-	// the first replica" has two halves, and an exec that hit replica 2 — or one
-	// that somehow hit both — returned Ok just as happily as the right one.
+	// the first replica" has two halves, and an exec that hit replica 2, or one
+	// that somehow hit both, returned Ok just as happily as the right one.
 	engine
 		.exec_with_options(
 			&file,

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -87,7 +87,7 @@ async fn engine_cp_follow_link_uploads_target_contents() {
 #[tokio::test]
 async fn engine_cp_to_container_renames_a_single_file() {
 	// `cp host-file svc:/tmp/newname.txt` must create a FILE named newname.txt,
-	// not a directory holding the source — matching `docker cp` rename-on-copy.
+	// not a directory holding the source, matching `docker cp` rename-on-copy.
 	let client = match podman().await {
 		Some(d) => d,
 		None => return,

--- a/tests/engine_integration/dns_resolution.rs
+++ b/tests/engine_integration/dns_resolution.rs
@@ -9,7 +9,7 @@
 //!
 //! These tests used to assert only the end-to-end outcome, so a runtime whose
 //! DNS server had died reported `service \`server\` was not reachable by its
-//! service name` — which reads as a podup defect and cost real debugging time
+//! service name`, which reads as a podup defect and cost real debugging time
 //! before measurement showed aardvark-dns was simply not running. Each layer is
 //! now asserted on its own, and a failure names the layer that produced it.
 
@@ -25,7 +25,7 @@ use super::*;
 /// podup never touched failing to resolve cannot be podup's alias handling.
 ///
 /// The signatures come from the measurement in #1330 rather than from guessing
-/// at what busybox prints — a dead server times out, while a live server that
+/// at what busybox prints: a dead server times out, while a live server that
 /// does not know the name answers NXDOMAIN, and only the first is the runtime's
 /// fault. `test_exec_capture` attaches stderr and does not inspect the exit
 /// code, so a failed lookup arrives as `Ok` carrying its own complaint.
@@ -47,8 +47,8 @@ async fn runtime_dns_is_down(engine: &Engine, from: &str, own_name: &str) -> boo
 /// The body both tests share: bring the project up, assert podup's layer, then
 /// the runtime's, and tear down whatever happened.
 ///
-/// `alias_context` distinguishes the two topologies in the failure message —
-/// an explicit `networks:` block versus the synthesized `default` network —
+/// `alias_context` distinguishes the two topologies in the failure message,
+/// an explicit `networks:` block versus the synthesized `default` network,
 /// because "the alias is missing" has a different cause in each.
 async fn assert_sibling_resolves_by_service_name(
 	engine: &Engine,
@@ -98,7 +98,7 @@ async fn assert_sibling_resolves_by_service_name(
 	);
 
 	// A runtime whose DNS is down cannot answer this question, and a test that
-	// could not run is not a test that failed. It skips — but only where the
+	// could not run is not a test that failed. It skips, but only where the
 	// environment does not promise Podman works.
 	//
 	// Where it does (the nested-virt lane sets PODUP_REQUIRE_PODMAN), the skip
@@ -111,7 +111,7 @@ async fn assert_sibling_resolves_by_service_name(
 			std::env::var_os("PODUP_REQUIRE_PODMAN").is_none(),
 			"the alias `server` is registered, so podup did its part, but the container \
 			 runtime's DNS server did not answer a lookup for the container's own name \
-			 either — aardvark-dns is down. PODUP_REQUIRE_PODMAN is set, so this is a \
+			 either: aardvark-dns is down. PODUP_REQUIRE_PODMAN is set, so this is a \
 			 broken environment rather than a test to skip."
 		);
 		eprintln!(
@@ -152,7 +152,7 @@ async fn sibling_resolves_service_by_name_on_shared_network() {
 
 // ---------------------------------------------------------------------------
 // With NO `networks:` block, services still reach each other by service name
-// (the synthesized `default` network — docker-compose parity, #417)
+// (the synthesized `default` network, docker-compose parity, #417)
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "test-helpers")]
@@ -165,7 +165,7 @@ async fn sibling_resolves_service_by_name_without_networks_block() {
 	let proj = proj("dnsdef");
 	let engine = Engine::new(client, proj.clone());
 
-	// No top-level `networks:` and no per-service `networks:` — the common case.
+	// No top-level `networks:` and no per-service `networks:`, the common case.
 	// Parse through the real CLI entry point so the implicit `default` network
 	// is synthesized; `parse_str` deliberately does not normalize.
 	let dir = tempfile::tempdir().unwrap();

--- a/tests/engine_integration/error_surfacing.rs
+++ b/tests/engine_integration/error_surfacing.rs
@@ -6,7 +6,7 @@
 //!
 //! `pid: "evil"` is pre-validated by podup (libpod's `ParseNamespace` is the
 //! matching upstream check), so the error is a structured `PodmanError::Field`
-//! naming `service.<name>: pid: ... (value: evil)` — no libpod call, no flake.
+//! naming `service.<name>: pid: ... (value: evil)`, with no libpod call and no flake.
 //! The other fields are accepted by libpod verbatim and surface from the OCI
 //! runtime, the cgroup manager, or the OCI hook path; what we assert there is
 //! that the libpod message is preserved in the surfaced error (not replaced by
@@ -116,7 +116,7 @@ async fn bogus_capability_surfaces_a_field_named_error() {
 	// wire message varies by Podman/OCI version, so we only assert the
 	// surfaced error is a non-zero exit and that the libpod detail
 	// (the offending capability name) reaches stderr. Pre-validation
-	// intentionally does not cover this — podup does not duplicate the
+	// intentionally does not cover this; podup does not duplicate the
 	// OCI runtime's capability allow-list (#1357).
 	if podman().await.is_none() {
 		return;

--- a/tests/engine_integration/exec_flags.rs
+++ b/tests/engine_integration/exec_flags.rs
@@ -8,7 +8,7 @@ use super::*;
 use std::collections::HashMap;
 
 /// Bring up `web` with three replicas, then drive `exec` from a *fresh* engine
-/// whose compose file still declares the default single replica — exactly the
+/// whose compose file still declares the default single replica: exactly the
 /// real CLI case where a later `podup exec` knows nothing of the prior
 /// `up --scale`. Before the fix, `exec` resolved the replica count from that
 /// static default (1): a bare `exec` targeted the unsuffixed `web` (which does
@@ -51,7 +51,7 @@ async fn engine_exec_reaches_live_scaled_replicas() {
 		.await;
 
 	// A bare `exec` (no index) must reach the lowest-numbered running replica,
-	// web-1 — not the never-created unsuffixed `web`.
+	// web-1, not the never-created unsuffixed `web`.
 	let bare = engine
 		.exec_with_options(
 			&file,

--- a/tests/engine_integration/health_targeting.rs
+++ b/tests/engine_integration/health_targeting.rs
@@ -42,7 +42,7 @@ fn active_profiles_via_env() {
 			};
 			let proj = proj("apv");
 			let engine = Engine::new(client, proj.clone());
-			// "debug" service has profile "debug" — not in "prod" → skipped
+			// "debug" service has profile "debug", not in "prod" → skipped
 			let file = parse_str(
 				"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n  debug:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    profiles: [\"debug\"]\n",
 			)
@@ -108,7 +108,7 @@ async fn wait_completed_polling() {
 	// init takes a while before exiting, so the first poll sees it running and the
 	// polling loop is exercised rather than short-circuited. The delay has to beat
 	// the cost of creating app's container, or `up` would appear ordered even with
-	// the wait removed — the reason 2s was not enough in
+	// the wait removed, the reason 2s was not enough in
 	// resources_health::depends_on_service_completed.
 	// The bind uses an absolute path, so no base_dir is needed.
 	let dir = tempfile::tempdir().unwrap();
@@ -155,7 +155,7 @@ async fn external_config_injected_into_container() {
 	}
 
 	// A long-form absolute target must land the config at that exact path, not
-	// under /run/secrets — the config-specific behaviour.
+	// under /run/secrets, the config-specific behaviour.
 	let yaml = format!(
 		"services:\n  app:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    configs:\n      - source: cfg\n        target: /etc/app.conf\nconfigs:\n  cfg:\n    external: true\n    name: {secret_name}\n"
 	);
@@ -334,7 +334,7 @@ async fn dep_on_profile_filtered_service() {
 	// podup ACTIVATES a profile-filtered service when a service that is running
 	// depends on it, transitively, so a retained service never points at a dropped
 	// one. The rationale is in internal/engine/profiles.rs. This comment used to
-	// say the opposite — that db is skipped and its dep wait skipped with it —
+	// say the opposite (that db is skipped and its dep wait skipped with it)
 	// which is what a deliberate design looks like when nothing pins it: the next
 	// reader believes the comment over the code.
 	let file = parse_str(
@@ -356,7 +356,7 @@ async fn dep_on_profile_filtered_service() {
 	// This is a DELIBERATE divergence from docker compose, pinned here so it
 	// cannot be reverted by accident. Measured 2026-08-02 against docker-compose
 	// v5.1.3 on the same Podman socket: it refuses the project with
-	// `service "web" depends on undefined service "db"` — a misleading message,
+	// `service "web" depends on undefined service "db"`, a misleading message,
 	// since db is defined and filtered, not undefined.
 	//
 	// podup is not departing from a standard. The Compose Specification says only
@@ -403,7 +403,7 @@ fn build_with_env_arg() {
 			// Same two traps as the build-arg tests in build_images.rs, and this one
 			// is the sharper case. A valueless `args: FROM_ENV:` entry is supposed to
 			// take its value from the environment, and the single-dollar form the old
-			// version used made compose substitute FROM_ENV in the YAML instead — so
+			// version used made compose substitute FROM_ENV in the YAML instead, so
 			// the value arrived by a completely different route than the one under
 			// test, and the ARG never mattered. `RUN echo` then left nothing to
 			// contradict it.

--- a/tests/engine_integration/include_extends.rs
+++ b/tests/engine_integration/include_extends.rs
@@ -2,7 +2,7 @@
 //!
 //! Both are covered thoroughly at the parser level (`tests/parse/include.rs`,
 //! `tests/parse/extends.rs`), which proves the merged model is right. Nothing
-//! proved a project using either actually comes **up** — the 2026-06-25 empirical
+//! proved a project using either actually comes **up**; the 2026-06-25 empirical
 //! sweep listed them among the surfaces it never reached.
 //!
 //! These go through the CLI rather than `Engine`, because the part with no
@@ -127,7 +127,7 @@ async fn extends_across_files_anchors_relative_paths_to_the_extended_file() {
 	let dir = tempdir().unwrap();
 	// The base lives in a subdirectory and names its env_file relatively. The
 	// compose spec anchors that path to the file the base is defined in, not to
-	// the one extending it — the runtime half of what tests/parse/extends.rs
+	// the one extending it, the runtime half of what tests/parse/extends.rs
 	// checks on the parsed model.
 	let sub = dir.path().join("common");
 	fs::create_dir(&sub).unwrap();

--- a/tests/engine_integration/lifecycle.rs
+++ b/tests/engine_integration/lifecycle.rs
@@ -184,7 +184,7 @@ async fn down_with_remove_volumes() {
 	// Match on the project prefix, not the declared name. podup namespaces a
 	// declared volume as `{project}_{name}`, so an equality check against
 	// `{proj}-data` can never match and the assertion would hold whatever `down`
-	// did — which is how the first version of this line survived its mutation.
+	// did, which is how the first version of this line survived its mutation.
 	assert!(
 		!volumes.lines().any(|v| v.contains(proj.as_str())),
 		"down --volumes left a volume belonging to the project behind: {volumes:?}"

--- a/tests/engine_integration/lifecycle_output.rs
+++ b/tests/engine_integration/lifecycle_output.rs
@@ -1,6 +1,6 @@
 //! #817/#818/#873: the lifecycle commands must report concise per-container
 //! progress on success (docker-compose style), on stderr so stdout stays a
-//! clean pipe — and `run -d` must echo the started container's id on stdout.
+//! clean pipe, and `run -d` must echo the started container's id on stdout.
 
 use std::fs;
 use std::process::Command;

--- a/tests/engine_integration/lifecycle_query.rs
+++ b/tests/engine_integration/lifecycle_query.rs
@@ -12,7 +12,7 @@ use super::*;
 /// level the only thing to assert is that listing a running project does not
 /// error. What it prints is checked where it is reachable, in
 /// `cli_lifecycle::cli_ps_subcommand`, which reads the container name and the
-/// STATUS column — the column #590 left empty for every container.
+/// STATUS column, the column #590 left empty for every container.
 #[tokio::test]
 async fn ps_shows_running_container() {
 	let client = match podman().await {
@@ -32,8 +32,8 @@ async fn ps_shows_running_container() {
 }
 
 /// Same shape as `ps`: `Engine::logs` streams to stdout and returns
-/// `Result<()>`. The output contract — the container's own line, carrying the
-/// `service |` prefix that #594 dropped — is asserted in
+/// `Result<()>`. The output contract (the container's own line, carrying the
+/// `service |` prefix that #594 dropped) is asserted in
 /// `cli_lifecycle::cli_logs_subcommand`.
 #[tokio::test]
 async fn logs_from_named_service() {
@@ -224,7 +224,7 @@ async fn exec_nonexistent_user_fails_fast() {
 	.unwrap();
 
 	engine.up(&file).await.unwrap();
-	// A nonexistent named user must surface a prompt, clear error — never hang for
+	// A nonexistent named user must surface a prompt, clear error, never hanging for
 	// the full client read timeout (~120s) and then report a misleading
 	// socket-timeout (issue #720).
 	let started = std::time::Instant::now();
@@ -246,7 +246,7 @@ async fn exec_nonexistent_user_fails_fast() {
 	);
 	let msg = err.to_string().to_ascii_lowercase();
 	// Either the engine's prompt diagnostic (it names the user / passwd file) or
-	// podup's exec-specific timeout message — but never the bare socket-timeout.
+	// podup's exec-specific timeout message, but never the bare socket-timeout.
 	assert!(
 		msg.contains("user") || msg.contains("passwd") || msg.contains("exec"),
 		"unexpected error for a bad exec user: {msg}"
@@ -358,7 +358,7 @@ async fn attach_logs_empty_attach_returns() {
 	};
 	let proj = proj("atl");
 	let engine = Engine::new(client, proj.clone());
-	// attach: false — attach_logs finds no targets and returns immediately
+	// attach: false, so attach_logs finds no targets and returns immediately
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    attach: false\n",
 	)

--- a/tests/engine_integration/multi_file.rs
+++ b/tests/engine_integration/multi_file.rs
@@ -2,8 +2,8 @@
 //!
 //! #1078 landed the merge rules and was closed while three of its cases stayed
 //! unverified: same-target `volumes` dedup, `!override` and `!reset`. All three
-//! turn out to be implemented — measured here against docker compose v5.1.3 on
-//! the same inputs — but nothing pinned them, so a regression would have been
+//! turn out to be implemented, measured here against docker compose v5.1.3 on
+//! the same inputs, but nothing pinned them, so a regression would have been
 //! silent. That is what these are for.
 //!
 //! They drive the CLI because multi-`-f` merging and project-directory anchoring
@@ -75,7 +75,7 @@ fn same_target_volume_is_replaced_not_duplicated() {
 #[test]
 fn volumes_on_different_targets_are_both_kept() {
 	// The other half of the same rule, and the one that tells a real merge from a
-	// wholesale replacement of the list — which would pass the test above too.
+	// wholesale replacement of the list, which would pass the test above too.
 	let dir = tempdir().unwrap();
 	write(
 		dir.path(),
@@ -153,8 +153,8 @@ async fn relative_paths_anchor_to_the_first_file_not_each_file() {
 	if super::podman().await.is_none() {
 		return;
 	}
-	// The compose spec anchors a relative path to the *project* directory — the
-	// first `-f`'s directory — not to the file the key was written in. Both
+	// The compose spec anchors a relative path to the *project* directory, the
+	// first `-f`'s directory, not to the file the key was written in. Both
 	// directories hold a `shared.env`, so reading the wrong one is visible rather
 	// than merely absent, and docker compose v5.1.3 resolves this pair to the
 	// root's file.

--- a/tests/engine_integration/niche.rs
+++ b/tests/engine_integration/niche.rs
@@ -24,7 +24,7 @@ async fn cli_wait_names_the_container_and_its_exit_code() {
 	let out = run(&["-f", c, "-p", &proj, "wait", "job"]);
 	assert!(out.status.success(), "wait failed: {:?}", out.stderr);
 	// One line per container, naming it (#1248). This used to assert a line
-	// that was exactly `"0"` — a bare code with nothing saying whose it was,
+	// that was exactly `"0"`, a bare code with nothing saying whose it was,
 	// which is what the change replaced.
 	let stdout = String::from_utf8_lossy(&out.stdout);
 	assert!(
@@ -112,7 +112,7 @@ async fn cli_attach_streams_output_until_exit() {
 	// `attach` streams LIVE output only (libpod `tail=0`), like `docker attach`:
 	// anything emitted before the client connects is not replayed. So the
 	// container must keep emitting after start, or the test races the attach
-	// connection. It prints a line every second for a few seconds, then exits —
+	// connection. It prints a line every second for a few seconds, then exits;
 	// attach connects, catches a live line, and the follow stream closes when the
 	// container stops (attach returns rather than blocking forever).
 	fs::write(

--- a/tests/engine_integration/push_registry.rs
+++ b/tests/engine_integration/push_registry.rs
@@ -168,7 +168,7 @@ async fn cli_push_reaches_a_real_registry() {
 ///
 /// The assertion reads the registry back out: every tag declared in
 /// `build.tags` must appear under `/v2/{repo}/tags/list`. A green exit code
-/// alone is not evidence — the bug it guards against was exactly that.
+/// alone is not evidence; the bug it guards against was exactly that.
 #[tokio::test]
 async fn cli_push_uploads_every_build_tags_alias() {
 	if super::podman().await.is_none() {
@@ -211,7 +211,7 @@ async fn cli_push_uploads_every_build_tags_alias() {
 	let compose = dir.path().join("docker-compose.yml");
 	// List every tag we want the registry to end up with. The primary tag is
 	// included deliberately: `apply_extra_tags` skips it on the build side, and
-	// `push` must skip it for the same reason — re-listing it here exercises
+	// `push` must skip it for the same reason, and re-listing it here exercises
 	// the dedup branch.
 	let tags_yaml = std::iter::once(format!("        - {image}\n"))
 		.chain(

--- a/tests/engine_integration/resources_health.rs
+++ b/tests/engine_integration/resources_health.rs
@@ -81,8 +81,8 @@ async fn inline_secret_materialized() {
 
 	engine.up(&file).await.unwrap();
 	// Inline content is created as a Podman-native secret and mounted at the
-	// usual /run/secrets/<name> path. `cat` alone only proves the path exists —
-	// it exits 0 on an empty file too — so compare the bytes.
+	// usual /run/secrets/<name> path. `cat` alone only proves the path exists
+	// (it exits 0 on an empty file too) so compare the bytes.
 	let read = engine
 		.exec_with_options(
 			&file,
@@ -234,7 +234,7 @@ async fn inline_config_materialized() {
 
 	engine.up(&file).await.unwrap();
 	// A config defaults to an absolute container-root path, unlike a secret's
-	// /run/secrets/<name> — so this also pins the default target, not just the
+	// /run/secrets/<name>, so this also pins the default target, not just the
 	// content.
 	let read = engine
 		.exec_with_options(
@@ -319,7 +319,7 @@ async fn depends_on_service_healthy() {
 	// time it takes to create web's container, or the mutation that empties the
 	// readiness map still leaves this green (see depends_on_service_completed).
 	// And `retries` has to outlast that same delay, or db is declared unhealthy
-	// before it writes and `up` fails before any assertion runs — which is what
+	// before it writes and `up` fails before any assertion runs, which is what
 	// 12s against 10 retries at a 1s interval did.
 	let yaml = format!(
 		"services:\n  db:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"sleep 12; echo db-ready > /out/ready; sleep infinity\"]\n    volumes:\n      - {out}:/out:z\n    healthcheck:\n      test: [\"CMD\", \"test\", \"-f\", \"/out/ready\"]\n      interval: 1s\n      timeout: 2s\n      retries: 30\n      start_period: 0s\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"cat /out/ready > /out/web-saw 2>/dev/null; sleep infinity\"]\n    volumes:\n      - {out}:/out:z\n    depends_on:\n      db:\n        condition: service_healthy\n",
@@ -370,7 +370,7 @@ async fn depends_on_service_healthy_with_default_timeout() {
 
 	assert!(
 		elapsed < std::time::Duration::from_secs(45),
-		"up took {elapsed:?} — a healthcheck with no explicit timeout must get the spec default, not 0s"
+		"up took {elapsed:?}; a healthcheck with no explicit timeout must get the spec default, not 0s"
 	);
 	assert_eq!(
 		names,
@@ -393,12 +393,12 @@ async fn depends_on_service_completed() {
 	//
 	// The delay has to beat the cost of creating app's container, not just be
 	// non-zero. `up` starts services in dependency levels, so init is launched
-	// before app whether or not the readiness wait happens — the wait only adds
+	// before app whether or not the readiness wait happens; the wait only adds
 	// "and has finished". With a 2s delay the mutation that empties the readiness
 	// map left this test green, because creating app took longer than that on its
 	// own.
 	// If app were started before init completed, the read finds nothing and the
-	// marker below stays empty — which is exactly what a dropped dependency wait
+	// marker below stays empty, which is exactly what a dropped dependency wait
 	// looks like from outside.
 	let yaml = format!(
 		"services:\n  init:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"sleep 12; echo init-done > /out/order; exit 0\"]\n    volumes:\n      - {out}:/out:z\n  app:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"cat /out/order > /out/app-saw 2>/dev/null; sleep infinity\"]\n    volumes:\n      - {out}:/out:z\n    depends_on:\n      init:\n        condition: service_completed_successfully\n",
@@ -445,7 +445,7 @@ async fn depends_on_scaled_service_completed() {
 	// than `init-1` 404s and aborts `up`.
 	//
 	// Measured: aiming the wait at the base name reddens this test at
-	// `up().unwrap()`, not here — so the bare unwrap already covered that
+	// `up().unwrap()`, not here, so the bare unwrap already covered that
 	// regression. What the assertion adds is that both replicas exist and app
 	// came up with them, which the unwrap could not distinguish from a run where
 	// app was silently skipped. Precision, not new falsifiability.
@@ -472,7 +472,7 @@ async fn profile_filtered_service_skipped() {
 	};
 	let proj = proj("prf");
 	let engine = Engine::new(client, proj.clone());
-	// "debug" service has profile "debug" — not in active profiles → skipped
+	// "debug" service has profile "debug", not in active profiles → skipped
 	// "web" has no profiles → always runs
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n  debug:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    profiles: [\"debug\"]\n",
@@ -567,7 +567,7 @@ async fn depends_on_healthy_no_healthcheck_skips_wait() {
 
 	assert!(
 		elapsed < std::time::Duration::from_secs(30),
-		"up took {elapsed:?} — a service_healthy dependency with no healthcheck must be skipped, not waited on"
+		"up took {elapsed:?}; a service_healthy dependency with no healthcheck must be skipped, not waited on"
 	);
 	assert_eq!(
 		names,
@@ -609,7 +609,7 @@ async fn ps_with_port_bindings() {
 /// `attach_logs` streams to stdout, so what it carries cannot be read from the
 /// library. Unlike `attach_logs_empty_attach_returns`, which asserts a bound
 /// because "returns immediately" is checkable without the stream, there is
-/// nothing here to bound — this one names the content. No CLI test covers
+/// nothing here to bound; this one names the content. No CLI test covers
 /// attached output either, so the claim in the name is unverified.
 #[tokio::test]
 async fn attach_logs_streams_container_output() {
@@ -633,7 +633,7 @@ async fn attach_logs_streams_container_output() {
 
 /// Same: `logs` prints, and whether a container's stderr is interleaved into it
 /// is a property of the output. `cli_logs_subcommand` asserts stdout content and
-/// the service prefix, but drives a service that writes only to stdout — so the
+/// the service prefix, but drives a service that writes only to stdout, so the
 /// stderr path this test is named for is asserted nowhere.
 #[tokio::test]
 async fn logs_with_stderr_output() {

--- a/tests/engine_integration/run_flags.rs
+++ b/tests/engine_integration/run_flags.rs
@@ -65,7 +65,7 @@ async fn engine_run_applies_volume_publish_and_interactive() {
 	let dir = tempfile::tempdir().unwrap();
 	fs::write(dir.path().join("marker.txt"), b"present").unwrap();
 	// `z` relabels the host directory so a confined container can read it. Without
-	// it this test fails on every SELinux-enforcing host — measured on Fedora 44 +
+	// it this test fails on every SELinux-enforcing host, measured on Fedora 44 +
 	// Podman 5.8.1, where a `user_tmp_t` file bound read-only gives the container
 	// `cat: can't open '/mnt/in/marker.txt': Permission denied`. Plain `podman run`
 	// behaves identically, so the denial was never podup's; the mount just needed

--- a/tests/engine_integration/scale.rs
+++ b/tests/engine_integration/scale.rs
@@ -97,10 +97,10 @@ async fn scale_subcommand_scales_up_then_down() {
 
 /// #815 regression: scaling down to one must PRESERVE the surviving replica
 /// (`worker-1`), not destroy and recreate it. Containers are always named
-/// `worker-1..N`, so the desired set at target 1 is `{worker-1}` — which matches
+/// `worker-1..N`, so the desired set at target 1 is `{worker-1}`, which matches
 /// the running `worker-1` and keeps it. Before the fix the desired set was the
 /// bare, never-created `worker`, so every numbered replica (incl. the survivor)
-/// was removed and a fresh container took its place — losing the container's
+/// was removed and a fresh container took its place, losing the container's
 /// identity, uptime and in-memory state.
 #[tokio::test]
 async fn scale_down_to_one_preserves_surviving_replica() {
@@ -137,7 +137,7 @@ async fn scale_down_to_one_preserves_surviving_replica() {
 		.success());
 	assert_eq!(running_count(c, &proj), 1, "scale down must remove surplus");
 
-	// The survivor must be the very same container — same id, never recreated.
+	// The survivor must be the very same container: same id, never recreated.
 	let id_after = container_id(&survivor);
 	assert_eq!(
 		id_before, id_after,

--- a/tests/engine_integration/stats_flags.rs
+++ b/tests/engine_integration/stats_flags.rs
@@ -103,7 +103,7 @@ fn run(c: &str, proj: &str, args: &[&str]) -> String {
 
 /// #1082: `stats --format json` while streaming emitted one pretty-printed array
 /// per sampling frame, concatenated. That is neither a single JSON document nor
-/// NDJSON, so no parser accepts it — the machine-readable format was unreadable
+/// NDJSON, so no parser accepts it: the machine-readable format was unreadable
 /// by machines for as long as it streamed.
 ///
 /// Streaming now emits one compact array per line. `--no-stream` prints a single

--- a/tests/engine_integration/watch.rs
+++ b/tests/engine_integration/watch.rs
@@ -67,7 +67,7 @@ async fn watch_sync_file_to_container() {
 	// second copy came back as the #1097 could-not-confirm error, which says in
 	// its own text that the copy may or may not have landed. #1270 owns that
 	// error-reporting defect. What this test owns is whether the bytes arrived,
-	// so it reads them and reports what the sync claimed alongside — which is
+	// so it reads them and reports what the sync claimed alongside, which is
 	// also the measurement #1270 needs to tell its branches apart.
 	let reported = engine
 		.test_sync_to_container(&cname, &src_file, "/tmp/app.txt")
@@ -256,8 +256,8 @@ async fn watch_sync_creates_missing_target_directory() {
 /// `rebuild` was the one watch action with no coverage at all, and it is the
 /// only one that goes all the way back through `build` and container recreation
 /// rather than touching a running container. It reads its trigger file into the
-/// image, so a rebuild that silently did nothing — or that rebuilt the image and
-/// left the old container running — is visible as stale content.
+/// image, so a rebuild that silently did nothing, or that rebuilt the image and
+/// left the old container running, is visible as stale content.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn watch_rebuild_recreates_the_container_from_the_new_image() {
 	let client = match podman().await {
@@ -332,7 +332,7 @@ async fn watch_sync_and_restart_does_both() {
 	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
 	// The command appends one line per start. A restart re-runs it against the
 	// same (persisting) filesystem, so the line count is a container-scoped
-	// counter of how many times the process was started — unlike /proc/uptime,
+	// counter of how many times the process was started, unlike /proc/uptime,
 	// which is not namespaced and would report the host's.
 	let file = parse_str(
 		"services:\n  web:\n    image: alpine:latest\n    command: [\"sh\", \"-c\", \"echo start >> /starts; sleep infinity\"]\n    develop:\n      watch:\n        - path: app.txt\n          action: sync+restart\n          target: /tmp/app.txt\n",

--- a/tests/fixtures/releases/test-sign.sh
+++ b/tests/fixtures/releases/test-sign.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression test for .github/scripts/sign.py — five fail-closed controls.
+# Regression test for .github/scripts/sign.py: five fail-closed controls.
 #
 # sign.py signs release artifacts with the org Ed25519 key. It refuses to
 # produce a signature in five places; this fixture walks every one of them
@@ -80,16 +80,16 @@ sk = Ed25519PrivateKey.generate()
 # private_bytes with TraditionalOpenSSL + NoEncryption returns the 32-byte
 # seed prefixed by a 16-byte PKCS#8 header for a total of 48 bytes; the
 # 32-byte seed sits at the END (the cryptography docs pin this). We use
-# the public_key().public_bytes() form instead — it is stable across
-# cryptography versions — and we derive the matching seed by re-running
+# the public_key().public_bytes() form instead (it is stable across
+# cryptography versions) and we derive the matching seed by re-running
 # `from_private_bytes` on a chosen 32-byte input. See below.
 pk_raw = sk.public_key().public_bytes(
 	serialization.Encoding.Raw,
 	serialization.PublicFormat.Raw,
 )
 # Build a 32-byte seed from sk. cryptography >=42 exposes
-# `private_bytes(Raw, Raw, NoEncryption)` which is the bare 32-byte seed
-# — try that first, fall back to deriving from the public key only when
+# `private_bytes(Raw, Raw, NoEncryption)` which is the bare 32-byte seed.
+# Try that first, fall back to deriving from the public key only when
 # the installed version does not support the Raw/Raw form.
 try:
 	seed = sk.private_bytes(
@@ -132,7 +132,7 @@ rc=$?
 set -e
 [[ $rc -eq 1 ]] || fail "expected exit 1 for argv<2, got $rc"
 # Usage is the script's __doc__. The distinctive fragment is the "Usage:" line
-# plus the description of how the key is passed — both must appear.
+# plus the description of how the key is passed; both must appear.
 grep -q "^Usage:" "$stderr1" || fail "expected 'Usage:' on stderr, got: $(cat "$stderr1")"
 grep -q "GLYNDOR_RELEASE_ED25519_KEY" "$stderr1" || fail "expected 'GLYNDOR_RELEASE_ED25519_KEY' on stderr (the env var it explains), got: $(cat "$stderr1")"
 echo "  OK    argv<2 → exit 1 with usage on stderr"
@@ -170,7 +170,7 @@ for case in unset empty whitespace; do
 		set -e
 		;;
 	whitespace)
-		# Three spaces — the .strip() in sign.py must turn this into ""
+		# Three spaces: the .strip() in sign.py must turn this into ""
 		# before the `if not seed_b64` check fires.
 		set +e
 		env GLYNDOR_RELEASE_ED25519_KEY="   " python3 "$SIGN_PY" "$tmp1/data" \
@@ -191,8 +191,8 @@ echo "  OK    unset / empty / whitespace all hit the refusal guard"
 # Part 3: the seed is not valid base64. validate=True must reject URL-safe
 # -/_ and stray characters (both are rejected by strict b64 decoding).
 #
-# The fixture must be valid in every other respect — the same input file,
-# the same invocation shape — so the rejection is unambiguously about the
+# The fixture must be valid in every other respect (the same input file,
+# the same invocation shape) so the rejection is unambiguously about the
 # base64 shape.
 #
 # Three sub-cases:
@@ -216,7 +216,7 @@ GOOD_SEED="$(cat "$seed_b64_file")"
 # further padding. This is the form we use to construct bad seeds: a
 # `-`/`_`/`!` inserted anywhere yields a 45-char string that
 #   * validate=True rejects outright ("Only base64 data is allowed")
-#   * validate=False ACCEPTS — the lenient decoder drops the stray
+#   * validate=False ACCEPTS: the lenient decoder drops the stray
 #     character and decodes the remaining 44 chars (with the trailing
 #     '=') to 32 bytes. This discrimination is what the test proves:
 #     the guard fails closed ONLY because validate=True is set.
@@ -235,7 +235,7 @@ for case in dash underscore stray; do
 	rc=$?
 	set -e
 	[[ $rc -eq 1 ]] || fail "case $case: expected exit 1, got $rc"
-	# The distinctive fragment: "is not valid base64" — this is the
+	# The distinctive fragment: "is not valid base64", which is the
 	# branch's error prefix. Asserting only "exit 1" would be satisfied
 	# by the length-guard below, which is a different guard.
 	grep -q "is not valid base64" "$stderr3" \
@@ -277,7 +277,7 @@ echo "  OK    bad-base64 seed rejected; valid 32-byte seed passes the base64 gua
 echo "Part 4: wrong-length seed → exit 1 with 'must decode to 32 bytes'"
 
 # Build a deterministic N-byte raw seed and base64-encode it (trivially
-# valid base64 — the rejection is solely about length). The seed bytes
+# valid base64; the rejection is solely about length). The seed bytes
 # are not a real key; the test only cares that the length-guard fires.
 gen_wrong_len() {
 	local out_var="$1" raw_len="$2"
@@ -333,7 +333,7 @@ echo "  OK    31/33-byte seeds rejected with 'must decode to 32 bytes'; 32-byte 
 #
 # A file-exists assertion would pass for a signature of the wrong bytes
 # (e.g. one made with a different key). The test therefore re-derives the
-# public key from the seed and verifies the signature under it — the same
+# public key from the seed and verifies the signature under it, the same
 # loop a consumer (install.sh / install.ps1 / internal/update/verify.rs)
 # would run on a freshly signed release.
 # -----------------------------------------------------------------------------
@@ -345,7 +345,7 @@ gen_test_key "$seed_b64_file5" "$seed_raw_file5" "$pub_raw_file5"
 GOOD_SEED5="$(cat "$seed_b64_file5")"
 printf 'fixture-payload-for-sign.py-test' > "$tmp5/data"
 
-# Default output path: <input>.sig — exercise that branch.
+# Default output path: <input>.sig; exercise that branch.
 stderr5="$tmp5/err" stdout5="$tmp5/out"
 set +e
 run_sign "$GOOD_SEED5" "$tmp5/data" "" "$stdout5" "$stderr5"
@@ -357,7 +357,7 @@ set -e
 # Verify the signature. A file-exists assertion would pass a wrong-key
 # signature; this is what the consumers actually do, so the test mirrors
 # them. The signature MUST verify under the public key derived from the
-# seed that sign.py used. The pubkey is 32 raw bytes — round-tripping it
+# seed that sign.py used. The pubkey is 32 raw bytes, and round-tripping it
 # through bash $() would mangle non-printable bytes, so we pass the file
 # path and let python read it.
 verify_out="$tmp5/verify_out" verify_err="$tmp5/verify_err"
@@ -440,7 +440,7 @@ data = open(sys.argv[2], "rb").read()
 pk = open(sys.argv[3], "rb").read()
 try:
 	Ed25519PublicKey.from_public_bytes(pk).verify(sig, data)
-	sys.exit("negative-control: a signature under a different key VERIFIED under our public key — the test would prove nothing")
+	sys.exit("negative-control: a signature under a different key VERIFIED under our public key; the test would prove nothing")
 except InvalidSignature:
 	pass
 PY

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -20,7 +20,7 @@ pub fn bin() -> &'static str {
 ///
 /// This is the integration suite's guard, not a `podman info` probe. The CI
 /// runner ships a podman binary that is *below podup's floor* with no socket
-/// running, so `podman info` succeeds while every command here fails — the
+/// running, so `podman info` succeeds while every command here fails; the
 /// weaker check let these run in the main CI job and fail for the environment
 /// rather than the code.
 pub async fn podman_up() -> bool {

--- a/tests/host_binding_warnings.rs
+++ b/tests/host_binding_warnings.rs
@@ -80,7 +80,7 @@ fn config_surfaces_every_active_host_binding_mode() {
 	let stderr = String::from_utf8_lossy(&out.stderr);
 
 	// Each declared mode produces its own `podup: warning:` line at default log
-	// level — the `config` surface is independent of `--no-warn`, so an
+	// level: the `config` surface is independent of `--no-warn`, so an
 	// operator who never runs `up` still sees the modes in CI logs.
 	for (service, field) in [
 		("net", "network_mode: host"),
@@ -99,7 +99,7 @@ fn config_surfaces_every_active_host_binding_mode() {
 		);
 	}
 
-	// The plain service must NOT warn — pin that the detector does not
+	// The plain service must NOT warn; pin that the detector does not
 	// over-trigger.
 	let plain_warning = stderr
 		.lines()
@@ -161,7 +161,7 @@ fn config_with_no_active_modes_is_silent() {
 fn generate_quadlet_warns_on_host_network_and_privileged() {
 	// Quadlet has no Podman client to surface warnings through, so it must
 	// emit them at generate time. The mode stays emitted in the unit file
-	// (Network=host, PodmanArgs=--privileged) — the warning is alongside, not
+	// (Network=host, PodmanArgs=--privileged); the warning is alongside, not
 	// instead of, the mapping.
 	let (_dir, file) = compose_file(
 		"compose.yaml",
@@ -226,7 +226,7 @@ fn generate_quadlet_warns_on_container_namespace_sharing() {
 #[test]
 fn no_warn_drops_the_host_binding_warnings_at_config_parse() {
 	// The `config` command goes through the same detector path. `--no-warn`
-	// must still suppress the per-service warning *at config time*? No —
+	// must still suppress the per-service warning *at config time*? No:
 	// `config` ignores `--no-warn` by design (the surface is the whole point
 	// of the command). This test pins that decision so a future refactor
 	// cannot silently change it: a compose with no host modes + `--no-warn`
@@ -296,7 +296,7 @@ fn generate_quadlet_no_warn_suppresses_the_warnings() {
 		!stderr.contains("podup: warning: privileged: true"),
 		"--no-warn must silence the privileged warning; got stderr:\n{stderr}"
 	);
-	// The unit still carries the modes — suppression is the per-line warning,
+	// The unit still carries the modes; suppression is the per-line warning,
 	// not the emitted directive.
 	let stdout = String::from_utf8_lossy(&out.stdout);
 	assert!(
@@ -313,7 +313,7 @@ fn generate_quadlet_no_warn_suppresses_the_warnings() {
 fn generate_quadlet_no_warn_without_modes_is_silent() {
 	// Sanity: `--no-warn` against a clean compose file produces no
 	// host-binding / privilege-escalation warning. (The Quadlet path also
-	// emits an unrelated platform advisory on non-Linux hosts — that is not
+	// emits an unrelated platform advisory on non-Linux hosts, and that is not
 	// gated on `--no-warn` and is intentionally left alone, so the assertion
 	// filters to the host-binding lines only.)
 	let (_dir, file) = compose_file(

--- a/tests/keyring_bootstrap_order.rs
+++ b/tests/keyring_bootstrap_order.rs
@@ -3,7 +3,7 @@
 //! The bootstrap this document publishes used to read `dpkg -i` first and
 //! `gpg --show-keys /usr/share/keyrings/glyndor.gpg` second. `dpkg -i` runs the
 //! package's maintainer scripts as root, so that order verified a keyring after
-//! giving the package that wrote it full privileges — the check ran on its own
+//! giving the package that wrote it full privileges: the check ran on its own
 //! subject. `dpkg-deb -x` unpacks the data archive and runs nothing, which is
 //! why the fingerprint has to come from an extracted copy.
 //!
@@ -28,7 +28,7 @@ fn doc() -> String {
 }
 
 /// Line index of the first line containing `needle`, or a failure naming what
-/// was being looked for — an `Option` that silently becomes `None` would let a
+/// was being looked for: an `Option` that silently becomes `None` would let a
 /// renamed command turn this test green.
 fn line_of(text: &str, needle: &str) -> usize {
 	text.lines()

--- a/tests/output_contract.rs
+++ b/tests/output_contract.rs
@@ -3,8 +3,8 @@
 //!
 //! #1082's closing observation is that nothing protected them: not one test
 //! asserted `NAME`, `STATUS`, or an `images` JSON key, so every drift in that
-//! issue — `ConfigFiles` always empty, `top` emitting `null`, `volumes`
-//! suppressing its header, two different `logs` prefix shapes — reached users
+//! issue (`ConfigFiles` always empty, `top` emitting `null`, `volumes`
+//! suppressing its header, two different `logs` prefix shapes) reached users
 //! before anyone noticed. Fixing them one by one only resets the clock; this is
 //! the net underneath.
 //!
@@ -22,7 +22,7 @@ use tempfile::tempdir;
 
 /// Every list command prints its header, including on an empty result. `volumes`
 /// used to be the exception, so a script locating its columns from the header
-/// broke on an empty project — and empty is a legitimate answer, not a missing
+/// broke on an empty project, and empty is a legitimate answer, not a missing
 /// one.
 #[tokio::test]
 async fn list_commands_print_their_table_headers() {
@@ -106,8 +106,8 @@ async fn json_output_keys_are_stable() {
 }
 
 /// `logs` and attached `up` tag the same container the same way: the service and
-/// index, project stripped, one space before the bar. They used to disagree —
-/// `myproj-web-1  | ` against `web-1 | ` — so anything parsing the prefix had to
+/// index, project stripped, one space before the bar. They used to disagree,
+/// `myproj-web-1  | ` against `web-1 | `, so anything parsing the prefix had to
 /// accept both shapes from one binary.
 #[tokio::test]
 async fn logs_prefix_is_service_and_index_with_one_space() {
@@ -135,7 +135,7 @@ async fn logs_prefix_is_service_and_index_with_one_space() {
 ///
 /// They did not: clap's derived `--version` rendered `podup 3.3.0` while the
 /// subcommand rendered `podup version v3.3.0`, so a script probing the binary
-/// got a different string depending on which spelling it happened to use — and
+/// got a different string depending on which spelling it happened to use, and
 /// the `v` prefix, which is what the tags and the release assets carry, appeared
 /// in only one of them. Measured on docker-compose v5.1.3, both spellings return
 /// `Docker Compose version v5.1.3` byte for byte.
@@ -277,7 +277,7 @@ fn autostart_status_renders_one_negative_one_way() {
 /// This is deliberately an end-to-end assertion rather than a unit test of the
 /// column choice. Both exist, because they fail for different reasons: the unit
 /// test catches a wrong choice, and only this one catches the choice being
-/// computed correctly and then not passed to the table — which is exactly the
+/// computed correctly and then not passed to the table, which is exactly the
 /// shape of the `logs` defect that survived every per-task review in #1247.
 #[tokio::test]
 async fn top_styles_its_process_rows() {
@@ -310,7 +310,7 @@ async fn top_styles_its_process_rows() {
 /// repainted.
 ///
 /// The live view is gated on **stdout** rather than stderr, because `stats` is
-/// its own output — `stats > file` on a terminal must still produce a file of
+/// its own output: `stats > file` on a terminal must still produce a file of
 /// frames rather than a file of cursor moves. `--format json` never repaints at
 /// all, whatever the terminal says, and keeps the split it already had: NDJSON
 /// while streaming, one pretty array for `--no-stream`.

--- a/tests/package_excludes.rs
+++ b/tests/package_excludes.rs
@@ -23,14 +23,14 @@ const PUBLISHED: &[&str] = &["internal"];
 
 /// Top-level directories that carry their own manifest at the top level.
 /// `cargo package` does not descend into a nested package, so these are absent
-/// from the crate whether or not `exclude` names them — which is why adding
+/// from the crate whether or not `exclude` names them, which is why adding
 /// `fuzz` to `exclude` closed nothing when it was tried.
 ///
 /// `bench` is deliberately NOT here. Its manifest is one level down, at
 /// `bench/timeit/Cargo.toml`, so `cargo package` descends into `bench/` and
 /// publishes everything beside that nested package: 30 files, measured. Listing
 /// it here was the first version of this file, and deleting `/bench` from the
-/// manifest left the test green — a control that can be removed without the
+/// manifest left the test green: a control that can be removed without the
 /// test noticing is not a control.
 const NESTED_PACKAGES: &[&str] = &["fuzz"];
 
@@ -85,7 +85,7 @@ fn every_top_level_directory_is_a_decision() {
 
 	// Ask git, not the filesystem. Inside a checkout `cargo package` takes its
 	// file list from git, so an untracked build directory in the working tree is
-	// never published — and reading `read_dir` here would fail the test on every
+	// never published, and reading `read_dir` here would fail the test on every
 	// machine that has one, which is the instrument measuring something other
 	// than the question.
 	let listing = Command::new("git")

--- a/tests/parse/extends.rs
+++ b/tests/parse/extends.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 fn make_chain_yaml(depth: usize) -> String {
 	let mut yaml = "services:\n".to_string();
-	// Reverse order so the deepest service comes first — forces full recursion.
+	// Reverse order so the deepest service comes first, forcing full recursion.
 	for i in (1..=depth).rev() {
 		yaml.push_str(&format!("  s{i}:\n    extends: s{}\n", i - 1));
 	}
@@ -348,7 +348,7 @@ services:
 
 #[test]
 fn extends_chain_within_depth_limit() {
-	// 16 services = 15 hops — must succeed.
+	// 16 services = 15 hops, which must succeed.
 	let yaml = make_chain_yaml(15);
 	assert!(
 		parse_str(&yaml).is_ok(),
@@ -358,7 +358,7 @@ fn extends_chain_within_depth_limit() {
 
 #[test]
 fn extends_chain_exceeds_depth_limit() {
-	// 17 services = 16 hops — must be rejected.
+	// 17 services = 16 hops, which must be rejected.
 	let yaml = make_chain_yaml(16);
 	let err = parse_str(&yaml).unwrap_err();
 	let msg = err.to_string();

--- a/tests/podman_floor.rs
+++ b/tests/podman_floor.rs
@@ -14,11 +14,11 @@
 //! The Podman floor is written in three places and nothing derives one from
 //! another.
 //!
-//! - `internal/libpod/client/mod.rs` — `MIN_LIBPOD_API_MAJOR`, the gate the
+//! - `internal/libpod/client/mod.rs`: `MIN_LIBPOD_API_MAJOR`, the gate the
 //!   running binary applies to the major the engine reports.
-//! - `install.sh` — `PODMAN_MIN_MAJOR`, the precheck that refuses to install
+//! - `install.sh`: `PODMAN_MIN_MAJOR`, the precheck that refuses to install
 //!   over a local engine below the floor.
-//! - `debian/control` — the `podman (>= N.0)` relationship.
+//! - `debian/control`: the `podman (>= N.0)` relationship.
 //!
 //! The third one used to be a `Recommends`, where a wrong number cost a
 //! suggestion. As a `Depends` it decides whether the package installs at all,
@@ -167,8 +167,8 @@ fn the_package_requires_unattended_upgrades() {
 /// package ships `/etc/apt/sources.list.d/glyndor.sources` and
 /// `/etc/apt/apt.conf.d/51glyndor-unattended-upgrades`, and with neither of
 /// them the daemon runs against Debian's own security suite and nothing else.
-/// Two paths reached that state — `dpkg -i` of a release `.deb`, and adding the
-/// repository by hand — and on both, podup installed and never updated again.
+/// Two paths reached that state (`dpkg -i` of a release `.deb`, and adding the
+/// repository by hand) and on both, podup installed and never updated again.
 /// #1602.
 #[test]
 fn the_package_requires_the_archive_keyring() {

--- a/tests/podup_is_not_published.rs
+++ b/tests/podup_is_not_published.rs
@@ -40,7 +40,7 @@ fn no_workflow_owned_here_runs_cargo_publish() {
 	// `reusable-rust-ci.yml` keeps a guarded `cargo publish --dry-run` behind
 	// `if: inputs.package-check`, which `ci.yml` now passes as false. It is
 	// excluded because it is a generic reusable rather than a decision about
-	// podup — the thing worth catching is a caller turning it back on, or a new
+	// podup; the thing worth catching is a caller turning it back on, or a new
 	// step publishing for real.
 	let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows");
 	let mut offenders = Vec::new();
@@ -75,7 +75,7 @@ fn no_workflow_owned_here_runs_cargo_publish() {
 /// have one home, so grepping the file you happen to be editing is not a check.
 ///
 /// Deliberately narrow: these three markers, not the words "crates.io", which the
-/// docs use correctly all over — the threat model lists it as untrusted network,
+/// docs use correctly all over: the threat model lists it as untrusted network,
 /// and the packaging notes explain why podup is not on it.
 #[test]
 fn no_document_still_says_the_library_is_published_or_consumed() {

--- a/tests/project_name_safety.rs
+++ b/tests/project_name_safety.rs
@@ -2,7 +2,7 @@
 //! any code path that builds a filesystem path from it.
 //!
 //! `--project` / `COMPOSE_PROJECT_NAME` and the compose `name:` field are taken
-//! verbatim, so a traversal value like `../evil` must be rejected up front —
+//! verbatim, so a traversal value like `../evil` must be rejected up front,
 //! including on the `generate quadlet` path, which neither locks nor stages and
 //! would otherwise never consult `is_safe_project_name`.
 

--- a/tests/reporting_contract.rs
+++ b/tests/reporting_contract.rs
@@ -22,14 +22,14 @@ use tempfile::tempdir;
 ///
 /// Its only two user-facing lines were `tracing::info!`, and the CLI floors
 /// tracing at `warn`, so a push that genuinely uploaded the image wrote zero
-/// bytes to stdout and stderr and exited 0 — measured against a real local
+/// bytes to stdout and stderr and exited 0, measured against a real local
 /// registry, which afterwards listed the repository. This asserts the line is
 /// back and that it goes to stderr, leaving stdout a clean pipe.
 ///
 /// Deliberately pointed at a registry that cannot exist (port 1) with an image
 /// that is not present locally: the progress line is emitted before the API
 /// call, so the assertion needs no registry and no build, and the command still
-/// fails afterwards — which is also what pins the line as *progress* rather
+/// fails afterwards, which is also what pins the line as *progress* rather
 /// than a success message.
 #[tokio::test]
 async fn push_reports_the_image_it_is_pushing() {
@@ -147,8 +147,8 @@ async fn up_reports_the_networks_and_volumes_it_creates() {
 /// It reported three that had not: measured on a project name that had never
 /// been created, `down -v` printed `Network …_extra Removed`, `Network
 /// …_default Removed` and `Volume …_data Removed`. The cause was `delete_ok`
-/// discarding the boolean `delete_existed` returns — the very distinction that
-/// method exists to preserve, and which the container path had always used — so
+/// discarding the boolean `delete_existed` returns, the very distinction that
+/// method exists to preserve, and which the container path had always used, so
 /// a 404 reached the caller as `Ok(())` and was announced as a deletion.
 ///
 /// A volume is where this is worst: it names data the operator is being told is
@@ -248,7 +248,7 @@ async fn lifecycle_commands_stay_quiet_when_they_did_act() {
 /// It printed a bare `0` per service. With more than one container nothing said
 /// which code was whose, and a service scaled to three collapsed to one line.
 /// Measured on docker compose v5.1.3 with three replicas: it reports per
-/// container, so the granularity here follows the reference — the rendering
+/// container, so the granularity here follows the reference; the rendering
 /// deliberately does not, since the reference prints a 64-character hex id, the
 /// same sentence on every line, and nothing a parser can read.
 #[tokio::test]
@@ -306,7 +306,7 @@ async fn wait_names_each_container_and_its_code() {
 ///
 /// This is the contract that protects CI logs. The live region only exists when
 /// stderr is a terminal and colour is on; anywhere else the same event model
-/// comes out as append-only lines. **Animation in a CI log is a defect** — and
+/// comes out as append-only lines. **Animation in a CI log is a defect**, and
 /// so is a CI log that says less than the terminal did, which is why the
 /// intermediate transitions are asserted here too. Before the board they did
 /// not exist at all: `up` reported only the finished state of each resource.
@@ -407,7 +407,7 @@ async fn the_board_never_touches_stdout() {
 }
 
 /// `down` gets a board too, seeded from what Podman actually has rather than
-/// from what the compose file describes — a service the file lists but that was
+/// from what the compose file describes: a service the file lists but that was
 /// never created would sit on the board as a row that never moves.
 #[tokio::test]
 async fn a_piped_down_gets_transitions_for_what_exists() {
@@ -436,7 +436,7 @@ async fn a_piped_down_gets_transitions_for_what_exists() {
 
 /// `pull` reports through the progress layer, with a matching `Pulled`.
 ///
-/// It used a bare `eprintln!` — the one user-facing line in the binary that
+/// It used a bare `eprintln!`, the one user-facing line in the binary that
 /// bypassed `ui` entirely, so it ignored `PROGRESS_ENABLED` and an embedder
 /// asking podup to stay silent got it anyway. There was never a `Pulled` at all,
 /// so a pull that finished looked exactly like one that hung.
@@ -468,7 +468,7 @@ async fn pull_reports_both_ends() {
 /// One image, one `Pulling`, even on the `up` path.
 ///
 /// `up` warms the image cache before the per-level walk and then pulls again
-/// inside it, and both reported — so `Pulling` appeared twice per image on `up`
+/// inside it, and both reported, so `Pulling` appeared twice per image on `up`
 /// while a standalone `pull` printed it once. The prefetch is best-effort
 /// warming and the walk's own pull is the authoritative one, so only the second
 /// speaks.

--- a/tests/substitute/modifiers.rs
+++ b/tests/substitute/modifiers.rs
@@ -206,7 +206,7 @@ fn empty_vs_unset_for_colon_dash() {
 
 #[test]
 fn empty_vs_unset_for_dash() {
-	// - treats empty as "use the empty string" — different from :-
+	// - treats empty as "use the empty string", different from :-
 	assert_eq!(substitute("${V-def}", &vars(&[])).unwrap(), "def");
 	assert_eq!(substitute("${V-def}", &vars(&[("V", "")])).unwrap(), "");
 }


### PR DESCRIPTION
## Summary

- Removes every em dash from this repository's public text: 1626 of them across 357 files, in the Markdown docs, the code comments, the workflows, the Debian packaging and two generated surfaces.
- Each is rewritten sentence by sentence, not substituted. A spaced hyphen left behind would be the same tell the standard warns about.
- No behaviour change, and no line added or removed anywhere.

## Changes

- **Markdown, 161 across 9 files.** `docs/commands.md` carried 48, `docs/docker-migration.md` 26, `docs/self-update.md` 23. Three `README.md` headings changed shape (`### Optional: macOS`), which moves their anchors; I grepped the tree and nothing links to them.
- **Code comments, roughly 1440.** `internal/compose/types/service.rs` alone had 98, all of one shape: a doc comment naming a backticked compose key, then a dash, then the description. A colon there would read as a doubled colon, since the compose key already ends in one, so those 98 took a verb instead (`` `image:` is the container image reference ``). The booleans do not take a verb, so there the dash became a comma.
- **Generated text kept in step with its generator.** `bench/chart.py` writes the SVG title, so `docs/assets/bench.svg` changed with it. `about.hbs` renders the NOTICES attribution line.
- **`debian/changelog`, 27**, all in entries for 2.0.0 through 4.0.0. `dpkg-parsechangelog` still reads the file.
- **Deliberately left alone:** `bench/aggregate.py` returns an em-dash string for a table cell with no measurement. That is a data glyph rather than punctuation, and changing it would alter published benchmark output without removing any tell.

`git diff --numstat` shows every file at equal insertions and deletions, so `line-limit` cannot move and the diff reads one line for one line.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally (2385 tests, 0 failures)
- [x] `./tests/shell/*.test.sh` pass locally (every tracked test, including `ci-runs-every-test.test.sh`)
- [x] shellcheck is clean on every tracked `*.sh` and every extensionless script with a shell shebang
- [ ] Podman lane ran (live Podman 5 and Podman 6, in the PR's own check run) for changes to `internal/`, the engine integration, or the libpod REST adapter
- [ ] Asset-contract fixtures ran for changes to `install.sh`, `install.ps1`, `internal/update/install.rs`, the signing scripts or the release fixtures

The last two run in this PR's own checks rather than locally; `internal/` and `install.sh` are both touched, comments only in each. This PR adds and changes no check, so there is no control to delete and watch go red. What it does touch is the wording of existing log and error strings, and I grepped the suites for every reworded string first to confirm none is asserted on.

- [ ] New or changed checks were verified by deleting the control and watching them fail

## Checklist

- [x] Targets `develop` (the release pull request that targets `main` is the one exception, gated by `reusable-main-guard.yml`)
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed (`required_signatures` is enforced on `develop` and `main`)
- [x] Labels applied (`type:`, `prio:`, `effort:`, `area:` where applicable)
- [x] Every new file in `tests/shell/` is named in some workflow's `test-command` (no new file here)
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] Docs updated if behaviour changed (behaviour is unchanged; the docs change is the point of the PR)
- [x] `Cargo.toml` and `debian/changelog` are at the same version (neither version line is touched)
- [x] `cargo build --release --locked --bin podup` fits `bench/binary-budget-mib` for changes that can move the binary size (comments and docs cannot move it)

## Related issues

Refs #1711.
