### PR TITLE
fix(audit): match secret_in_environment on name segments, not substrings

### DIFF
--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -48,10 +48,59 @@ pub(super) fn run_checks(
 	out
 }
 
-/// Field-name substring matching for the `secret_in_environment` check:
-/// `PASSWORD`, `SECRET`, `TOKEN`, `KEY`. Case-insensitive. The list is the
-/// issue, so it lives in one place.
-const SECRET_NAME_SUBSTRINGS: &[&str] = &["PASSWORD", "SECRET", "TOKEN", "KEY"];
+/// Field-name segments the `secret_in_environment` check matches after
+/// splitting: `PASSWORD`, `SECRET`, `TOKEN`, `KEY`. Comparison is segment
+/// equality, case-insensitive (segments are upper-cased before the
+/// lookup). Do not rename this back to a substring list: `contains` here
+/// reported `MONKEY_HABITAT` and `MD_Keywords` as hard-coded secrets
+/// (#1709), and the name is what says which of the two this is.
+const SECRET_NAME_SEGMENTS: &[&str] = &["PASSWORD", "SECRET", "TOKEN", "KEY"];
+
+/// Split an environment key into upper-case segments. Splits on the
+/// separators `_`, `-`, and `.`, and at camelCase (lower-to-upper) and
+/// PascalCase (upper-upper-followed-by-lower) boundaries. The camelCase
+/// split is what kept `apiToken` matching under the new rule; without
+/// it the helper would have treated `apiToken` as a single segment and
+/// the check would have stopped flagging it after the substring match
+/// was removed.
+fn segments(name: &str) -> Vec<String> {
+	let mut out = Vec::new();
+	for part in name.split(['_', '-', '.']) {
+		if part.is_empty() {
+			continue;
+		}
+		// Env keys are conventional identifiers and the keyword list is
+		// ASCII; working in bytes keeps the boundary check free of a
+		// UTF-8 decode at every step. A non-ASCII byte is upper-cased
+		// as-is and never splits on either side.
+		let bytes = part.as_bytes();
+		let mut start = 0;
+		let mut i = 1;
+		while i < bytes.len() {
+			let prev = bytes[i - 1];
+			let cur = bytes[i];
+			// Lower-to-upper: `aB`. A non-ASCII lead byte counts as the
+			// lower side: before this, `contains` flagged `NKey` spelled
+			// with a leading n-tilde, and dropping that would have been a
+			// silent false negative rather than the false positive #1709
+			// set out to remove. The split index is always an ASCII byte,
+			// so it is always a char boundary.
+			let lower_upper =
+				(prev.is_ascii_lowercase() || !prev.is_ascii()) && cur.is_ascii_uppercase();
+			// Upper-upper-followed-by-lower: `ABc` (PascalCase).
+			let upper_upper_lower = prev.is_ascii_uppercase()
+				&& cur.is_ascii_uppercase()
+				&& bytes.get(i + 1).is_some_and(|b| b.is_ascii_lowercase());
+			if lower_upper || upper_upper_lower {
+				out.push(part[start..i].to_ascii_uppercase());
+				start = i;
+			}
+			i += 1;
+		}
+		out.push(part[start..].to_ascii_uppercase());
+	}
+	out
+}
 
 /// `privileged: true`, grants extended host privileges that bypass the
 /// default capability set. Under rootless Podman the effect is reduced but
@@ -229,9 +278,11 @@ fn check_no_userns(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Fi
 	}
 }
 
-/// `environment:` key whose name contains `PASSWORD|SECRET|TOKEN|KEY`
-/// (case-insensitive) with a literal non-empty value. Bare keys (host
-/// inheritance) and unresolved `${VAR}` placeholders are not secrets.
+/// `environment:` key whose name, split into segments on `_`, `-`, `.`,
+/// and camelCase/PascalCase boundaries, has a segment equal to
+/// `PASSWORD|SECRET|TOKEN|KEY` (case-insensitive), with a literal
+/// non-empty value. Bare keys (host inheritance) and unresolved
+/// `${VAR}` placeholders are not secrets.
 ///
 /// Service-local: the check is a positional grep on the `environment:` map
 /// of this service. These are surfaced so the operator can
