### PR TITLE
test: require every shell suite to say it reached its end

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -15,6 +15,7 @@ on:
       - ".github/workflows/reusable-shell-ci.yml"
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
+      - "tests/shell/check-suite-completeness.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
   pull_request:
@@ -34,6 +35,7 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
+      - "tests/shell/check-suite-completeness.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -62,7 +64,16 @@ jobs:
       #
       # branch-health-conclusion.test.sh exercises the conclusion script
       # the branch-health reusable calls.
-      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh && bash ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+      #
+      # check-suite-completeness.test.sh runs every other shell test and
+      # requires each one to print its sentinel (the DONE line is the last
+      # thing every test writes, after the last check and before the
+      # `[ "$fail" -eq 0 ]` gate). A test that exits early -- a planted
+      # `exit 0`, a `set -e` abort, anything that cuts the run short --
+      # never produces the sentinel, and this check names the file that
+      # did not. Without this check, a truncated test and a passing one
+      # look the same to the chain: exit 0, no count line.
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/tests/shell/branch-health-conclusion.test.sh
+++ b/tests/shell/branch-health-conclusion.test.sh
@@ -128,4 +128,5 @@ esac
 
 echo
 echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/check-hardening-macos.test.sh
+++ b/tests/shell/check-hardening-macos.test.sh
@@ -18,6 +18,8 @@ script=.github/scripts/check-hardening-macos.sh
 
 if ! command -v clang >/dev/null 2>&1 || ! command -v otool >/dev/null 2>&1 || ! command -v nm >/dev/null 2>&1; then
 	echo "SKIP: clang/otool/nm are not all on PATH; this test runs on the macOS CI runner only."
+	pass=0; fail=0
+	printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 	exit 0
 fi
 
@@ -102,4 +104,5 @@ check "no arguments is a usage error, exit 2" "2" "$rc"
 
 echo
 echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/check-hardening.test.sh
+++ b/tests/shell/check-hardening.test.sh
@@ -85,4 +85,5 @@ check "no arguments is a usage error, exit 2" "2" "$rc"
 
 echo
 echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/check-suite-completeness.test.sh
+++ b/tests/shell/check-suite-completeness.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Run every test file the workflow invokes and require each one to print its
+# sentinel. The sentinel is the last line every test file writes:
+#
+#     printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+#
+# It sits between the count line and `[ "$fail" -eq 0 ]`, so it is reached
+# only after the last `check` runs. A test that exits early -- because
+# someone planted `exit 0`, because `set -e` killed it on an unexpected
+# error, or because anything else cut the run short -- never produces the
+# sentinel, and this file names it.
+#
+# Why this shape, not a trap on EXIT: a trap fires on the truncated path
+# too, so it would print the sentinel exactly when the file stopped early,
+# which is the defect, not the fix. The sentinel is a plain `printf` that
+# runs only when control reaches it.
+#
+# Why this shape, not a sidecar file: every test would have to know the
+# sidecar path and append to it, and a non-writable sidecar is a new
+# failure mode unrelated to what this catches.
+#
+# Why this shape, not parsing lint-shell.yml inside this file: the list
+# of files is right there in the workflow, but a runner that parses YAML
+# to find its own input couples itself to the workflow's shape. The
+# workflow lists the tests as this file's arguments, and
+# `tests/shell/ci-runs-every-test.test.sh` already keeps that list
+# honest (every file invoked must exist, every file must be invoked).
+#
+# The macOS fixture skips cleanly where clang/otool/nm are absent; the
+# skip path prints the sentinel before exiting 0, so the Linux job still
+# sees it.
+#
+# Usage: check-suite-completeness.test.sh <test-file> [<test-file> ...]
+
+set -u
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <test-file> [<test-file> ...]" >&2
+	exit 2
+fi
+
+self="${BASH_SOURCE[0]##*/}"
+
+# Every test file must end with a sentinel of the form
+# `DONE <basename> <pass-count> <fail-count>`. The basename is what the
+# file itself sees in BASH_SOURCE, so the check is by basename rather than
+# the path the runner was given: a file invoked as `./tests/foo.test.sh`
+# and as `tests/foo.test.sh` both report `foo.test.sh` in their sentinel,
+# and either way the runner reaches the same answer.
+sentinel_re='^DONE [A-Za-z0-9_.-]+\.test\.sh [0-9]+ [0-9]+$'
+
+for f in "$@"; do
+	basename="${f##*/}"
+
+	# Skip self if invoked recursively (it would not terminate).
+	[ "$basename" = "$self" ] && continue
+
+	output="$("$f" 2>&1)"
+	rc=$?
+
+	# The test's own output is the diagnosis: the FAIL line it printed
+	# when one of its checks failed, or the `ok` line that was its last
+	# printed word before a planted `exit 0`. Print it so the operator
+	# who comes after the runner has the same picture.
+	printf '%s\n' "$output"
+
+	# The sentinel, if the test reached it, is the last line of output.
+	# Command substitution strips trailing newlines, so the sentinel's
+	# terminating \n is not in $output; the last line is the sentinel's
+	# body.
+	last_line="$(printf '%s' "$output" | tail -n 1)"
+	has_sentinel=0
+	if [ -n "$last_line" ] && [[ "$last_line" =~ $sentinel_re ]]; then
+		has_sentinel=1
+	fi
+
+	check "$basename reached its end" "1" "$has_sentinel"
+	if [ "$has_sentinel" -eq 0 ]; then
+		echo "        last line was: $last_line"
+	fi
+
+	if [ "$rc" -ne 0 ]; then
+		check "$basename exited 0" "1" "0"
+	else
+		check "$basename exited 0" "1" "1"
+	fi
+done
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "$self" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/ci-runs-every-test.test.sh
+++ b/tests/shell/ci-runs-every-test.test.sh
@@ -91,4 +91,5 @@ check "every test a workflow invokes exists" "" \
 
 echo
 echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/locale-pinned.test.sh
+++ b/tests/shell/locale-pinned.test.sh
@@ -57,4 +57,5 @@ check "every sort runs under a pinned collation" "" "${unpinned%$'\n'}"
 
 echo
 echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+++ b/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
@@ -265,4 +265,5 @@ check "a workflow that does not parse does not fail the step" "0" "$rc"
 check "but is reported as skipped, so the silence is visible" "1" "$(said "$out" '::warning')"
 
 echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
The tooling-isolation step found a secret with a regex that only matched
`secrets.NAME`, and it searched the re-serialized job alone. Two shapes
hold a secret at runtime and walked past it: the index form
`secrets['NAME']`, and a workflow-level `env:`, which is the normal
place
to put a value several jobs need.

The scan now matches all three spellings, whitespace inside the brackets
included, and counts a job as holding a secret when the workflow-level
`env:` holds one. Each violation carries where the secret came from, so
an author who reads the message, looks at the job and sees no secret is
told to look further up the file instead of concluding the check is
broken.

`secrets: inherit` and a `secrets:` block on a reusable call still do
not
count, and the case pinning that stays green.

The new test extracts the step's `run:` body from the workflow, so it
exercises the script as it ships, and runs it against fixtures for both
new shapes, the already caught form as the positive control, and a job
with no secret that installs tooling as the negative one. Each refusal
asserts which message fired. I planted both shapes and watched them go
red before wiring the test in.

Closes #1720.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>