### PR TITLE
ci: report when a protected branch is red

### DIFF
--- a/.github/scripts/check-branch-conclusion.sh
+++ b/.github/scripts/check-branch-conclusion.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Decide whether the newest completed run of a workflow on a branch is a
+# pass. Extracted from the step in `reusable-branch-health.yml` so the
+# conclusion logic can be exercised against planted API answers without
+# `gh` or the network.
+#
+# Reads the GitHub API response on stdin (the JSON returned by
+# `repos/:owner/:repo/actions/workflows/:workflow/runs?branch=:branch&status=completed&per_page=1`),
+# prints a one-line summary on stdout, and exits 0 only when the
+# newest run's `conclusion` is `success`.
+#
+# Exits 1 otherwise. The line printed is the same one the workflow step
+# surfaces, so a planted test can match on it.
+
+set -euo pipefail
+
+workflow=${WORKFLOW:?WORKFLOW env var is required}
+branch=${BRANCH:?BRANCH env var is required}
+
+# Pull both fields out of the response in a single `jq` call. `jq` reads
+# stdin exactly once, so two separate calls would race for the input and
+# the second would see nothing. `gh api ... --jq` gives exactly the same
+# shape on a runner; here `jq` is the same dependency the workflow
+# already requires for the JSON parsing elsewhere, so this script does
+# not introduce a new tool.
+#
+# Each filter emits one line, in order, so two reads pick them up cleanly.
+# Joining them on a single tab-separated line and slicing with shell
+# parameter expansion would also work; two reads is the shape the rest of
+# the test suite uses (`grep | sed | while read`) and reads the same way.
+fields="$(jq -r '.workflow_runs[0].conclusion // empty, .workflow_runs[0].html_url // empty')"
+conclusion="$(printf '%s\n' "$fields" | sed -n '1p')"
+run_url="$(printf '%s\n' "$fields" | sed -n '2p')"
+
+if [ -z "$conclusion" ]; then
+	echo "::error::No completed run of ${workflow} on record for branch ${branch}."
+	echo "A protected branch with no completed run is not a branch to release from." >&2
+	exit 1
+fi
+
+echo "Newest completed run of ${workflow} on ${branch}: conclusion=${conclusion}, url=${run_url}"
+
+case "$conclusion" in
+	success)
+		echo "Within the success threshold."
+		exit 0
+		;;
+	failure)
+		echo "::error::Newest completed run of ${workflow} on ${branch} failed: ${run_url}"
+		exit 1
+		;;
+	cancelled)
+		# A cancelled run is a suite that was interrupted, not one that
+		# passed. Reporting it as success would let a published branch
+		# carry a "we never finished" verdict; reporting it as a generic
+		# failure loses the reason. So name it.
+		echo "::error::Newest completed run of ${workflow} on ${branch} was cancelled: ${run_url}"
+		echo "A cancelled run on a protected branch is a published state whose suite was interrupted." >&2
+		exit 1
+		;;
+	skipped)
+		# Skipped is the workflow's own gate deciding not to run for the
+		# branch. On a branch whose `on:` is supposed to cover it, that is
+		# the gate not exercising the protection the comment claims.
+		echo "::error::Newest completed run of ${workflow} on ${branch} was skipped: ${run_url}"
+		echo "A skipped run on a protected branch is the workflow deciding not to exercise the gate." >&2
+		exit 1
+		;;
+	*)
+		# Any other conclusion (timed_out, action_required, neutral,
+		# startup_failure, stale) is also not success. The workflow does
+		# not enumerate them, and this script is the single place that
+		# decides which ones to enumerate.
+		echo "::error::Newest completed run of ${workflow} on ${branch} has unexpected conclusion ${conclusion}: ${run_url}"
+		exit 1
+		;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,43 @@ jobs:
       workflow: benchmark.yml
       max-age-days: 65
 
