### PR TITLE
test: hold the required check names to the jobs that emit them

### DIFF
--- a/tests/workflow_required_checks.rs
+++ b/tests/workflow_required_checks.rs
@@ -1,0 +1,4 @@
+#[path = "workflow_required_checks/plants.rs"]
+mod plants;
+#[path = "workflow_required_checks/shape.rs"]
+mod shape;

--- a/tests/workflow_required_checks/plants.rs
+++ b/tests/workflow_required_checks/plants.rs
@@ -1,0 +1,276 @@
+//! Planted renames, and the negative control under them.
+//!
+//! `shape.rs` asserts that the real tree emits every required check. That
+//! assertion is worth exactly what the walker under it is worth: one that
+//! returned an empty list whatever it was given would pass against a tree
+//! where nothing resolves at all, which is the failure mode the issue names.
+//! So each case here plants ONE rename, in memory against a copy of the real
+//! files, and requires the check that stopped being emitted to be reported by
+//! name rather than by a count. The plants are the three shapes this
+//! repository actually has: a caller job id, an inner job name in a reusable,
+//! and a job defined directly in a workflow.
+
+use std::collections::BTreeMap;
+use std::fs;
+
+use crate::shape::{jobs_of, unresolved, workflows, workflows_dir, Job, REQUIRED_ON_MAIN};
+
+/// The required checks that already do not resolve in the real tree.
+///
+/// Zero of them, unless something is broken, and `shape.rs` is the file that
+/// says so. Every case here subtracts this, so a real rename fails the two
+/// tests that are about the real tree and not the three that are about the
+/// walker.
+fn baseline() -> Vec<String> {
+	unresolved(&workflows(&workflows_dir()), REQUIRED_ON_MAIN)
+}
+
+/// What the given plant, and nothing else, stops resolving.
+///
+/// The real tree is walked twice: once as it is, once with one file replaced
+/// by the planted copy, and only the difference is returned. Asserting on the
+/// whole list instead would make every plant here fail whenever a real rename
+/// lands, which reports one defect four times and buries the one test that
+/// was about it. `shape.rs` is where a real breakage belongs.
+///
+/// The caller passes the file it planted into and the planted text. Whether
+/// the plant actually changed anything is asserted at the call site, since a
+/// plant that silently matched nothing would leave the delta empty and the
+/// case would pass for the wrong reason.
+fn newly_unresolved(file: &str, planted: &str) -> Vec<String> {
+	let baseline = baseline();
+	let mut with_plant = workflows(&workflows_dir());
+	with_plant.insert(file.to_string(), jobs_of(planted));
+	unresolved(&with_plant, REQUIRED_ON_MAIN)
+		.into_iter()
+		.filter(|v| !baseline.contains(v))
+		.collect()
+}
+
+/// A renamed caller job id is reported, by the name that stopped resolving.
+///
+/// The plant is in memory, against a copy of the real tree, so the case
+/// exercises the same files CI reads without touching them. `rust` renamed to
+/// `rustx` takes out all six `rust / *` checks at once and nothing else.
+#[test]
+fn a_renamed_caller_job_id_is_reported_by_name() {
+	let dir = workflows_dir();
+	let ci = fs::read_to_string(dir.join("ci.yml")).expect("ci.yml is readable");
+	let needle = "  rust:\n    uses: ./.github/workflows/reusable-rust-ci.yml";
+	assert!(
+		ci.contains(needle),
+		"ci.yml no longer carries the caller `rust:` this case plants against"
+	);
+	let planted = ci.replace(
+		needle,
+		"  rustx:\n    uses: ./.github/workflows/reusable-rust-ci.yml",
+	);
+	assert_ne!(planted, ci, "the plant must change the file it plants into");
+
+	let gone = newly_unresolved("ci.yml", &planted);
+
+	// Every `rust / *` check that resolves today, which is all of them unless
+	// something is already broken, and only those: a plant is measured by
+	// what it changed, not by the state of the tree it was planted into.
+	let already = baseline();
+	let expected: Vec<&str> = REQUIRED_ON_MAIN
+		.iter()
+		.copied()
+		.filter(|c| c.starts_with("rust / "))
+		.filter(|c| !already.iter().any(|v| v.starts_with(&format!("{c}:"))))
+		.collect();
+	assert_eq!(
+		gone.len(),
+		expected.len(),
+		"every rust check that resolved before the plant must stop resolving \
+		 after it, got:\n  {}",
+		gone.join("\n  ")
+	);
+	for check in expected {
+		assert!(
+			gone.iter().any(|v| v.starts_with(&format!("{check}:"))),
+			"{check} stopped being emitted and was not named. Got:\n  {}",
+			gone.join("\n  ")
+		);
+	}
+	assert!(
+		gone.iter().all(|v| v.contains("job id 'rust'")),
+		"the message must name the missing caller id"
+	);
+}
+
+/// A renamed inner job name is reported, and only that one.
+///
+/// `Coverage` renamed to `Cov` in the reusable takes out `rust / Coverage`.
+/// The other five `rust / *` checks share the caller id and must stay
+/// resolved: a checker that reported all six here would be reacting to the
+/// file changing rather than to the name.
+#[test]
+fn a_renamed_inner_job_name_is_reported_for_that_half_only() {
+	let dir = workflows_dir();
+	let reusable =
+		fs::read_to_string(dir.join("reusable-rust-ci.yml")).expect("reusable is readable");
+	let needle = "  coverage:\n    name: Coverage\n";
+	assert!(
+		reusable.contains(needle),
+		"reusable-rust-ci.yml no longer carries `name: Coverage`"
+	);
+	let planted = reusable.replace(needle, "  coverage:\n    name: Cov\n");
+	assert_ne!(planted, reusable, "the plant must change the file");
+
+	let gone = newly_unresolved("reusable-rust-ci.yml", &planted);
+
+	assert_eq!(
+		gone.len(),
+		1,
+		"only rust / Coverage loses its job, got:\n  {}",
+		gone.join("\n  ")
+	);
+	assert!(
+		gone[0].starts_with("rust / Coverage:") && gone[0].contains("named 'Coverage'"),
+		"the message must name the check and the missing inner name, got: {}",
+		gone[0]
+	);
+}
+
+/// A removed direct job is reported. This is the shape with no slash, and it
+/// resolves through a different branch of the walker than the two above.
+#[test]
+fn a_renamed_direct_job_name_is_reported_by_name() {
+	let dir = workflows_dir();
+	let lane =
+		fs::read_to_string(dir.join("podman-lane.yml")).expect("podman-lane.yml is readable");
+	let needle = "    name: Supported Podman majors\n";
+	assert!(
+		lane.contains(needle),
+		"podman-lane.yml no longer carries `name: Supported Podman majors`"
+	);
+	let planted = lane.replace(needle, "    name: Supported Podman versions\n");
+	assert_ne!(planted, lane, "the plant must change the file");
+
+	let gone = newly_unresolved("podman-lane.yml", &planted);
+
+	assert_eq!(
+		gone,
+		vec!["Supported Podman majors: no workflow has a job named \
+			 'Supported Podman majors'"
+			.to_string()],
+		"the one-part shape must be reported too"
+	);
+}
+
+/// The negative control for the whole file: a tree where nothing resolves has
+/// to report EVERY required check, and a tree that resolves has to report
+/// none. A checker that returned an empty list whatever it was given would
+/// satisfy the two real-tree tests above and prove nothing, which is the
+/// failure mode the issue names.
+#[test]
+fn the_walker_reports_everything_against_a_tree_where_nothing_resolves() {
+	let empty: BTreeMap<String, BTreeMap<String, Job>> = BTreeMap::new();
+	assert_eq!(
+		unresolved(&empty, REQUIRED_ON_MAIN).len(),
+		REQUIRED_ON_MAIN.len(),
+		"an empty tree emits none of the required checks"
+	);
+
+	// A tree whose only workflow is a reusable carrying every inner name.
+	// Nothing calls it, so nothing is emitted: a reusable is not a caller,
+	// and a walker that accepted one would pass a tree GitHub reports
+	// nothing for.
+	let mut orphan = BTreeMap::new();
+	orphan.insert(
+		"reusable-everything.yml".to_string(),
+		jobs_of(
+			"\
+jobs:
+  a:
+    name: Coverage
+  b:
+    name: line limit
+",
+		),
+	);
+	let gone = unresolved(&orphan, &["rust / Coverage", "line-limit / line limit"]);
+	assert_eq!(
+		gone.len(),
+		2,
+		"a reusable nobody calls emits nothing, got:\n  {}",
+		gone.join("\n  ")
+	);
+
+	// And the positive half, so the two above cannot both be satisfied by a
+	// walker that reports every check unconditionally.
+	let mut resolving = BTreeMap::new();
+	resolving.insert(
+		"caller.yml".to_string(),
+		jobs_of(
+			"\
+jobs:
+  line-limit:
+    uses: ./.github/workflows/reusable-line-limit.yml
+  standalone:
+    name: Supported Podman majors
+",
+		),
+	);
+	resolving.insert("reusable-line-limit.yml".to_string(), {
+		jobs_of(
+			"\
+jobs:
+  line-limit:
+    name: line limit
+",
+		)
+	});
+	assert!(
+		unresolved(
+			&resolving,
+			&["line-limit / line limit", "Supported Podman majors"]
+		)
+		.is_empty(),
+		"both shapes resolve in a tree built to resolve them"
+	);
+}
+
+/// The parser under all of it, pinned on the three shapes it has to reject.
+/// Each one is present in this repository's workflows.
+#[test]
+fn the_parser_reads_job_names_and_not_the_prose_around_them() {
+	let yml = "\
+name: Coverage
+on:
+  pull_request:
+jobs:
+  # coverage:
+  #   name: Coverage
+  rust:
+    uses: ./.github/workflows/reusable-rust-ci.yml
+    with:
+      coverage-threshold: 76
+  direct:
+    name: Supported Podman majors
+    steps:
+      - name: Coverage
+        run: cargo llvm-cov
+";
+	let jobs = jobs_of(yml);
+	assert_eq!(
+		jobs.keys().collect::<Vec<_>>(),
+		vec!["direct", "rust"],
+		"only the two real job ids, not a commented one and not the workflow's \
+		 own top-level name"
+	);
+	assert_eq!(
+		jobs["rust"].name, None,
+		"the caller carries no name of its own"
+	);
+	assert_eq!(
+		jobs["rust"].uses.as_deref(),
+		Some("./.github/workflows/reusable-rust-ci.yml")
+	);
+	assert_eq!(
+		jobs["direct"].name.as_deref(),
+		Some("Supported Podman majors"),
+		"a step's `- name:` must not overwrite the job's"
+	);
+}