@@ -240,8 +291,11 @@ fn check_no_userns(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Fi
 fn check_secret_in_environment(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
 	let mut out = Vec::new();
 	for (key, value) in service.environment.to_map() {
-		let upper = key.to_ascii_uppercase();
-		if !SECRET_NAME_SUBSTRINGS.iter().any(|s| upper.contains(s)) {
+		let key_segments = segments(&key);
+		if !key_segments
+			.iter()
+			.any(|s| SECRET_NAME_SEGMENTS.contains(&s.as_str()))
+		{
 			continue;
 		}
 		let Some(value) = value else {

--- a/internal/audit/checks_more_tests.rs
+++ b/internal/audit/checks_more_tests.rs
@@ -419,3 +419,136 @@ fn audit_no_new_privileges_off_flags_an_explicit_false() {
 	);
 	assert!(report.iter().any(|f| f.check == "no_new_privileges_off"));
 }
+
+// ---------------------------------------------------------------------------
+// secret_in_environment: segment equality replaces the old substring match
+// (issue 1709). The four keyword-segment rows below each pin one shape:
+// a name where a keyword only appears as a substring, a name where the
+// segment merely starts with a keyword, underscore/dot separators, and
+// camelCase splits. The fifth test pins the helper itself, so a regression
+// in how segments are computed is caught before it can masquerade as a
+// verdict change.
+// ---------------------------------------------------------------------------
+
+/// `MONKEY_HABITAT` contains `KEY` only as a substring; its segments
+/// (`MONKEY`, `HABITAT`) match no keyword. The old `contains` rule
+/// flagged this name; segment equality leaves it silent.
+#[test]
+fn audit_secret_in_environment_silent_when_keyword_only_appears_as_substring() {
+	let yaml = r#"
+services:
+  app:
+    image: alpine:3.20
+    environment:
+      - MONKEY_HABITAT=bananas
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		!findings.iter().any(|f| f.check == "secret_in_environment"),
+		"MONKEY_HABITAT must NOT fire secret_in_environment; got {findings:#?}"
+	);
+}
+
+/// `MD_Keywords` has segments `MD`, `KEYWORDS`. `KEYWORDS` starts with
+/// `KEY` but does not equal it, so the check stays silent. The same is
+/// true for `MD_Terminos`, which has no overlap with any keyword at
+/// all; grouping them keeps the load-bearing case (KEYWORDS vs KEY)
+/// next to its non-overlap sibling.
+#[test]
+fn audit_secret_in_environment_silent_when_segment_only_starts_with_keyword() {
+	for key in ["MD_Keywords", "MD_Terminos"] {
+		let yaml = format!(
+			"services:\n  app:\n    image: alpine:3.20\n    environment:\n      - {key}=value\n"
+		);
+		let findings = report_for(&yaml);
+		assert!(
+			!findings.iter().any(|f| f.check == "secret_in_environment"),
+			"{key} must NOT fire secret_in_environment; got {findings:#?}"
+		);
+	}
+}
+
+/// `DB_PASSWORD`, `AWS_SECRET_ACCESS_KEY`, `API_X_Token`, `API_YT_Key`,
+/// `my.secret.value` each split into segments that include a full
+/// keyword. `_` and `.` are the two separators the helper treats like
+/// `WORD` boundaries; they are pinned together here so a regression
+/// that drops one separator is caught.
+#[test]
+fn audit_secret_in_environment_flags_keys_split_by_underscore_or_dot() {
+	for key in [
+		"DB_PASSWORD",
+		"AWS_SECRET_ACCESS_KEY",
+		"API_X_Token",
+		"API_YT_Key",
+		"my.secret.value",
+	] {
+		let yaml = format!(
+			"services:\n  app:\n    image: alpine:3.20\n    environment:\n      - {key}=value\n"
+		);
+		let findings = report_for(&yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "secret_in_environment"),
+			"{key} must fire secret_in_environment; got {findings:#?}"
+		);
+	}
+}
+
+/// `apiToken` and `API_T_ClientSecret` carry their keyword inside a
+/// run-on word; the camelCase split is what surfaces it. Without it
+/// the helper would have left each name as a single segment, and
+/// these two cases would have become false negatives after the
+/// substring match was removed.
+#[test]
+fn audit_secret_in_environment_flags_camel_case_keys() {
+	for key in ["apiToken", "API_T_ClientSecret"] {
+		let yaml = format!(
+			"services:\n  app:\n    image: alpine:3.20\n    environment:\n      - {key}=value\n"
+		);
+		let findings = report_for(&yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "secret_in_environment"),
+			"{key} must fire secret_in_environment; got {findings:#?}"
+		);
+	}
+}
+
+/// A non-ASCII lead byte counts as the lower side of a camelCase
+/// boundary. Measured while reviewing #1709: without that clause the
+/// segment split swallowed the key whole, so a name the old substring
+/// match reported went silent, trading the false positive for a false
+/// negative.
+#[test]
+fn audit_secret_in_environment_flags_camel_case_after_a_non_ascii_byte() {
+	let yaml =
+		"services:\n  app:\n    image: alpine:3.20\n    environment:\n      - \u{d1}Key=value\n";
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "secret_in_environment"),
+		"a key whose Key segment follows a non-ASCII byte must fire secret_in_environment; got {findings:#?}"
+	);
+}
+
+/// Helper contract: the segments the helper produces for each row of
+/// the issue's truth table. A regression in the split (a missing
+/// camelCase boundary, a dropped separator) flips this test red
+/// before the verdict tests above can pass on accident.
+#[test]
+fn audit_secret_in_environment_segments_split_at_case_and_separator_boundaries() {
+	let cases: &[(&str, &[&str])] = &[
+		("MONKEY_HABITAT", &["MONKEY", "HABITAT"]),
+		("MD_Keywords", &["MD", "KEYWORDS"]),
+		("MD_Terminos", &["MD", "TERMINOS"]),
+		("API_X_Token", &["API", "X", "TOKEN"]),
+		("API_T_ClientSecret", &["API", "T", "CLIENT", "SECRET"]),
+		("API_YT_Key", &["API", "YT", "KEY"]),
+		("DB_PASSWORD", &["DB", "PASSWORD"]),
+		("AWS_SECRET_ACCESS_KEY", &["AWS", "SECRET", "ACCESS", "KEY"]),
+		("apiToken", &["API", "TOKEN"]),
+		("my.secret.value", &["MY", "SECRET", "VALUE"]),
+	];
+	for (name, expected_segments) in cases {
+		let got = super::segments(name);
+		let got_refs: Vec<&str> = got.iter().map(String::as_str).collect();
+		assert_eq!(got_refs, *expected_segments, "wrong segments for {name}");
+	}
+}