+  # Fails when the newest COMPLETED run of `ci.yml` on a protected branch is
+  # not a success. The freshness watchers above cannot catch this: they read
+  # the newest SUCCESSFUL scheduled run, so a failing scheduled run is
+  # missing from their answer by construction. A protected branch whose
+  # gates are red is the published state failing rather than a broken
+  # integration branch, and that is the gap this closes.
+  #
+  # Two jobs, one per branch. They MUST stay separate. Each name carries
+  # the branch it watches, and a single job that watched both would emit
+  # one check name covering two branches - and a check name that does not
+  # move is the property required checks depend on (Glyndor/podup#1552).
+  #
+  # MUST NOT BECOME A REQUIRED STATUS CHECK. A red `main` would then block
+  # the pull request that repairs it, which is the exact failure mode this
+  # check exists to surface. The reason is repeated inside the reusable,
+  # where somebody wiring required checks would look first. Do not remove
+  # either copy.
+  health-main:
+    name: branch health (main)
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+
+  health-develop:
+    name: branch health (develop)
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: develop
+
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
   # when no pull request has been opened recently enough.

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -57,7 +57,18 @@ jobs:
       # clang/otool (Linux, most non-macOS); the workflow only invokes it,
       # the script only runs the controls where the tools exist, and
       # ci-runs-every-test.test.sh still sees the file as wired.
-      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh
+      #
+      # branch-health-conclusion.test.sh exercises the conclusion script
+      # the branch-health reusable calls.
+      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh
+      # branch-health-conclusion.test.sh pipes API JSON into the
+      # conclusion script and asserts exit codes. jq is the tool that
+      # turns the response into shell-readable lines, and it is not in
+      # the runner's base image. Install it through the reusable's
+      # apt-packages input rather than a one-off step so the dependency
+      # travels with the test, and shellcheck keeps a single place to
+      # see what the suite needs.
+      apt-packages: jq
 
   # The macOS gate on a Mac. The fixture skips where clang/otool/nm are
   # absent, so on the Linux job above it never runs; the first release that

--- a/.github/workflows/reusable-branch-health.yml
+++ b/.github/workflows/reusable-branch-health.yml
@@ -1,0 +1,116 @@
+name: Branch health (reusable)
+
+# Fails when the newest COMPLETED run of a workflow on a branch is not a
+# success.
+#
+# The companion guard `reusable-schedule-freshness.yml` watches workflows
+# that fire on `event=schedule`; this one watches a workflow on a branch.
+# The two together are the same idea in two places: a thing that is
+# supposed to be true about a workflow is converted from "silence when
+# broken" into a red check on ordinary work, because nobody watches a
+# quiet log.
+#
+# The defect that prompted this file: the freshness watchers cannot catch
+# it. They read the newest SUCCESSFUL scheduled run, so a failing run is
+# missing from their answer by construction. On 2026-09-06 three
+# distribution channels sat with `main` red for twenty minutes after a
+# pull request merged while its suite was still reporting, and the only
+# reason anybody knew is that somebody went looking. The fix the other
+# three shipped was `scripts/check-suite-on-main.sh`; this file mirrors
+# its shape, not its spelling, because those repos are shell-only and
+# this one runs on GitHub Actions.
+#
+# Three states that are NOT failures and must not be reported as one:
+#
+# 1. A run still in progress. `status=completed` in the API query
+#    excludes it, and the comment on the `gh api` line says so. Do NOT
+#    widen the filter to "newest run of any status"; an in-progress run
+#    reported as a failure would defeat the purpose of this check.
+# 2. An empty history. A protected branch whose suite has never
+#    completed is not a branch anybody should be releasing from, so the
+#    empty case fails with a message that says "no completed run on
+#    record". Make that non-fatal only with a reason; the script does
+#    not.
+# 3. A conclusion of `cancelled` or `skipped`, which are neither success
+#    nor failure. Both are decided as failures: a cancelled run is a
+#    suite that was interrupted, and a skipped one is the workflow's own
+#    gate deciding not to exercise the branch it claims to protect.
+#    Reporting either as success would let a published branch carry a
+#    "we never finished" verdict.
+#
+# Permissions: same as the freshness reusable. A called workflow cannot
+# elevate beyond the permissions of the workflow that calls it, and
+# reading this repository's run history needs `actions: read`. Without
+# that grant the run does not start.
+#
+# NOT A REQUIRED STATUS CHECK. A red `main` would then block the pull
+# request that repairs it, which is exactly the situation this check
+# exists to surface. The reason lives beside the `uses:` line below; do
+# not remove it.
+
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        description: >-
+          File name of the workflow to check, e.g. "ci.yml".
+        type: string
+        required: true
+      branch:
+        description: >-
+          Branch to read the newest completed run for, e.g. "main".
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: branch-health-${{ github.workflow }}-${{ github.ref }}-${{ inputs.workflow }}-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  health:
+    name: branch health
+    runs-on: ubuntu-latest
+    # Bound: the request itself is small; ten seconds covers the fetch and the
+    # jq pass. Ten times that, rounded up; the six-hour default is what a hang
+    # would otherwise cost.
+    timeout-minutes: 10
+    permissions:
+      actions: read # reading this repository's workflow-run history
+    steps:
+      # The step below runs a script from this repository, so the tree has to be
+      # here. Without this the job dies with `No such file or directory` and exit
+      # 127, which reads like a broken script rather than a missing checkout.
+      #
+      # `persist-credentials: false` because nothing here writes: the API read
+      # uses GITHUB_TOKEN from the env below, and leaving a credential in the
+      # git config of a job that never pushes is reach it has no use for.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # This step runs as GITHUB_TOKEN, a job-scoped token on its own rate
+      # limit, and reads nothing beyond this repository's own run history. No
+      # personal credential is ever used here, and the `actions: read` grant
+      # above is the whole of what it can reach.
+      - name: Check the newest completed run on the branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ inputs.workflow }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          # `status=completed` excludes runs that are queued or in progress;
+          # do NOT widen this to all statuses. A run that is still running
+          # would otherwise be reported as a failure, and the job that
+          # repairs the branch would block itself with a verdict nobody
+          # has finished reaching.
+          #
+          # `per_page=1` returns the newest match. The full set is not
+          # needed; the question is "is the most recent run a success".
+          gh api \
+            "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=${BRANCH}&status=completed&per_page=1" \
+            | bash .github/scripts/check-branch-conclusion.sh

