### PR TITLE
ci: account for the cron this file does not watch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
   #
   # max-age-days allows about two periods, so one miss is tolerated:
   # 15 for weekly, 3 for daily, 65 for the monthly benchmark.
+  #
+  # These jobs are ADVISORY and must never be promoted to required status
+  # checks. Each one fails because a cron somewhere else stopped firing, which
+  # has nothing to do with the change under review, so requiring one would
+  # block every pull request for the length of an unrelated outage. The rule
+  # lives in the organisation standard, and it is repeated here because this
+  # file is what somebody wiring a ruleset has open.
   freshness-audit:
     permissions:
       contents: read
@@ -137,6 +144,25 @@ jobs:
   # successful scheduled run on record" until the workflow has reached `main`
   # and its cron has fired once. `pin-watch.yml` (#1526) is waiting for exactly
   # that and gets its entry afterwards.
+  #
+  # `podman-lane-develop-nightly.yml` has a cron and is deliberately NOT
+  # watched here, so that its absence reads as a decision rather than an
+  # oversight. Two reasons, and the second is the blocking one.
+  #
+  # Its output is an observation, not a gate: it reports the coverage of
+  # `develop` under Podman 6 against a floor that no pull request can move,
+  # since the gate a pull request answers to is the 76 per cent threshold on
+  # `rust / Coverage`. A watcher would then report the staleness of a number
+  # nobody is required to keep fresh.
+  #
+  # And a watcher added today would be born red. The guard reads the newest
+  # scheduled run with `status=success`, and measured on 2026-09-06 the last
+  # successful nightly was 2026-09-01: five consecutive nights failed on the
+  # 88 per cent floor (85.51, then 85.38, then 85.40 on the three that print
+  # the figure). A cron that fires nightly and fails nightly is, to this
+  # guard, indistinguishable from a cron that stopped. The entry belongs here
+  # once that lane is green again, not before, and #1380 is where the floor
+  # itself is argued.
 
   # Monthly (`0 4 1 * *`), so seventeen days without a run is normal and a
   # weekly threshold here would fail on ordinary work for most of the month.


### PR DESCRIPTION
Two things the freshness block did not say.

The first is that these jobs are advisory. A `freshness-*` job fails
because a cron somewhere else stopped firing, which has nothing to do
with the change under review, so promoting one to a required check would
block every pull request for the length of an unrelated outage. That
rule lived only in the organisation standard, which is not the file open
in front of somebody wiring a ruleset. It is now beside the jobs.

The second is `podman-lane-develop-nightly.yml`. It declares a cron and
has no watcher, and nothing said whether that was decided or forgotten,
so a reader had to guess. It is a decision, and the comment now carries
both halves of it.

I went to add the watcher and measured why it cannot go in yet. The
guard reads the newest scheduled run with `status=success`. On
2026-09-06 the last successful nightly was 2026-09-01: five consecutive
nights failed the 88 per cent coverage floor, at 85.51, 85.38 and 85.40
on the three runs that print the figure. Any threshold under five days
is red on arrival. A cron that fires nightly and fails nightly looks
exactly like a cron that stopped, which is the one thing this guard
cannot tell apart.

The lane also produces an observation rather than a gate: the threshold
a pull request answers to is the 76 per cent on `rust / Coverage`, so a
watcher would be reporting the staleness of a number nobody is required
to keep fresh. The entry belongs here once the lane is green again.

Closes #1723.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>