--- a/internal/audit/checks_more_tests.rs
+++ b/internal/audit/checks_more_tests.rs
@@ -162,7 +162,7 @@ fn audit_secret_in_environment_flags_literal_secret_keys() {
 			findings.iter().any(|f| f.check == "secret_in_environment"),
 			"environment: {key}=literal must fire secret_in_environment; got {findings:#?}"
 		);
-		// The reason must name the key without echoing the value back ,
+		// The reason must name the key without echoing the value back:
 		// the literal value would defeat the whole point of the audit.
 		let f = findings
 			.iter()


### PR DESCRIPTION
## Summary

- `podup audit` no longer reports `secret_in_environment` for a name that merely *contains* `PASSWORD`, `SECRET`, `TOKEN` or `KEY`. `MONKEY_HABITAT` and `MD_Keywords` are silent; `DB_PASSWORD`, `apiToken` and `API_T_ClientSecret` still fire.
- The name is split into segments and each segment is compared for equality, so `KEYWORDS` is not `KEY`.
- Fixes #1709.

## Changes

- `internal/audit/checks.rs`: new private `segments()` helper splitting on `_`, `-`, `.` and at camelCase/PascalCase boundaries; `check_secret_in_environment` compares segments for equality. The constant is renamed from `SECRET_NAME_SUBSTRINGS` to `SECRET_NAME_SEGMENTS`, because a name that says "substring" next to equality matching is a name that will mislead the next reader.
- `internal/audit/checks_more_tests.rs`: six tests. One per group of the issue's truth table, one pinning the exact segment list for all ten rows (so a split regression surfaces before the verdict tests can pass by accident), and one for the non-ASCII case below.
- A second commit fixes an unrelated stray `back , the` in a neighbouring comment. It predates the em-dash sweep in `eb29897`; I only noticed it because I was editing the file.