--- a/tests/shell/branch-health-conclusion.test.sh
+++ b/tests/shell/branch-health-conclusion.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# `check-branch-conclusion.sh` decides whether the newest completed run of a
+# workflow on a branch is a pass. It is the only piece of behaviour in the
+# branch-health guard, and the rest of it is a YAML wiring the shell script
+# is fed by `gh api`. A test that exercises the wiring but not the decision
+# proves nothing about the decision.
+#
+# The harness here plants API answers on stdin and asserts exit code plus
+# the matching summary line. Three states the brief calls out by name --
+# `success` passes, `failure` fails, an empty list reports "no run on
+# record" -- are covered with the same JSON the GitHub API returns today,
+# plus `cancelled` and `skipped`, which the reusable's comment says it
+# treats as failures (the comment above the script's `case` is the
+# contract this test pins).
+#
+# Each plant is a complete `repos/.../runs` response, not just the array,
+# because the script reads `.workflow_runs[0]` and would behave differently
+# against a bare array vs. an envelope. Building plants out of the envelope
+# is the cheapest way to read what the script reads.
+#
+# Requires: bash, jq, the script under test, nothing else.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+script=.github/scripts/check-branch-conclusion.sh
+[ -x "$script" ] || { echo "FAIL  $script is not executable in git"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL  jq is required to run this test"; exit 1; }
+
+pass=0; fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Run the script under test against a planted API answer. The script
+# reads WORKFLOW and BRANCH from the environment, so the harness passes
+# them in.
+run_with() { # <workflow> <branch> <json-on-stdin>
+	WORKFLOW="$1" BRANCH="$2" bash "$script" <<<"$3"
+}
+
+# Each plant is a complete response from the workflow-runs endpoint, with
+# exactly one entry under `.workflow_runs`. The shape comes from the
+# GitHub docs and the value the script reads is `.workflow_runs[0].conclusion`.
+
+plant_success='{"workflow_runs":[{"id":1,"conclusion":"success","html_url":"https://x/r/1"}]}'
+plant_failure='{"workflow_runs":[{"id":2,"conclusion":"failure","html_url":"https://x/r/2"}]}'
+plant_cancelled='{"workflow_runs":[{"id":3,"conclusion":"cancelled","html_url":"https://x/r/3"}]}'
+plant_skipped='{"workflow_runs":[{"id":4,"conclusion":"skipped","html_url":"https://x/r/4"}]}'
+plant_empty='{"workflow_runs":[],"total_count":0}'
+
+# --- success passes ---
+out=$(run_with "ci.yml" "main" "$plant_success"); rc=$?
+check "success on main exits 0" "0" "$rc"
+check "success on main prints the url" "https://x/r/1" \
+	"$(printf '%s\n' "$out" | grep -oE 'https://x/r/[0-9]+' || true)"
+
+# --- failure fails ---
+out=$(run_with "ci.yml" "main" "$plant_failure"); rc=$?
+check "failure on main exits 1" "1" "$rc"
+check "failure on main names the conclusion" "failure" \
+	"$(printf '%s\n' "$out" | grep -oE 'conclusion=f[a-z]+' | head -1 | cut -d= -f2)"
+
+# --- cancelled fails and explains why ---
+out=$(run_with "ci.yml" "main" "$plant_cancelled"); rc=$?
+check "cancelled on main exits 1" "1" "$rc"
+case "$out" in
+	*cancelled*) check "cancelled on main is named" "yes" "yes" ;;
+	*) check "cancelled on main is named" "cancelled-named" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+# --- skipped fails and explains why ---
+out=$(run_with "ci.yml" "main" "$plant_skipped"); rc=$?
+check "skipped on main exits 1" "1" "$rc"
+case "$out" in
+	*skipped*) check "skipped on main is named" "yes" "yes" ;;
+	*) check "skipped on main is named" "skipped-named" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+# --- empty history fails with "no completed run on record" ---
+out=$(run_with "ci.yml" "main" "$plant_empty"); rc=$?
+check "empty history on main exits 1" "1" "$rc"
+case "$out" in
+	*"No completed run"*) check "empty history says no run on record" "yes" "yes" ;;
+	*) check "empty history says no run on record" "no-run-on-record" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+# --- the script's branch parameter actually surfaces in the message ---
+# Same input, different branch argument: the failure message names the
+# branch the caller asked about, not whichever the harness happens to use.
+out_main=$(run_with "ci.yml" "main" "$plant_failure")
+out_develop=$(run_with "ci.yml" "develop" "$plant_failure")
+case "$out_main" in
+	*"on main"*) check "failure message names branch=main" "yes" "yes" ;;
+	*) check "failure message names branch=main" "branch=main" "$(printf '%s\n' "$out_main" | head -1)" ;;
+esac
+case "$out_develop" in
+	*"on develop"*) check "failure message names branch=develop" "yes" "yes" ;;
+	*) check "failure message names branch=develop" "branch=develop" "$(printf '%s\n' "$out_develop" | head -1)" ;;
+esac
+
+# --- the script refuses to run without WORKFLOW or BRANCH ---
+out=$(WORKFLOW='' BRANCH=main bash "$script" <<<"$plant_success" 2>/dev/null); rc=$?
+check "missing WORKFLOW is fatal" "1" "$rc"
+out=$(WORKFLOW=ci.yml BRANCH='' bash "$script" <<<"$plant_success" 2>/dev/null); rc=$?
+check "missing BRANCH is fatal" "1" "$rc"
+
+# --- the negative control: a planted response the parser is asked to
+# reject, with a conclusion that does not exist in the API. The script
+# falls through to the default branch, which is "not success" rather
+# than silently passing. ---
+plant_unknown='{"workflow_runs":[{"id":5,"conclusion":"made_up","html_url":"https://x/r/5"}]}'
+out=$(run_with "ci.yml" "main" "$plant_unknown"); rc=$?
+check "unknown conclusion exits 1" "1" "$rc"
+case "$out" in
+	*"unexpected conclusion made_up"*) check "unknown conclusion is named" "yes" "yes" ;;
+	*) check "unknown conclusion is named" "unexpected-made_up" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+echo
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/tests/workflow_branch_health.rs
+++ b/tests/workflow_branch_health.rs
@@ -1,0 +1,372 @@
+//! The branch-health guard must cover both protected branches, query the
+//! newest COMPLETED run, and stay advisory rather than required.
+//!
+//! The reusable lives next to `reusable-schedule-freshness.yml` and is
+//! called from `ci.yml` for `main` and `develop`. The freshness watchers
+//! cannot catch this defect: they read the newest SUCCESSFUL scheduled
+//! run, so a failing run is missing from their answer by construction.
+//! On 2026-09-06 three distribution channels sat with `main` red for
+//! twenty minutes after a pull request merged while its suite was still
+//! reporting, and the only reason anybody knew is that somebody went
+//! looking. This file asserts the shape of the fix on every pull request,
+//! so the gap is closed at the moment it would otherwise re-open.
+//!
+//! Four properties, one test each, plus a planted negative control:
+//!
+//! 1. Both `main` and `develop` are covered. A single job that watched
+//!    both would emit one check name covering two branches, and a check
+//!    name that does not move is the property required checks depend on
+//!    (Glyndor/podup#1552). The two jobs stay separate.
+//! 2. The query asks for `status=completed`. Asking for the newest run of
+//!    any status would report an in-progress run as a failure, and the
+//!    pull request repairing the branch would block itself with a
+//!    verdict nobody has finished reaching.
+//! 3. The check is advisory. Reading the live rulesets requires the
+//!    GitHub Settings UI, and `gh api` is forbidden here, so the
+//!    property asserted is the comment beside the job explaining why it
+//!    must not be marked required. The reason is also beside the
+//!    `uses:` inside the reusable. Both copies must stay.
+//! 4. The parser reads what it claims. A planted YAML string with the
+//!    shape being asserted exercises the parser; a parser that always
+//!    returned true would satisfy the structural assertions and prove
+//!    nothing.
+//!
+//! The conclusion logic itself lives in
+//! `.github/scripts/check-branch-conclusion.sh` and is exercised against
+//! planted API answers in `tests/shell/branch-health-conclusion.test.sh`,
+//! which is the only assertion of behavior this repository can make
+//! without `gh`.
+
+use std::fs;
+use std::path::Path;
+
+fn read(name: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join(".github/workflows")
+		.join(name);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{name} is readable: {e}"))
+}
+
+/// Pull the value of a `branch:` input out of a job's `with:` block in
+/// `ci.yml`. Scoped to the named job so a future drift between the two
+/// `health-*` jobs is not papered over.
+///
+/// Same shape as `tests/workflow_toolchain_pin/deb_pair.rs`'s scoped
+/// parsers: the scan starts at the `with:` block under the named job
+/// (jobs live at the same indent in `ci.yml`) and stops when a sibling
+/// key at the same or lower indent appears.
+fn ci_yml_health_branch(workflow: &str, job_id: &str) -> String {
+	let lines: Vec<&str> = workflow.lines().collect();
+	let job_idx = lines
+		.iter()
+		.position(|l| l.trim_start_matches(' ').trim_start() == format!("{job_id}:"))
+		.unwrap_or_else(|| panic!("ci.yml has a `{job_id}` job"));
+	let job_indent = lines[job_idx].len() - lines[job_idx].trim_start().len();
+	let job_end = lines[job_idx + 1..]
+		.iter()
+		.position(|l| {
+			let trimmed = l.trim_start();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				return false;
+			}
+			let indent = l.len() - trimmed.len();
+			indent <= job_indent
+		})
+		.map(|p| p + job_idx + 1)
+		.unwrap_or(lines.len());
+
+	let with_idx = lines[job_idx + 1..job_end]
+		.iter()
+		.position(|l| l.trim() == "with:")
+		.unwrap_or_else(|| panic!("`{job_id}` in ci.yml has a `with:` block"));
+	let with_abs = job_idx + 1 + with_idx;
+
+	for line in &lines[with_abs + 1..job_end] {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some(rest) = trimmed.strip_prefix("branch:") {
+			return rest.trim().trim_matches('"').to_string();
+		}
+	}
+	panic!("`{job_id}` in ci.yml passes a `branch:` input");
+}
+
+/// Pull the workflow file name out of the same `with:` block.
+fn ci_yml_health_workflow(workflow: &str, job_id: &str) -> String {
+	let lines: Vec<&str> = workflow.lines().collect();
+	let job_idx = lines
+		.iter()
+		.position(|l| l.trim_start_matches(' ').trim_start() == format!("{job_id}:"))
+		.unwrap_or_else(|| panic!("ci.yml has a `{job_id}` job"));
+	let job_indent = lines[job_idx].len() - lines[job_idx].trim_start().len();
+	let job_end = lines[job_idx + 1..]
+		.iter()
+		.position(|l| {
+			let trimmed = l.trim_start();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				return false;
+			}
+			let indent = l.len() - trimmed.len();
+			indent <= job_indent
+		})
+		.map(|p| p + job_idx + 1)
+		.unwrap_or(lines.len());
+
+	let with_idx = lines[job_idx + 1..job_end]
+		.iter()
+		.position(|l| l.trim() == "with:")
+		.unwrap_or_else(|| panic!("`{job_id}` in ci.yml has a `with:` block"));
+	let with_abs = job_idx + 1 + with_idx;
+
+	for line in &lines[with_abs + 1..job_end] {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some(rest) = trimmed.strip_prefix("workflow:") {
+			return rest.trim().trim_matches('"').to_string();
+		}
+	}
+	panic!("`{job_id}` in ci.yml passes a `workflow:` input");
+}
+
+/// Job ids that have to keep their name. A required check is matched by
+/// name, so a renamed job is a phantom the ruleset still requires.
+const HEALTH_JOBS: &[&str] = &["health-main", "health-develop"];
+
+#[test]
+fn both_protected_branches_have_their_own_health_job() {
+	let ci = read("ci.yml");
+	let main = ci_yml_health_branch(&ci, "health-main");
+	let develop = ci_yml_health_branch(&ci, "health-develop");
+
+	assert_eq!(
+		main, "main",
+		"health-main passes branch={main:?}, not \"main\". A wrong branch \
+		 means the job watches the wrong history, and a red `main` goes \
+		 unreported on the only branch where the gap matters."
+	);
+	assert_eq!(
+		develop, "develop",
+		"health-develop passes branch={develop:?}, not \"develop\". Same \
+		 defect as a wrong value on health-main."
+	);
+}
+
+#[test]
+fn both_jobs_watch_the_same_workflow() {
+	let ci = read("ci.yml");
+	let main = ci_yml_health_workflow(&ci, "health-main");
+	let develop = ci_yml_health_workflow(&ci, "health-develop");
+	assert_eq!(
+		main, develop,
+		"health-main watches {main:?} but health-develop watches \
+		 {develop:?}. A different workflow on the two branches means one \
+		 of them is reading the wrong signal; the point of the pair is \
+		 they read the same one."
+	);
+}
+
+#[test]
+fn the_reusable_checks_out_the_tree_before_running_the_script() {
+	// The step runs a script from this repository. Without a checkout the job
+	// dies with `No such file or directory` and exit 127, which reads like a
+	// broken script rather than a missing step; it happened on the first run of
+	// this workflow, and the same omission cost two of the distribution
+	// channels a red job earlier the same day.
+	let reusable = read("reusable-branch-health.yml");
+	let checkout = reusable
+		.lines()
+		.position(|l| l.contains("actions/checkout@"))
+		.expect("the health job checks out the repository");
+	let script = reusable
+		.lines()
+		.position(|l| l.contains("check-branch-conclusion.sh"))
+		.expect("the health job runs the conclusion script");
+	assert!(
+		checkout < script,
+		"the checkout has to come before the script that needs the tree"
+	);
+	assert!(
+		reusable.contains("persist-credentials: false"),
+		"nothing here writes, so the checkout must not leave a credential behind"
+	);
+}
+
+#[test]
+fn the_reusable_asks_for_completed_runs_only() {
+	let reusable = read("reusable-branch-health.yml");
+	// The query must be a literal `status=completed` substring on a line
+	// that runs `gh api`. A reader that returned the newest run of any
+	// status would silently turn the guard into a "report in-progress
+	// runs as failures" alarm, which defeats the purpose.
+	let has_query = reusable.lines().any(|l| {
+		let trimmed = l.trim_start();
+		if trimmed.starts_with('#') {
+			return false;
+		}
+		trimmed.contains("status=completed")
+	});
+	assert!(
+		has_query,
+		"reusable-branch-health.yml's `gh api` call no longer asks for \
+		 status=completed. Asking for the newest run of any status would \
+		 report an in-progress run as a failure, and the pull request \
+		 repairing the branch would block itself with a verdict nobody \
+		 has finished reaching."
+	);
+
+	// And it must NOT ask for status=success alone, which would miss
+	// every failing run that should be the loudest signal of all.
+	let has_success_only = reusable.lines().any(|l| {
+		let trimmed = l.trim_start();
+		if trimmed.starts_with('#') {
+			return false;
+		}
+		trimmed.contains("status=success")
+	});
+	assert!(
+		!has_success_only,
+		"reusable-branch-health.yml's `gh api` call asks for status=success \
+		 on its own. That is the freshness watcher's shape and cannot \
+		 catch this defect: a failing run is missing from its answer by \
+		 construction. The whole point of this file is to read COMPLETED \
+		 runs and decide the conclusion itself."
+	);
+}
+
+#[test]
+fn the_check_is_advisory_and_the_file_says_so() {
+	let reusable = read("reusable-branch-health.yml");
+	let ci = read("ci.yml");
+
+	// The reusable carries the warning in its own header, where somebody
+	// wiring required checks against it would look first. The wording is
+	// deliberately emphatic ("NOT A REQUIRED STATUS CHECK"); the assertion
+	// is case-insensitive so future rewording that drops the caps still
+	// satisfies it, as long as the warning is present.
+	let reusable_warns = reusable.lines().any(|l| {
+		let lower = l.to_lowercase();
+		lower.contains("required status check") && lower.contains("not ")
+	});
+	assert!(
+		reusable_warns,
+		"reusable-branch-health.yml no longer carries the comment that \
+		 warns against making it a required status check. A red branch \
+		 would then block the pull request that repairs it, which is the \
+		 failure this check exists to surface."
+	);
+
+	// `ci.yml` carries a matching comment beside the job ids. Without
+	// both copies, a reviewer wiring the check required has to read the
+	// reusable to learn the rule, and the place they would actually look
+	// is the call site.
+	let ci_warns = ci
+		.lines()
+		.any(|l| l.contains("MUST NOT BECOME A REQUIRED STATUS CHECK"));
+	assert!(
+		ci_warns,
+		"ci.yml no longer carries the `MUST NOT BECOME A REQUIRED STATUS \
+		 CHECK` comment beside the branch-health jobs. That copy is what \
+		 stops a reviewer from marking them required at the call site, \
+		 which is where required checks are wired."
+	);
+
+	// Both jobs must keep their ids. A required check is matched by name,
+	// so a rename creates a phantom the ruleset still requires. The ids
+	// below are part of the wire format.
+	for id in HEALTH_JOBS {
+		assert!(
+			ci.contains(&format!("{id}:")),
+			"ci.yml is missing the `{id}` job. Renaming a job that is \
+			 intended as advisory is fine; the warning here is for the \
+			 branch-health pair, whose job ids are part of the file's \
+			 contract with this test."
+		);
+	}
+}
+
+/// The parser is what the structural tests trust. Pin it on input that
+/// differs from today's `ci.yml`, including a job whose `with:` block
+/// lists `workflow:` and `branch:` in the wrong order and a comment that
+/// names them out of scope. A parser that always returned the same
+/// string would pass every assertion above and prove nothing.
+#[test]
+fn the_branch_parser_reads_what_it_claims() {
+	// Both keys in the order the file happens to use.
+	let ci_a = "\
+jobs:
+  health-main:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+  health-develop:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: develop
+";
+	assert_eq!(ci_yml_health_branch(ci_a, "health-main"), "main");
+	assert_eq!(ci_yml_health_workflow(ci_a, "health-main"), "ci.yml");
+	assert_eq!(ci_yml_health_branch(ci_a, "health-develop"), "develop");
+
+	// Reversed order. The parser walks the `with:` block and stops on
+	// the first matching key, so the test it backs must be order-blind.
+	let ci_b = "\
+jobs:
+  health-main:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      branch: main
+      workflow: ci.yml
+";
+	assert_eq!(ci_yml_health_branch(ci_b, "health-main"), "main");
+	assert_eq!(ci_yml_health_workflow(ci_b, "health-main"), "ci.yml");
+
+	// A sibling job that also names `branch:` and `workflow:` in its
+	// own `with:` block must not contaminate the answer for the one
+	// being asked about.
+	let ci_c = "\
+jobs:
+  freshness-benchmark:
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
+    with:
+      workflow: benchmark.yml
+      max-age-days: 65
+  health-main:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+  health-develop:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: develop
+";
+	assert_eq!(
+		ci_yml_health_workflow(ci_c, "health-main"),
+		"ci.yml",
+		"the parser took the sibling's value"
+	);
+	assert_eq!(ci_yml_health_branch(ci_c, "health-main"), "main");
+
+	// A comment that names `branch:` and `workflow:` with fake values
+	// must not be returned.
+	let ci_d = "\
+jobs:
+  health-main:
+    # with:
+    #   workflow: fake.yml
+    #   branch: nonsense
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+";
+	assert_eq!(ci_yml_health_workflow(ci_d, "health-main"), "ci.yml");
+	assert_eq!(ci_yml_health_branch(ci_d, "health-main"), "main");
+}


