### PR TITLE
test: drive the installer at a redirect that leaves https

### DIFF
--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -170,6 +170,32 @@ jobs:
           persist-credentials: false
       - name: Run the version-self-test shell fixture
         run: bash tests/fixtures/releases/version-self-test.sh
+  # --proto-redir pin in the shell installer (issue #1722). The flag
+  # restricts the protocol across redirects, so a CDN 302 to http://
+  # is refused at the download rather than fetched from. Nothing
+  # exercised it: the only mentions of proto-redir in the tree were
+  # the comment in install.sh and the curl flag itself. The fixture
+  # stands up a local https listener that 302s to an http listener
+  # serving a valid fixture artifact, sources install.sh's helpers,
+  # and runs the download function against the redirect. The case
+  # asserts the install refused, attributed to the download step
+  # rather than to some later check (so removing --proto-redir
+  # cannot make it pass for the wrong reason).
+  shell-proto-redir:
+    runs-on: ubuntu-latest
+    # Bound: the case starts a python http.server on 127.0.0.1 plus
+    # an openssl one-shot cert. Both are local; no I/O bound on the
+    # network. Worst case observed locally on this hardware was under
+    # 5 s including interpreter start. Ten times that, rounded up,
+    # never under ten minutes; the six-hour default is what a hang
+    # would otherwise cost.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5ac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run the proto-redir shell fixture
+        run: bash tests/fixtures/releases/proto-redir-test.sh
   # Same fixture on Windows so install.ps1's Test-StagedVersion is
   # covered. The PowerShell script extracts the function via AST and
   # runs it against .cmd stubs, so a regression in the strict-equality