No deny list of words like `KEYWORDS` or `KEYRING`. Segment equality gets the same result without a list that never stops growing.

| name | segments | before | after |
|---|---|---|---|
| `MONKEY_HABITAT` | MONKEY, HABITAT | flagged | silent |
| `MD_Keywords` | MD, KEYWORDS | flagged | silent |
| `MD_Terminos` | MD, TERMINOS | silent | silent |
| `API_X_Token` | API, X, TOKEN | flagged | flagged |
| `API_T_ClientSecret` | API, T, CLIENT, SECRET | flagged | flagged |
| `API_YT_Key` | API, YT, KEY | flagged | flagged |
| `DB_PASSWORD` | DB, PASSWORD | flagged | flagged |
| `AWS_SECRET_ACCESS_KEY` | AWS, SECRET, ACCESS, KEY | flagged | flagged |
| `apiToken` | API, TOKEN | flagged | flagged |
| `my.secret.value` | MY, SECRET, VALUE | flagged | flagged |

### One case the issue did not cover

A non-ASCII byte counts as the lower side of a camelCase boundary. The first version of the split required `prev.is_ascii_lowercase()`, and the lead byte of an n-tilde is not, so a key spelled `<n-tilde>Key` was swallowed whole and went silent, when `contains` had reported it. That is a false negative introduced while removing a false positive, which is a worse trade than the bug. One extra term and a test pin it. Measured against the built binary: `SENA_SECRET` (with n-tilde) and `<n-tilde>Key` fire, `CLAVE_MANANA` (with n-tilde) does not.

### The test file is now warning on line-limit

Rebased onto `develop` after #1713 landed. `internal/audit/checks_more_tests.rs` is at 432 code lines: 242 before either audit fix, 342 after #1713, 432 after this one. The soft limit is 300 and the hard limit is 500, so the gate warns and does not fail.

I only caught this after the rebase, because on #1713 I checked `wc -l` against 500 rather than the code-line count against 300, which is the number the gate reads. Tracked as #1715 rather than folded in here: splitting the file is a separate change and would bury the fix.

## Test plan

- [x] `cargo fmt --all --check` is clean
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test --locked --all-features --workspace` passes locally (33 test binaries, 0 failures)
- [x] `./tests/shell/*.test.sh` pass locally
- [x] shellcheck is clean on every tracked `*.sh`
- [ ] Podman lane ran (live Podman 5 and Podman 6, in the PR's own check run)
- [ ] Asset-contract fixtures ran

Reproduced against the shipped v5.9.1 binary first: `MD_Keywords` and `MONKEY_HABITAT` reported, `MD_Terminos` (same value, different name) not, which isolates the name match as the cause. `audit --strict` exited 1. The built binary reports neither afterwards.

Sabotage: reverting `checks.rs` wholesale is not a valid sabotage here, because the segment-contract test calls the helper and the build fails, which is red for the wrong reason. So I put the `contains` call back and left the helper in place, which reintroduces the defect and nothing else. Two tests went red, `silent_when_keyword_only_appears_as_substring` and `silent_when_segment_only_starts_with_keyword`; the other eight stayed green, which is correct, because they pin behaviour `contains` also satisfied.

- [x] New or changed checks were verified by deleting the control and watching them fail

## Checklist

- [x] Targets `develop`
- [x] Commits are signed off (DCO, `git commit -s`)
- [x] Commits are signed
- [x] Labels applied
- [x] No secrets, keys or credentials in code, logs or fixtures
- [x] Docs updated if behaviour changed
- [x] `Cargo.toml` and `debian/changelog` are at the same version

## Related issues

Refs #1709.