### PR DESCRIPTION
## Summary

- Nothing reported that `main` or `develop` was failing its own gates.
- The freshness watchers cannot see it: `reusable-schedule-freshness`
reads the newest **successful** scheduled run of the workflow it names,
so a failing run is missing from its answer by construction.
- Fixes #1719.

## Why it matters more here

The three distribution channels hit this on 2026-09-06: a pull request
merged while its suite was still reporting, `main` red in two of them for
twenty minutes, and the only reason anybody knew is that somebody went
looking. Here the release is cut from `main`, so a red `main` is the
published state failing its gates rather than a broken integration
branch.

## Changes

- New `.github/workflows/reusable-branch-health.yml`: reads the newest
COMPLETED run of a workflow on a branch and fails when its conclusion is
not `success`. `status=completed` is what excludes a run still in
progress, and a comment says so, because that is the parameter somebody
later "simplifies" away.
- New `.github/scripts/check-branch-conclusion.sh`: the conclusion logic,
extracted so it can be exercised against planted API answers with no `gh`
and no network.
- `ci.yml`: two jobs, `health-main` and `health-develop`. They stay
separate because each check name carries the branch it watches, and a
stable check name is what a required check depends on.
- `lint-shell.yml`: runs the new shell test, and installs `jq`.

`cancelled` and `skipped` are named rather than folded into a generic
failure. Neither is a pass: a cancelled run is a suite that was
interrupted, and a skipped one is the workflow deciding not to exercise
the gate at all. An empty history fails with its own message, because a
protected branch with no completed run is not a branch to release from.

**Neither job may become a required status check.** A red branch would
then block the pull request that repairs it, which is the failure this
exists to surface. The reason is written twice, in `ci.yml` beside the
jobs and inside the reusable, and both copies say not to remove the
other.

## Tests

- `tests/shell/branch-health-conclusion.test.sh`: sixteen assertions over
six cases plus a negative control, driving the real script against
planted API answers. `success` passes; `failure`, `cancelled`, `skipped`
and an unknown conclusion each fail with their own message; an empty list
reports no run on record.
- `tests/workflow_branch_health.rs`: five tests over the workflow shape,
with a planted YAML negative control proving the parser reads what it
claims to.