### PR TITLE
fix(audit): stop reporting unpinned_image on a tag the service builds itself

### DIFF
--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -272,6 +272,14 @@ fn check_secret_in_environment(name: &str, service: &Service, _file: &ComposeFil
 /// `image:` is unpinned: no tag (defaults to `latest`), tag is `latest`,
 /// or `latest` is not pinned by a digest. An `@sha256:` digest counts as
 /// pinned even when a tag is also present.
+///
+/// A `build:` service can still pull when its image is missing locally and
+/// the pull policy asks for one, so a blanket skip on `build:` would hide
+/// a real registry reference. Only skip when the policy itself forbids
+/// the fetch: `pull_policy: build` or `pull_policy: never`. In every
+/// other case where `build:` is present the finding still fires, but
+/// names the operator-actionable fix (set `pull_policy: build`) instead
+/// of asking for a digest that no registry can serve.
 fn check_unpinned_image(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
 	let Some(reference) = service.image.as_deref() else {
 		// A `build:` service without an `image:` is built from source and
@@ -288,22 +296,38 @@ fn check_unpinned_image(name: &str, service: &Service, _file: &ComposeFile) -> V
 	// The tag/separator sits after the last colon not preceded by a slash;
 	// an image with no tag stops there.
 	let has_tag = last_colon > last_slash;
-	if !has_tag {
+	let needs_finding = !has_tag || &reference[last_colon + 1..] == "latest";
+	if !needs_finding {
+		return Vec::new();
+	}
+	if service.build.is_some()
+		&& matches!(
+			service.pull_policy.as_deref(),
+			Some("build") | Some("never")
+		) {
+		// Skip here: the operator's `pull_policy` already commits to a
+		// local-only run, so the check would duplicate a decision the
+		// policy has locked in and have nothing actionable to add.
+		return Vec::new();
+	}
+	if service.build.is_some() {
+		// Use a different message because a digest can only anchor a tag
+		// that exists in some registry; for a locally built image the
+		// actionable fix is the pull policy, not a pin.
 		return vec![finding(
 			name,
 			"unpinned_image",
-			&format!("image: {reference} has no tag; defaults to :latest"),
+			&format!(
+				"image: {reference} is built here, so a digest cannot pin it; set pull_policy: build to keep it from being pulled"
+			),
 		)];
 	}
-	let tag = &reference[last_colon + 1..];
-	if tag == "latest" {
-		return vec![finding(
-			name,
-			"unpinned_image",
-			&format!("image: {reference} pins to :latest, which moves under you"),
-		)];
-	}
-	Vec::new()
+	let msg = if !has_tag {
+		format!("image: {reference} has no tag; defaults to :latest")
+	} else {
+		format!("image: {reference} pins to :latest, which moves under you")
+	};
+	vec![finding(name, "unpinned_image", &msg)]
 }
 
 /// Construct one [`Finding`]. Private to this module so callers always go

--- a/internal/audit/checks_more_tests.rs
+++ b/internal/audit/checks_more_tests.rs
@@ -263,6 +263,125 @@ services:
 	);
 }
 
+#[test]
+fn audit_unpinned_image_keeps_existing_message_when_no_build() {
+	// Row 1 of the build+image+pull_policy matrix: a `:latest` image on a
+	// service with no `build:` keeps the legacy wording because no locally
+	// produced artifact is in play.
+	let yaml = r#"
+services:
+  web:
+    image: myapp:latest
+"#;
+	let findings = report_for(yaml);
+	let f = findings
+		.iter()
+		.find(|f| f.check == "unpinned_image")
+		.expect("unpinned_image must fire when no build is present");
+	assert!(
+		f.reason.contains("pins to :latest, which moves under you"),
+		"row 1 must keep the legacy wording, got: {f:?}"
+	);
+	assert!(
+		!f.reason.contains("is built here"),
+		"row 1 must not switch to the built-here wording, got: {f:?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_flags_build_service_with_latest_under_default_policy() {
+	// Row 3 of the matrix: `build:` + `:latest` with the default
+	// `pull_policy` (missing) still fires because the policy does not
+	// forbid a fetch when the image is absent locally, so the
+	// operator-actionable message has to name the policy as the fix.
+	let yaml = r#"
+services:
+  web:
+    image: myapp:latest
+    build: .
+"#;
+	let findings = report_for(yaml);
+	let f = findings
+		.iter()
+		.find(|f| f.check == "unpinned_image")
+		.expect("unpinned_image must fire on a built service under default policy");
+	assert!(
+		f.reason.contains("is built here"),
+		"row 3 must name the locally-built origin, got: {f:?}"
+	);
+	assert!(
+		f.reason.contains("pull_policy: build"),
+		"row 3 must recommend `pull_policy: build`, got: {f:?}"
+	);
+	assert!(
+		!f.reason.contains("pins to :latest, which moves under you"),
+		"row 3 must not use the legacy wording, got: {f:?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_passes_when_build_and_pull_policy_build() {
+	// Row 4 of the matrix: the policy itself commits to a local-only run,
+	// so the check has nothing actionable to add.
+	let yaml = r#"
+services:
+  web:
+    image: myapp:latest
+    build: .
+    pull_policy: build
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "unpinned_image"),
+		"`pull_policy: build` must suppress the check on a built service: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_passes_when_build_and_pull_policy_never() {
+	// Row 5 of the matrix: `pull_policy: never` is the other policy that
+	// forbids the fetch, so the same skip applies.
+	let yaml = r#"
+services:
+  web:
+    image: myapp:latest
+    build: .
+    pull_policy: never
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "unpinned_image"),
+		"`pull_policy: never` must suppress the check on a built service: {findings:#?}"
+	);
+}
+
+#[test]
+fn audit_unpinned_image_flags_build_service_with_pull_policy_always() {
+	// Row 6 of the matrix: `pull_policy: always` still pulls even when
+	// the image is local, so the registry can race the build; the
+	// built-here message is the only one that names the right fix.
+	let yaml = r#"
+services:
+  web:
+    image: myapp:latest
+    build: .
+    pull_policy: always
+"#;
+	let findings = report_for(yaml);
+	let f = findings
+		.iter()
+		.find(|f| f.check == "unpinned_image")
+		.expect("unpinned_image must fire on a built service under pull_policy: always");
+	assert!(
+		f.reason.contains("is built here"),
+		"row 6 must name the locally-built origin, got: {f:?}"
+	);
+	assert!(
+		f.reason.contains("pull_policy: build"),
+		"row 6 must recommend `pull_policy: build`, got: {f:?}"
+	);
+}
+
 /// `CAP_SYS_ADMIN`, `sys_admin` and `SYS_ADMIN` are the same capability, and
 /// compose files carry all three spellings; the check has to read them alike.
 #[test]