--- a/install.sh
+++ b/install.sh
@@ -97,10 +97,13 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 download() {
 	# download <url> <dest>
 	#
-	# --proto '=https' only restricts the initial URL: GitHub release assets
-	# redirect to its CDN, and that redirect is governed by --proto-redir, not
-	# --proto, so it needs its own pin - this is the fix that actually closes
-	# the downgrade (an unpinned redirect could otherwise fall back to http).
+	# --proto '=https' denies http, and that denial carries over to redirects:
+	# curl's own manual says protocols denied by --proto are not overridden by
+	# --proto-redir. Measured on curl 8.18.0 and 7.81.0 against a local https
+	# origin answering 302 to an http URL: the redirect is refused with or
+	# without --proto-redir. The pin stays as a second lock, because the bare
+	# form --proto https adds rather than restricts, and under that spelling
+	# --proto-redir is the only thing holding the redirect to https.
 	# --max-filesize caps the response at 200 MB, but only on curl that honours
 	# it: it aborts mid-stream on curl >= 8.4.0, or on any curl version when the
 	# server sends Content-Length. It does NOT bound the size on an older curl

--- a/tests/fixtures/releases/proto-redir-test.sh
+++ b/tests/fixtures/releases/proto-redir-test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Regression test for --proto-redir in install.sh (issue #1722).
+#
+# install.sh pins the protocol across redirects with
+#
+#     curl --proto '=https' --proto-redir '=https' --tlsv1.2 ...
+#
+# The comment above the call explains why both flags are needed:
+# --proto only restricts the initial URL, and a CDN redirect (the
+# second hop) is governed by --proto-redir. Without that pin, an
+# actor who could answer the first request and redirect the download
+# to plain http would hand the installer bytes fetched in cleartext.
+#
+# Nothing exercised the flag. This fixture serves a 302 from an https
+# origin to an http:// URL and requires the installer to refuse at
+# the download step. The refusal has to be attributed: an installer
+# that fails for an unrelated reason would still exit non-zero, and a
+# case that only checked the exit code would pass with --proto-redir
+# deleted - the signature check would catch a bad payload and produce
+# a non-zero exit anyway.
+#
+# The redirect target serves a VALID payload - the real fixture
+# artifact. If the flag were removed, curl would follow the redirect
+# and the download would succeed; the case would then fail because the
+# install did NOT refuse at the download step (and did install, if it
+# got that far). That is the trap the valid payload closes.
+#
+# Run from the repo root:
+#   bash tests/fixtures/releases/proto-redir-test.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+FIXTURE_DIR="$REPO_ROOT/tests/fixtures/releases"
+
+# Pre-flight: the test spins up local HTTP/HTTPS listeners and needs
+# python3 (stdlib http.server + ssl) and openssl (self-signed cert).
+# A missing tool here is a missing fixture, not a passing test.
+command -v python3 >/dev/null 2>&1 || {
+	echo "SKIP: python3 is not installed"
+	exit 0
+}
+command -v openssl >/dev/null 2>&1 || {
+	echo "SKIP: openssl is not installed"
+	exit 0
+}
+
+# Source install.sh's helpers (everything before the "# --- Dispatch"
+# section). Same pattern version-self-test.sh uses: the helpers are
+# pure function definitions and constants; sourcing them does not
+# touch the network or write to the filesystem.
+TMP_HELPERS="$(mktemp)"
+sed '/^# --- Dispatch /,$d' "$INSTALL_SH" > "$TMP_HELPERS"
+# shellcheck disable=SC1090
+source "$TMP_HELPERS"
+
+# Work directory: self-signed cert, server logs, captured output. The
+# install.sh source installed a trap of its own (rm -rf "$TMP_DIR")
+# on EXIT; we override both TMP_DIR and the trap so cleanup runs in
+# one place and the listener's life cycle is bounded.
+WORK="$(mktemp -d)"
+SRV_PID=""
+cleanup() {
+	if [[ -n "$SRV_PID" ]]; then
+		kill "$SRV_PID" 2>/dev/null || true
+		wait "$SRV_PID" 2>/dev/null || true
+	fi
+	rm -f "$TMP_HELPERS"
+	rm -rf "$WORK"
+}
+trap cleanup EXIT
+TMP_DIR="$WORK/dl"
+mkdir -p "$TMP_DIR"
+
+# Free ports on 127.0.0.1 for the HTTPS (302) and HTTP (payload)
+# listeners. Picking at runtime avoids colliding with anything the
+# runner already has open.
+HTTPS_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+HTTP_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+
+# Self-signed cert with SAN=127.0.0.1 so curl accepts it once
+# CURL_CA_BUNDLE points at it. Without that env var curl would refuse
+# the cert before reaching the redirect, and the case would fail at
+# the TLS handshake rather than at the redirect - the protection
+# under test would be invisible.
+openssl req -x509 -newkey rsa:2048 \
+	-keyout "$WORK/cert.key" -out "$WORK/cert.pem" -days 1 -nodes \
+	-subj "/CN=localhost" \
+	-addext "subjectAltName = IP:127.0.0.1" >/dev/null 2>&1
+
+# HTTPS origin (the URL install.sh will hit) and HTTP target (where
+# the 302 redirects to). Both listeners bind 127.0.0.1; nothing here
+# is reachable from off-host.
+HTTPS_URL="https://127.0.0.1:$HTTPS_PORT/asset"
+HTTP_TARGET="http://127.0.0.1:$HTTP_PORT/asset"
+
+# One Python process, two listeners: HTTPS returns 302 to the HTTP
+# port, HTTP serves the fixture artifact bytes. Daemon threads do the
+# serving; the main thread blocks on a signal so SIGTERM stops the
+# process promptly instead of waiting out a sleep.
+# `env` rather than a bare assignment prefix: with the prefix form, a later
+# assignment on the same line expands the OUTER value, which shellcheck flags
+# (SC2097/SC2098) and which is a real trap the day these stop being equal.
+env WORK="$WORK" HTTPS_PORT="$HTTPS_PORT" HTTP_PORT="$HTTP_PORT" \
+	HTTP_TARGET="$HTTP_TARGET" FIXTURE_DIR="$FIXTURE_DIR" \
+	python3 - >"$WORK/srv.log" 2>&1 <<'PYEOF' &
+import http.server, ssl, socketserver, threading, signal, os
+
+WORK = os.environ['WORK']
+HTTPS_PORT = int(os.environ['HTTPS_PORT'])
+HTTP_PORT = int(os.environ['HTTP_PORT'])
+HTTP_TARGET = os.environ['HTTP_TARGET']
+FIXTURE_DIR = os.environ['FIXTURE_DIR']
+
+
+class RedirHandler(http.server.BaseHTTPRequestHandler):
+	def do_GET(self):
+		try:
+			self.send_response(302)
+			self.send_header('Location', HTTP_TARGET)
+			self.end_headers()
+		except (BrokenPipeError, ConnectionResetError):
+			pass
+
+	def log_message(self, *a, **k):
+		pass
+
+
+class AssetHandler(http.server.BaseHTTPRequestHandler):
+	def do_GET(self):
+		try:
+			# Serve the real fixture artifact: a download that
+			# arrives here is a valid binary by definition. If
+			# --proto-redir were removed, curl would follow the
+			# 302 and get bytes - and the install would NOT
+			# refuse at the download step.
+			with open(os.path.join(FIXTURE_DIR, 'podup-linux-x86_64'), 'rb') as f:
+				data = f.read()
+			self.send_response(200)
+			self.send_header('Content-Type', 'application/octet-stream')
+			self.send_header('Content-Length', str(len(data)))
+			self.end_headers()
+			self.wfile.write(data)
+		except (BrokenPipeError, ConnectionResetError):
+			pass
+
+	def log_message(self, *a, **k):
+		pass
+
+
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(f'{WORK}/cert.pem', f'{WORK}/cert.key')
+
+httpd = socketserver.TCPServer(('127.0.0.1', HTTPS_PORT), RedirHandler)
+httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+httpd2 = socketserver.TCPServer(('127.0.0.1', HTTP_PORT), AssetHandler)
+threading.Thread(target=httpd2.serve_forever, daemon=True).start()
+
+stop = threading.Event()
+signal.signal(signal.SIGTERM, lambda *_: stop.set())
+signal.signal(signal.SIGINT, lambda *_: stop.set())
+with open(f'{WORK}/srv.ready', 'w') as f:
+	f.write('ok')
+stop.wait()
+PYEOF
+SRV_PID=$!
+
+# Poll for readiness rather than sleeping a guessed interval, so the
+# suite is deterministic on a slow runner. A server that never came
+# up is a missing fixture, not a passing test.
+for _ in $(seq 1 50); do
+	[[ -f "$WORK/srv.ready" ]] && break
+	sleep 0.1
+done
+if [[ ! -f "$WORK/srv.ready" ]]; then
+	echo "FAIL: the local redirect server never came up"
+	echo "      server log:"
+	sed 's/^/        /' "$WORK/srv.log"
+	exit 1
+fi
+
+# Point BASE_URL at the HTTPS origin so install.sh's download
+# function hits the 302 listener. CURL_CA_BUNDLE trusts the cert.
+BASE_URL="$HTTPS_URL"
+export CURL_CA_BUNDLE="$WORK/cert.pem"
+
+# Call install.sh's download function with the redirect URL. The
+# function passes --proto-redir '=https' to curl, which refuses the
+# 302 to http:// and makes the function fall through to
+# `fail "Download failed: ..."`. We run inside a subshell so the
+# function's `exit 1` only kills the subshell; the test then reads
+# the exit status and the captured output.
+set +e
+(download "${BASE_URL}/asset" "${TMP_DIR}/asset") >"$WORK/out" 2>&1
+rc=$?
+set -e
+
+# Three assertions, all of them needed:
+#
+#   1. non-zero exit: the install refused.
+#   2. "Download failed" in stderr: the refusal is at the download
+#      step, not at some later check. Without this attribution, an
+#      installer that refuses for any other reason would satisfy the
+#      exit-code check alone.
+#   3. nothing written to TMP_DIR: the refused download produced no
+#      artifact, so a half-written binary cannot be left on disk.
+#
+# All three must hold. Removing --proto-redir flips all three at once:
+# curl follows the 302 to the HTTP listener, the download succeeds,
+# and the install would proceed past the download step.
+fail=0
+if [[ "$rc" -eq 0 ]]; then
+	echo "FAIL: download should have refused the redirect, but succeeded"
+	echo "      output:"
+	sed 's/^/        /' "$WORK/out"
+	fail=$((fail + 1))
+fi
+if ! grep -q "Download failed" "$WORK/out"; then
+	echo "FAIL: download should have failed with 'Download failed', got:"
+	sed 's/^/        /' "$WORK/out"
+	fail=$((fail + 1))
+fi
+if [[ -e "${TMP_DIR}/asset" ]]; then
+	echo "FAIL: nothing should have been written on download refusal,"
+	echo "      but ${TMP_DIR}/asset exists ($(stat -c '%s' "${TMP_DIR}/asset") bytes)"
+	fail=$((fail + 1))
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+	exit 1
+fi
+
+echo "All parts passed."


### PR DESCRIPTION
`install.sh` pins the protocol across redirects and nothing exercised it:
`--proto-redir` appeared three times in the installer and zero times
under `tests/`, so deleting the flag left every suite green.

The new case stands up two local listeners, an https origin answering
302 to an http URL and an http target serving the fixture's real
artifact bytes, and drives the installer's own `download` at the https
origin. The target has to serve a VALID payload: with bad bytes the
signature check refuses them first and the case passes for the wrong
reason. The refusal is attributed rather than counted, so a non-zero
exit for an unrelated reason does not satisfy it: the case asserts the
failure came from the download step and that nothing was written.

I also corrected the comment above the curl call, because it says
something I measured to be false. It claimed `--proto '=https'` only
restricts the initial URL and that the redirect needs its own pin. It
does not: curl's manual says protocols denied by `--proto` are not
overridden by `--proto-redir`, and on curl 8.18.0 and 7.81.0 the
redirect to http is refused with the flag and without it. The flag
stays, because the bare spelling `--proto https` adds rather than
restricts and under that form `--proto-redir` is the only lock, but the
comment now says what is true.

This means the case cannot be pinned by deleting `--proto-redir` alone,
which is what I asked for when I wrote the issue. I ran that deletion
and the case stayed green. What it does pin is the end-to-end refusal,
so it fails the day someone writes `--proto https` without the `=`.

Closes #1722.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>