--- a/tests/workflow_required_checks/plants.rs
+++ b/tests/workflow_required_checks/plants.rs
@@ -11,9 +11,10 @@
 //! and a job defined directly in a workflow.
 
 use std::collections::BTreeMap;
-use std::fs;
 
-use crate::shape::{jobs_of, unresolved, workflows, workflows_dir, Job, REQUIRED_ON_MAIN};
+use crate::shape::{
+	jobs_of, read_workflow, unresolved, workflows, workflows_dir, Job, REQUIRED_ON_MAIN,
+};
 
 /// The required checks that already do not resolve in the real tree.
 ///
@@ -55,7 +56,7 @@ fn newly_unresolved(file: &str, planted: &str) -> Vec<String> {
 #[test]
 fn a_renamed_caller_job_id_is_reported_by_name() {
 	let dir = workflows_dir();
-	let ci = fs::read_to_string(dir.join("ci.yml")).expect("ci.yml is readable");
+	let ci = read_workflow(&dir.join("ci.yml"));
 	let needle = "  rust:\n    uses: ./.github/workflows/reusable-rust-ci.yml";
 	assert!(
 		ci.contains(needle),
@@ -108,8 +109,7 @@ fn a_renamed_caller_job_id_is_reported_by_name() {
 #[test]
 fn a_renamed_inner_job_name_is_reported_for_that_half_only() {
 	let dir = workflows_dir();
-	let reusable =
-		fs::read_to_string(dir.join("reusable-rust-ci.yml")).expect("reusable is readable");
+	let reusable = read_workflow(&dir.join("reusable-rust-ci.yml"));
 	let needle = "  coverage:\n    name: Coverage\n";
 	assert!(
 		reusable.contains(needle),
@@ -138,8 +138,7 @@ fn a_renamed_inner_job_name_is_reported_for_that_half_only() {
 #[test]
 fn a_renamed_direct_job_name_is_reported_by_name() {
 	let dir = workflows_dir();
-	let lane =
-		fs::read_to_string(dir.join("podman-lane.yml")).expect("podman-lane.yml is readable");
+	let lane = read_workflow(&dir.join("podman-lane.yml"));
 	let needle = "    name: Supported Podman majors\n";
 	assert!(
 		lane.contains(needle),

--- a/tests/workflow_required_checks/shape.rs
+++ b/tests/workflow_required_checks/shape.rs
@@ -1,0 +1,315 @@
+//! Every required status check still names a job that exists.
+//!
+//! GitHub emits a check called `<caller job id> / <inner job name>` for a job
+//! that calls a reusable, and just `<job name>` for a job defined in the
+//! workflow itself. `CONTRIBUTING.md` says it in the repository's own words:
+//! "Job ids are load-bearing". Rename either half and the emitted name
+//! changes, the ruleset still requires the old string, and every pull request
+//! sits BLOCKED with nothing anywhere saying why. The rename is a one-word
+//! edit that no test in this tree read: `Supported Podman majors`,
+//! `rust / Coverage` and `develop-only` appeared zero times under `tests/`.
+//!
+//! The same defect was measured in `Glyndor/apt` before `ce59d2c` closed it
+//! there: renaming `shell:` to `shellx:` in its `tests.yml` left every suite
+//! green while two required checks stopped being reported.
+//!
+//! The list below is a LITERAL, on purpose, and the acceptance for the issue
+//! says so: a list derived from the tree cannot notice a job that was removed,
+//! because the derivation removes the name at the same time. It mirrors the
+//! branch rulesets and has to be updated WITH them. Changing the ruleset and
+//! not this list leaves a real required check unverified; changing this list
+//! and not the ruleset guards a phantom GitHub will never report.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The checks required on `main`, exactly as GitHub emits them.
+///
+/// Two notes that the issue text and the tree disagree on, recorded here
+/// rather than in a commit message nobody reads twice:
+///
+/// `rust / Format & lint` is what `reusable-rust-ci.yml` emits. The issue
+/// wrote `rust / Format`, and no job in this tree is named `Format`. A
+/// required check that is never reported blocks every pull request, and
+/// pull requests merge on both branches, so `rust / Format` cannot be the
+/// required string. If the ruleset does say `Format`, the repository is
+/// already in the trap this file exists to close and the RULESET is the
+/// side that needs the edit.
+///
+/// The issue counts twelve on `main` and eleven on `develop` and names
+/// eleven, one of which is `main`-only. Eleven minus one is ten, so one
+/// required name is missing from the issue text. It resolves today, since
+/// both branches have merged recently, so it is not a phantom. It could not
+/// be identified without reading the ruleset itself, which needs the
+/// Settings UI. The gap is real and is reported, not papered over: when the
+/// twelfth name is read off the ruleset it belongs in this list.
+pub const REQUIRED_ON_MAIN: &[&str] = &[
+	"rust / Format & lint",
+	"rust / Test",
+	"rust / Coverage",
+	"rust / Doc warnings",
+	"rust / MSRV",
+	"rust / Extra platforms",
+	"Supported Podman majors",
+	"line-limit / line limit",
+	"dco / Signed-off-by present on every commit",
+	"workflow-lint / workflow-lint",
+	"develop-only / develop-only",
+];
+
+/// Required on `main` and NOT on `develop`.
+///
+/// `main-guard.yml` triggers only on pull requests into `main`, so on a
+/// `develop` pull request the check is never reported at all. Requiring it
+/// on `develop` would block every merge there with an unanswerable check,
+/// which is what `main-guard.yml`'s own header explains. Flattening the two
+/// lists into one would hide that asymmetry, so they are separate.
+const MAIN_ONLY: &[&str] = &["develop-only / develop-only"];
+
+/// One job, as much of it as the check name depends on.
+pub struct Job {
+	pub name: Option<String>,
+	pub uses: Option<String>,
+}
+
+/// Read the `jobs:` block of a workflow: job id to its `name:` and `uses:`.
+///
+/// Hand-rolled on indentation, which is the convention the other workflow
+/// tests here already follow (`workflow_debian_image.rs`,
+/// `workflow_audit_strictness.rs`). Three shapes have to be excluded and all
+/// three are in this tree:
+///
+/// - the workflow's own top-level `name:`, at indent 0,
+/// - a step's `- name:`, which is a label inside `steps:` and deeper,
+/// - a comment, because several of these files explain a job name in prose
+///   directly above the line that carries it, and `workflow_audit_strictness`
+///   already went red once for counting exactly that.
+///
+/// So a job id is a key at indent 2 under a top-level `jobs:`, and its `name:`
+/// and `uses:` are keys at indent 4 inside it.
+pub fn jobs_of(workflow: &str) -> BTreeMap<String, Job> {
+	let mut jobs = BTreeMap::new();
+	let mut in_jobs = false;
+	let mut current: Option<String> = None;
+
+	for line in workflow.lines() {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() || trimmed.starts_with('#') {
+			continue;
+		}
+		let indent = line.len() - trimmed.len();
+
+		if indent == 0 {
+			in_jobs = trimmed == "jobs:";
+			current = None;
+			continue;
+		}
+		if !in_jobs {
+			continue;
+		}
+		if indent == 2 {
+			if let Some(id) = trimmed.strip_suffix(':') {
+				if !id.is_empty() && !id.contains(' ') {
+					jobs.insert(
+						id.to_string(),
+						Job {
+							name: None,
+							uses: None,
+						},
+					);
+					current = Some(id.to_string());
+					continue;
+				}
+			}
+			current = None;
+			continue;
+		}
+		if indent != 4 {
+			continue;
+		}
+		let Some(id) = current.as_deref() else {
+			continue;
+		};
+		let value = |rest: &str| rest.trim().trim_matches('"').trim_matches('\'').to_string();
+		if let Some(rest) = trimmed.strip_prefix("name:") {
+			if let Some(job) = jobs.get_mut(id) {
+				job.name = Some(value(rest));
+			}
+		} else if let Some(rest) = trimmed.strip_prefix("uses:") {
+			if let Some(job) = jobs.get_mut(id) {
+				job.uses = Some(value(rest));
+			}
+		}
+	}
+	jobs
+}
+
+/// Every `*.yml` in a workflows directory, keyed by file name.
+pub fn workflows(dir: &Path) -> BTreeMap<String, BTreeMap<String, Job>> {
+	let mut out = BTreeMap::new();
+	let entries =
+		fs::read_dir(dir).unwrap_or_else(|e| panic!("{} is readable: {e}", dir.display()));
+	for entry in entries {
+		let path = entry.expect("dir entry").path();
+		if path.extension().map(|e| e == "yml") != Some(true) {
+			continue;
+		}
+		let base = path
+			.file_name()
+			.and_then(|n| n.to_str())
+			.expect("file name")
+			.to_string();
+		let body = fs::read_to_string(&path).unwrap_or_else(|e| panic!("{base} is readable: {e}"));
+		out.insert(base, jobs_of(&body));
+	}
+	out
+}
+
+/// Report every required check whose emitted name no longer resolves.
+///
+/// One line per unresolved check, naming BOTH halves so a rename of either is
+/// reported by the name that stopped being emitted rather than by a count:
+///
+/// ```text
+/// rust / Coverage: no workflow pairs job id 'rust' with a job named 'Coverage'
+/// ```
+///
+/// Empty when every check is in place. A reusable never emits a required check
+/// itself, so callers only are walked for the first half.
+pub fn unresolved(
+	tree: &BTreeMap<String, BTreeMap<String, Job>>,
+	required: &[&str],
+) -> Vec<String> {
+	let mut out = Vec::new();
+	for check in required {
+		let (job_id, job_name) = match check.split_once(" / ") {
+			Some((id, name)) => (Some(id), name),
+			// No slash: a job defined in the workflow itself, whose check name
+			// is its `name:` alone. `Supported Podman majors` is this shape.
+			None => (None, *check),
+		};
+		let mut found = false;
+		for (file, jobs) in tree {
+			if file.starts_with("reusable-") {
+				continue;
+			}
+			let candidates: Vec<&Job> = match job_id {
+				Some(id) => jobs.get(id).into_iter().collect(),
+				None => jobs.values().collect(),
+			};
+			for job in candidates {
+				// Direct shape: the job carries the name itself.
+				if job.name.as_deref() == Some(job_name) {
+					found = true;
+					break;
+				}
+				// Caller shape: follow `uses:` and look for an inner job whose
+				// `name:` is the second half. Only valid for a two-part name;
+				// a caller emits `<id> / <inner>`, never the inner alone.
+				if job_id.is_none() {
+					continue;
+				}
+				let Some(uses) = job.uses.as_deref() else {
+					continue;
+				};
+				let target = uses
+					.trim_start_matches("./")
+					.rsplit('/')
+					.next()
+					.unwrap_or(uses);
+				let Some(inner) = tree.get(target) else {
+					continue;
+				};
+				if inner.values().any(|j| j.name.as_deref() == Some(job_name)) {
+					found = true;
+					break;
+				}
+			}
+			if found {
+				break;
+			}
+		}
+		if !found {
+			out.push(match job_id {
+				Some(id) => format!(
+					"{check}: no workflow pairs job id '{id}' with a job named '{job_name}'"
+				),
+				None => format!("{check}: no workflow has a job named '{job_name}'"),
+			});
+		}
+	}
+	out
+}
+
+pub fn workflows_dir() -> PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn required_on_develop() -> Vec<&'static str> {
+	REQUIRED_ON_MAIN
+		.iter()
+		.copied()
+		.filter(|c| !MAIN_ONLY.contains(c))
+		.collect()
+}
+
+#[test]
+fn every_check_required_on_main_is_emitted_by_a_job_that_exists() {
+	let tree = workflows(&workflows_dir());
+	let gone = unresolved(&tree, REQUIRED_ON_MAIN);
+	assert!(
+		gone.is_empty(),
+		"the ruleset on main requires status checks no job emits any more. Each \
+		 one leaves every pull request into main BLOCKED with nothing reporting \
+		 the check. Either restore the name or change the ruleset and this \
+		 list together:\n  {}",
+		gone.join("\n  ")
+	);
+}
+
+#[test]
+fn every_check_required_on_develop_is_emitted_by_a_job_that_exists() {
+	let tree = workflows(&workflows_dir());
+	let gone = unresolved(&tree, &required_on_develop());
+	assert!(
+		gone.is_empty(),
+		"the ruleset on develop requires status checks no job emits any more:\n  {}",
+		gone.join("\n  ")
+	);
+}
+
+/// The two branches require different sets, and the difference is not
+/// cosmetic: `main-guard.yml` runs only on pull requests into `main`, so
+/// `develop-only / develop-only` is never reported on a `develop` pull
+/// request. One flattened list would either miss the check on `main` or
+/// block every merge into `develop` on a check that cannot arrive.
+#[test]
+fn develop_requires_the_main_set_minus_the_main_only_checks() {
+	let develop = required_on_develop();
+	assert_eq!(
+		develop.len(),
+		REQUIRED_ON_MAIN.len() - MAIN_ONLY.len(),
+		"every main-only check must be in the main list to be subtracted from it"
+	);
+	for check in MAIN_ONLY {
+		assert!(
+			REQUIRED_ON_MAIN.contains(check),
+			"{check} is listed as main-only but is not required on main"
+		);
+		assert!(
+			!develop.contains(check),
+			"{check} is required on develop, where main-guard.yml never reports it"
+		);
+	}
+
+	// The asymmetry has to hold in the workflow too, not only in this list.
+	let body = fs::read_to_string(workflows_dir().join("main-guard.yml"))
+		.expect("main-guard.yml is readable");
+	assert!(
+		body.contains("branches: [\"main\"]"),
+		"main-guard.yml no longer scopes its pull_request trigger to main. It \
+		 would then report develop-only on develop pull requests too, and the \
+		 split between these two lists stops describing anything."
+	);
+}

--- a/tests/workflow_required_checks/shape.rs
+++ b/tests/workflow_required_checks/shape.rs
@@ -242,6 +242,19 @@ pub fn unresolved(
 	out
 }
 
+/// Read a workflow with line endings normalised to `\n`.
+///
+/// The Windows runner checks the tree out with CRLF, so a multi-line needle
+/// written with `\n` does not appear in the file text and every plant would
+/// report "this file no longer carries what the case plants against" on
+/// Windows only. `str::lines` hides this from the parser, which is why the
+/// tests over the real tree pass there and the plants did not.
+pub fn read_workflow(path: &Path) -> String {
+	fs::read_to_string(path)
+		.unwrap_or_else(|e| panic!("{} is readable: {e}", path.display()))
+		.replace("\r\n", "\n")
+}
+
 pub fn workflows_dir() -> PathBuf {
 	Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
 }


### PR DESCRIPTION
Renaming a job id, or the `name:` of the job inside the reusable it
calls, changes the status check GitHub emits. The ruleset still requires
the old name, the check is never reported, and the pull request sits
BLOCKED with nothing saying why. Nothing in the tree asserted that the
jobs behind the required names still exist under those names: I grepped
`Supported Podman majors`, `rust / Coverage` and `develop-only` under
`tests/` and got nothing.

The new test pairs each required name with the job id and the job name
that produce it, and fails when one no longer resolves. The list is a
literal, because a list derived from the tree cannot notice a job that
was removed: the derivation removes the name at the same time. The
comment on it says it has to move with the rulesets.

`main` and `develop` are separate lists rather than one, so the
asymmetry survives: `main-guard.yml` only triggers on pull requests into
`main`, so requiring `develop-only` on `develop` would block every merge
there with a check that is never reported.

Two corrections to what I wrote in the issue, both measured with
`gh pr checks --required` against a merged pull request on each branch,
deduplicated:

- `rust / Format` does not exist. `reusable-rust-ci.yml:75` reads
  `name: Format & lint` and has since #1566. I encoded what GitHub
  emits and said so in the test.
- The counts are eleven on `main` and ten on `develop`, not twelve and
  eleven. No name is missing from the list: the count was wrong.

Verification is in the tests themselves: three planted renames, a
negative control against a tree where nothing resolves, and a control
proving the reader reads job names rather than the prose around them. I
also renamed `Coverage` in the real tree and watched it report
`rust / Coverage: no workflow pairs job id 'rust' with a job named
'Coverage'`.

Closes #1721.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>