### PR DESCRIPTION
## Summary

- `podup audit` no longer reports `unpinned_image` for a service whose `pull_policy` already forbids a fetch (`build` or `never`) while it builds the tag itself.
- Where the policy still allows a fetch, the finding stays but names the fix that applies: set `pull_policy: build`. A digest cannot anchor a tag that exists in no registry.
- Fixes #1710.

## Changes

- `internal/audit/checks.rs`: `check_unpinned_image` now consults `service.build` and `service.pull_policy`. The digest guard, the missing-`image:` guard and the tag parsing are untouched; the new branches sit after them.
- `internal/audit/checks_more_tests.rs`: five tests, one per row of the matrix below that the suite did not already cover. Two assert on the message text, because two rows differ from the existing behaviour only in wording.

Deliberately **not** a blanket skip on `build.is_some()`. With `build:` and `image:` both present and the policy at its default, Compose pulls when the image is absent, and `pull_services_with_options` (`internal/engine/build/pull.rs`) filters on `image.is_some()` with no `build:` exclusion, so `podup pull` does try to fetch such a tag. A blanket skip would trade this false positive for a blind spot on a real registry image that also carries a build fallback.

| `build:` | `image:` | `pull_policy:` | before | after |
|---|---|---|---|---|
| absent | `foo:latest` | default | flagged | flagged, wording unchanged |
| present | absent | default | not flagged | not flagged |
| present | `foo:latest` | default | flagged, "moves under you" | flagged, names `pull_policy: build` |
| present | `foo:latest` | `build` | flagged | not flagged |
| present | `foo:latest` | `never` | flagged | not flagged |
| present | `foo:latest` | `always` | flagged, "moves under you" | flagged, names `pull_policy: build` |

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally
- [x] `./tests/shell/*.test.sh` pass locally (every tracked test, including `ci-runs-every-test.test.sh`)
- [x] shellcheck is clean on every tracked `*.sh` and every extensionless script with a shell shebang
- [ ] Podman lane ran (live Podman 5 and Podman 6, in the PR's own check run) for changes to `internal/`, the engine integration, or the libpod REST adapter
- [ ] Asset-contract fixtures ran for changes to `install.sh`, `install.ps1`, `internal/update/install.rs`, the signing scripts or the release fixtures

The bug was reproduced against the shipped v5.9.1 binary before the change, on both the default policy and `pull_policy: build`, which is how I found that the policy was not being read at all. After it, the built binary reports the new message on the default-policy file and nothing at all on the `pull_policy: build` one.

Sabotage: I restored the old `check_unpinned_image` body while keeping the new tests, confirmed with `diff -q` that the file really changed, and ran them. Four of the five went red (the three policy rows and the new-wording row); the fifth stayed green, which is correct, because it pins the behaviour for a service with no `build:` and that behaviour is deliberately unchanged.

- [x] New or changed checks were verified by deleting the control and watching them fail

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] Docs updated if behaviour changed
- [x] `Cargo.toml` and `debian/changelog` are at the same version

## Related issues

Refs #1710.
