### PR TITLE
ci: see the two other ways a job holds a secret

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -30,8 +30,10 @@ on:
       # without this line a pull request that touches only the reusable
       # merges without ever running it.
       - ".github/workflows/reusable-shell-ci.yml"
+      - ".github/workflows/reusable-workflow-lint.yml"
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
+      - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -60,7 +62,7 @@ jobs:
       #
       # branch-health-conclusion.test.sh exercises the conclusion script
       # the branch-health reusable calls.
-      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh
+      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh && bash ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -111,11 +111,16 @@ jobs:
 
           import yaml
 
-          # `secrets.<id>` is how every GitHub Actions expression reaches a
-          # secret. `secrets: inherit` and `secrets:` declarations on
-          # reusable calls don't match, because those are declaration blocks, not
-          # references, and `secrets:` does not contain a `.`.
-          SECRET_RE = re.compile(r"(?<!\w)secrets\.[A-Za-z_]\w*")
+          # Three forms reach a secret at runtime: `secrets.<id>`,
+          # `secrets['<id>']` and `secrets["<id>"]` (with optional
+          # whitespace inside the brackets). `secrets: inherit` and the
+          # `secrets:` block on a reusable call don't match, because
+          # those are declaration blocks, not references, and `secrets:`
+          # is not followed by `.` or `[`.
+          SECRET_RE = re.compile(
+              r"(?<!\w)secrets(?:\.[A-Za-z_]\w*|\[\s*['\"]"
+              r"[A-Za-z_]\w*['\"]\s*])"
+          )
 
           # (`pattern`, `opt-out marker on the same line`). The marker, when
           # present on the line, exempts that install: the only case where
@@ -159,6 +164,19 @@ jobs:
                   return violations
               if not isinstance(spec, dict):
                   return violations
+
+              # A workflow-level `env:` propagates to every job in the
+              # workflow, so a secret referenced there reaches every step.
+              # `defaults:` only sets `shell` and `working-directory`, not
+              # `env`, so a secret under it does NOT reach a step and is
+              # not in scope here.
+              workflow_env = spec.get("env")
+              workflow_env_text = (
+                  yaml.safe_dump(workflow_env)
+                  if isinstance(workflow_env, dict) else ""
+              )
+              workflow_holds_secret = bool(SECRET_RE.search(workflow_env_text))
+
               jobs = spec.get("jobs") or {}
               for job_id, job in jobs.items():
                   if not isinstance(job, dict):
@@ -168,7 +186,11 @@ jobs:
                   # Comments are stripped by safe_load, so they cannot
                   # produce a false positive.
                   job_text = yaml.safe_dump(job)
-                  if not SECRET_RE.search(job_text):
+                  # The job holds a secret if its own text references one,
+                  # or if the workflow-level env does (every job inherits
+                  # it).
+                  job_holds_secret = bool(SECRET_RE.search(job_text))
+                  if not job_holds_secret and not workflow_holds_secret:
                       continue
                   for step in (job.get("steps") or []):
                       if not isinstance(step, dict):
@@ -184,7 +206,12 @@ jobs:
                               if pattern in line and not (
                                   except_marker and except_marker in line
                               ):
-                                  violations.append((spec_path, job_id, line))
+                                  violations.append((
+                                      spec_path, job_id, line,
+                                      "the workflow-level `env:`"
+                                      if not job_holds_secret
+                                      else "this job",
+                                  ))
                                   break
               return violations
 
@@ -198,9 +225,14 @@ jobs:
               for path in files:
                   violations.extend(find_violations(path))
               if violations:
-                  for path, job_id, line in violations:
+                  for path, job_id, line, source in violations:
+                      # Naming where the secret comes from matters when it is
+                      # not in the job: an author reading "job X holds a
+                      # secret" and seeing no secret in job X concludes the
+                      # check is wrong rather than looking further up the file.
                       msg = (
-                          f"job `{job_id}` installs third-party tooling while holding a secret: "
+                          f"job `{job_id}` installs third-party tooling while holding a secret "
+                          f"from {source}: "
                           f"`{line.strip()}`. See Glyndor/apt#121. Fix by moving the install "
                           f"into a job that holds no secrets, or pin it by hash "
                           f"(e.g. `pip install --require-hashes`)."

--- a/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+++ b/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the tooling-isolation assertion in
+# .github/workflows/reusable-workflow-lint.yml: a job that holds a secret
+# must not install third-party tooling.
+#
+# The step parses every workflow under .github/workflows and refuses, with
+# its own message, a job that calls cargo/go/gem/npm install or `pip
+# install` (without --require-hashes) while holding a secret reference. The
+# step is the gate; a script that gates gets tests, and this is the test.
+#
+# Two shapes of secret reach a step and were not seen before #1720:
+#
+#   1. The bracket-index form, `secrets['NAME']` or `secrets["NAME"]`,
+#      with optional whitespace inside the brackets. The reference shape
+#      `secrets.NAME` was the only one the previous regex matched.
+#
+#   2. A workflow-level `env:`. Every job in the workflow inherits it, so
+#      a secret declared there reaches every step. The scan reserialised
+#      the job, not the workflow-level env, so it never looked at it.
+#
+# Each refusal asserts WHICH message fired. Naming where the secret comes
+# from matters when it is not in the job: an author reading "job X holds a
+# secret" and seeing no secret in job X concludes the check is wrong rather
+# than looking further up the file.
+#
+# The `secrets: inherit` line and the `secrets:` declaration block on a
+# reusable call stay unrefused: those are declaration blocks, not
+# references, and `secrets:` is not followed by `.` or `[`.
+#
+# Each step's `run:` body is extracted from the workflow and executed as it
+# ships, in a temporary tree shaped like a repository. Every refusal is
+# paired with an acceptance of the same shape just inside the line.
+#
+# Requires: python3 with PyYAML (the tooling-isolation step imports it).
+# The fixtures below carry literal `${{ secrets.X }}` expressions and
+# backticks: the assertion under test reads those characters, so they must
+# reach the file unexpanded. Single quotes are the point, not an oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Pull one step's `run:` body out of a workflow, dedented, so it can be run.
+# Same helper shape as tests/shell/ci-runs-every-test.test.sh: the point
+# is to exercise the script as it ships rather than a copy of it that can
+# drift.
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if "name: " + sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A job holding a secret must not install" > "$WORK/tooling.sh"
+check "the tooling assertion was extracted from the workflow" "1" \
+	"$(grep -c 'INSTALL_PATTERNS' "$WORK/tooling.sh" | awk '{print ($1>0)}')"
+
+new() { rm -rf "$WORK/t"; mkdir -p "$WORK/t/.github/workflows"; printf '%s' "$WORK/t"; }
+run_in() { # $1=dir $2=script -> stdout+stderr, status in $?
+	( cd "$1" && bash "$2" 2>&1 )
+}
+said() { printf '%s' "$1" | grep -q -- "$2" && echo 1 || echo 0; }
+
+tooling_case() { # $1=dir $2=env line (or empty) $3=run line
+	cat > "$1/.github/workflows/job.yml" <<EOF
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      $2
+    steps:
+      - run: |
+          $3
+EOF
+}
+
+# ===========================================================================
+# A job holding a secret must not install third-party tooling
+# ===========================================================================
+
+# --- a secret plus a pip install is refused, and named --------------------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' 'pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret that pip installs is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+
+# --- the same install pinned by hash is the documented exemption ----------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' 'pip install --require-hashes -r req.txt'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pip install --require-hashes while holding a secret is allowed" "0" "$rc"
+check "and the step says nothing was found" "1" "$(said "$out" 'no job holding a secret installs')"
+
+# --- cargo install has no hash exemption ---------------------------------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' 'cargo install --locked cargo-cyclonedx'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "cargo install --locked while holding a secret is still refused" "1" "$rc"
+
+# --- the same install without a secret is fine ---------------------------
+d="$(new)"; tooling_case "$d" 'PLAIN: value' 'cargo install --locked cargo-cyclonedx'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "the same install in a job holding no secret passes" "0" "$rc"
+
+# --- a commented-out install is not an install ---------------------------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' '# pip install requests'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "an install that only appears in a comment is not reported" "0" "$rc"
+
+# --- a secret referenced in a step, not the job env, still counts --------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: go install example.com/tool@v1
+      - run: echo "$KEY"
+        env:
+          KEY: ${{ secrets.SIGNING_KEY }}
+EOF
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "a secret held by a later step of the same job still counts" "1" "$rc"
+
+# --- a `secrets: inherit` declaration is not a reference -----------------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable-x.yml
+    secrets: inherit
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: go install example.com/tool@v1
+EOF
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "secrets: inherit on a reusable call is not a secret reference" "0" "$rc"
+
+# --- the bracket-index form secrets['X'] is caught, single-quoted --------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets['DEPLOY_TOKEN'] }}
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret via secrets['X'] is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'no job holding a secret installs')"
+check "and there is no parse-error warning hiding the miss" "0" \
+	"$(said "$out" '::warning')"
+
+# --- the same bracket-index form, double-quoted, is also caught ----------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets["DEPLOY_TOKEN"] }}
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret via secrets[\"X\"] is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'no job holding a secret installs')"
+
+# --- bracket-index form with whitespace inside the brackets is caught -----
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets[ 'DEPLOY_TOKEN' ] }}
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret via secrets[ 'X' ] (whitespace) is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+
+# --- a workflow-level env that holds a secret catches every job -----------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+env:
+  TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job whose workflow-level env holds a secret is refused" "1" "$rc"
+check "and the message names workflow-level env as the source, not the job" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from the workflow-level `env:`: `pip install requests`')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'no job holding a secret installs')"
+check "and there is no parse-error warning hiding the miss" "0" \
+	"$(said "$out" '::warning')"
+
+# --- an unparseable workflow is a warning, not a silent skip -------------
+d="$(new)"; printf 'name: [\n' > "$d/.github/workflows/broken.yml"
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a workflow that does not parse does not fail the step" "0" "$rc"
+check "but is reported as skipped, so the silence is visible" "1" "$(said "$out" '::warning')"
+
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The tooling-isolation step found a secret with a regex that only matched
`secrets.NAME`, and it searched the re-serialized job alone. Two shapes
hold a secret at runtime and walked past it: the index form
`secrets['NAME']`, and a workflow-level `env:`, which is the normal place
to put a value several jobs need.

The scan now matches all three spellings, whitespace inside the brackets
included, and counts a job as holding a secret when the workflow-level
`env:` holds one. Each violation carries where the secret came from, so
an author who reads the message, looks at the job and sees no secret is
told to look further up the file instead of concluding the check is
broken.

`secrets: inherit` and a `secrets:` block on a reusable call still do not
count, and the case pinning that stays green.

The new test extracts the step's `run:` body from the workflow, so it
exercises the script as it ships, and runs it against fixtures for both
new shapes, the already caught form as the positive control, and a job
with no secret that installs tooling as the negative one. Each refusal
asserts which message fired. I planted both shapes and watched them go
red before wiring the test in.

Closes #1720.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>