### PR TITLE
ci: refuse a caller if: that can switch off a required check

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -36,6 +36,7 @@ on:
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
+      - "tests/shell/reusable-workflow-lint-caller-if.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -73,7 +74,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -360,3 +360,256 @@ jobs:
           if __name__ == "__main__":
               sys.exit(main())
           PY
+
+      # A caller-level `if:` on a job that emits a required check name is a
+      # switch, not a filter. GitHub reports a SKIPPED required check as
+      # SUCCESS, so one `if:` line can switch off coverage, the MSRV floor,
+      # or the validation on both supported Podman majors while the ruleset
+      # reports the gate as satisfied.
+      #
+      # Measured against this repository on 2026-09-06: eleven status checks
+      # are required on `main` and ten on `develop`. Every one of them is
+      # emitted either directly by a job in this tree or by a reusable a job
+      # here calls. Nothing in this repository asserts that property; #1718.
+      #
+      # The interesting case is `if: always()`. It can never evaluate false,
+      # so the job always runs and the check is always reported. Allowed.
+      # That is the load-bearing pattern from #1552: a gate job summarises a
+      # matrix that may fail, so it has to run on `failure` too and reads
+      # `needs.*.result` to make the verdict. The reusable-rust-ci and
+      # podman-lane gates are full of it.
+      #
+      # `if:` lines INSIDE a reusable are not in scope here. They are how
+      # the reusable is configured (`if: inputs.msrv != ''`), and refusing
+      # them would take down the repository by deleting controls. The step
+      # below skips files whose basename starts with `reusable-` so the
+      # rejection cannot reach them.
+      #
+      # Why a list of names and not "any job in any reusable": a ruleset
+      # requires a stable name (Glyndor/podup#1552), so the named set is the
+      # actual contract. A reuse-side `name: foo (bar)` whose value moves
+      # is its own problem; this step refuses a switch in front of it, not
+      # the move.
+      #
+      # Lives here for the same reason tooling-isolation does: a workflow-lint
+      # job inside the shell suite would share the fate of the `if:` it tries
+      # to gate, and any other required job is the one whose `if:` is the
+      # defect being caught.
+      - name: A caller of a required check must not carry a switchable `if:`
+        run: |
+          python3 - <<'PY'
+          import glob
+          import os
+          import sys
+
+          import yaml
+
+          # Reusables whose jobs' `name:` becomes part of a required check
+          # name when a job here calls them. Each entry is the basename of
+          # the reusable; the matching caller is any job with
+          # `uses: ./.github/workflows/<name>`.
+          #
+          # The names below are the ones the rulesets on `main` and `develop`
+          # require, deduplicated and corrected against
+          # `gh pr checks <merged-PR> --required` on 2026-09-06. They move
+          # only when a required check is added or removed, and that is
+          # pulled by reading the live ruleset, not by guessing.
+          REQUIRED_REUSABLES = {
+              "reusable-rust-ci.yml": [
+                  "Format & lint", "Test", "Coverage", "Doc warnings",
+                  "MSRV", "Extra platforms",
+              ],
+              "reusable-dco.yml": [
+                  "Signed-off-by present on every commit",
+              ],
+              "reusable-line-limit.yml": [
+                  "line limit",
+              ],
+              "reusable-main-guard.yml": [
+                  "develop-only",
+              ],
+              "reusable-workflow-lint.yml": [
+                  "workflow-lint",
+              ],
+          }
+
+          # Required check names emitted directly by a job in this
+          # repository, not via a reusable call. The set is the value of
+          # the job's `name:` field that GitHub reports. A future addition
+          # lands here with its check name; the file it sits in is
+          # incidental.
+          DIRECT_EMITTER_NAMES = {
+              "Supported Podman majors",
+          }
+
+          # `if: always()` is the only `if:` value allowed on a caller of
+          # a required check. It evaluates true on every outcome, so the
+          # job runs and the check is reported. Anything else can evaluate
+          # false (`false`, `github.event_name == ...`, `inputs.x`,
+          # `success()`), and a skipped required check reports Success.
+          ALWAYS = "always()"
+
+
+          def is_switchable(value):
+              """True if an `if:` value can skip the job. Anything other
+              than `always()` can, including `true` (redundant but not
+              skip-causing on its own; refuse on principle so the rule is
+              easy to read and the tree does not grow decorative
+              conditionals). The point is that the assertion is precise:
+              the only blessed form is `always()`, and the reason is that
+              it cannot evaluate false."""
+              if isinstance(value, bool):
+                  return True
+              if not isinstance(value, str):
+                  return True
+              # A bare `if:` is evaluated as an expression whether or not
+              # the author wraps it in the dollar-brace form, so the wrapped
+              # spelling of `always()` means the same thing. Comparing the
+              # raw text would refuse it, which is valid and common, and
+              # push somebody to rewrite working code. The wrapper is
+              # stripped once, and only when it wraps the whole value:
+              # `always() && needs.x.result` keeps its tail, stays unequal
+              # and is refused, which is right because it can be false.
+              # The opening delimiter is built rather than written out:
+              # actionlint parses any literal one it finds inside this
+              # `run:` block as an expression of this workflow and fails on
+              # it, which is a real trap for anybody editing this scanner.
+              open_expr = "$" + "{{"
+              text = value.strip()
+              if text.startswith(open_expr) and text.endswith("}}"):
+                  text = text[len(open_expr):-2].strip()
+              return text != ALWAYS
+
+
+          def main():
+              files = sorted(set(
+                  glob.glob(".github/workflows/*.yml")
+                  + glob.glob(".github/workflows/*.yaml")
+              ))
+
+              # First pass: walk the reusables themselves to learn which
+              # required check names each one emits. The map is asserted
+              # against the static list above: a move in a reusable's
+              # `name:` is a defect this step refuses to silently follow.
+              # Skipping reusable-* in the caller scan below is the reason
+              # the static map is needed: those files are scanned for
+              # their own internals, not for how callers use them.
+              reusable_emits = {}
+              for path in files:
+                  name = os.path.basename(path)
+                  if not name.startswith("reusable-"):
+                      continue
+                  if name not in REQUIRED_REUSABLES:
+                      # An unknown reusable is not in scope; a caller
+                      # wrapping it is not gated. Leave it alone.
+                      continue
+                  try:
+                      with open(path) as fh:
+                          spec = yaml.safe_load(fh)
+                  except yaml.YAMLError as e:
+                      print(f"::warning file={path}::skipped: YAML parse error: {e}")
+                      continue
+                  if not isinstance(spec, dict):
+                      continue
+                  expected = set(REQUIRED_REUSABLES[name])
+                  found = set()
+                  jobs = spec.get("jobs") or {}
+                  for job_id, job in jobs.items():
+                      if not isinstance(job, dict):
+                          continue
+                      jname = job.get("name")
+                      if isinstance(jname, str) and jname in expected:
+                          found.add(jname)
+                  missing = expected - found
+                  if missing:
+                      print(
+                          f"::warning file={path}::reusable `{name}` no longer "
+                          f"emits expected required check name(s) {sorted(missing)}; "
+                          "the static map may be stale. Verify against "
+                          "`gh pr checks <merged-PR> --required`."
+                      )
+                  reusable_emits[name] = expected
+
+              violations = []
+
+              for path in files:
+                  name = os.path.basename(path)
+                  # A reusable's own `if:` lines are INSIDE the reusable
+                  # and configure it (`if: inputs.msrv != ''`). They are
+                  # not a caller switch and must stay allowed. The same
+                  # file is also scanned above for the emit assertion.
+                  if name.startswith("reusable-"):
+                      continue
+                  try:
+                      with open(path) as fh:
+                          spec = yaml.safe_load(fh)
+                  except yaml.YAMLError as e:
+                      print(f"::warning file={path}::skipped: YAML parse error: {e}")
+                      continue
+                  if not isinstance(spec, dict):
+                      continue
+                  jobs = spec.get("jobs") or {}
+                  if not isinstance(jobs, dict):
+                      continue
+                  for job_id, job in jobs.items():
+                      if not isinstance(job, dict):
+                          continue
+                      # Direct emitter: the job's `name:` is a required
+                      # check name. The file the job sits in is
+                      # incidental; what the ruleset matches is the
+                      # name GitHub reports.
+                      job_name = job.get("name")
+                      if isinstance(job_name, str) and job_name in DIRECT_EMITTER_NAMES:
+                          required_name = job_name
+                      else:
+                          required_name = None
+                      # Reusable caller: `uses:` references a known
+                      # required-emitting reusable.
+                      caller_required_names = []
+                      uses = job.get("uses")
+                      if isinstance(uses, str) and uses.startswith("./"):
+                          ref = uses[2:]
+                          for entry in reusable_emits:
+                              if ref.endswith(entry):
+                                  caller_required_names = sorted(reusable_emits[entry])
+                                  break
+                      if required_name is None and not caller_required_names:
+                          continue
+                      if "if" not in job:
+                          continue
+                      value = job["if"]
+                      if not is_switchable(value):
+                          # `if: always()` is the blessed form. Allowed.
+                          continue
+                      listed = (
+                          f"required check `{required_name}`"
+                          if required_name is not None
+                          else f"required checks {caller_required_names}"
+                      )
+                      violations.append((
+                          path, job_id, value, listed,
+                      ))
+
+              if violations:
+                  for path, job_id, value, listed in violations:
+                      print(
+                          f"::error file={path}::job `{job_id}` in {path} "
+                          f"emits {listed} and carries a job-level `if:` "
+                          f"of `{value!r}`. A caller-level conditional on a "
+                          "required check is a switch, not a filter: a "
+                          "skipped required check reports Success and does "
+                          "not block a merge. Only `if: always()` is allowed "
+                          "(it always evaluates true). Move the condition "
+                          "into the job's steps, or change it to "
+                          "`if: always()` if that is what you mean."
+                      )
+                  sys.exit(1)
+              print(
+                  "caller-if: every caller of a required check carries no "
+                  "switchable `if:` (only `if: always()` is allowed)."
+              )
+
+
+          if __name__ == "__main__":
+              main()
+          PY

--- a/tests/shell/reusable-workflow-lint-caller-if.test.sh
+++ b/tests/shell/reusable-workflow-lint-caller-if.test.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the caller-if assertion in
+# .github/workflows/reusable-workflow-lint.yml: a caller of a job that
+# emits a required check name must not carry a switchable job-level
+# 'if:'.
+#
+# Eleven status checks are required on 'main' and ten on 'develop'.
+# Every one of them is emitted either directly by a job in this tree or
+# by a reusable a job here calls. GitHub reports a SKIPPED required
+# check as Success, so a job-level 'if: false' (or anything else that
+# can evaluate false) switches the gate off without failing it. The
+# assertion refuses that, with one message naming the file, the job,
+# and the property being violated.
+#
+# 'if: always()' is the one allowed form. It can never evaluate false,
+# so the job always runs and the check is always reported. This is the
+# load-bearing pattern from #1552: a gate job summarises a matrix that
+# may fail, so it has to run on 'failure' too and reads 'needs.*.result'
+# to make its verdict. The podman-lane gate and the rust-ci gates are
+# the documented cases in this repository, and the assertion keeps them
+# passing while refusing every other value.
+#
+# 'if:' lines INSIDE a reusable are not in scope: they configure how
+# the reusable behaves ('if: inputs.msrv !=') and refusing them would
+# take down the repository by deleting controls. The assertion skips
+# files whose basename starts with 'reusable-', so it never reaches
+# them. One of the tests plants a switching 'if:' inside
+# reusable-rust-ci.yml-shaped content to prove the seam holds.
+#
+# Each step's 'run:' body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository. Every
+# refusal asserts WHICH message fired. Each refusal is paired with an
+# acceptance of the same shape just inside the line.
+#
+# Requires: python3 with PyYAML (the step under test imports it).
+# The fixtures below carry literal '${{ ... }}' expressions and
+# backticks: the assertion under test reads those characters, so they
+# must reach the file unexpanded. Single quotes are the point, not an
+# oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# All test descriptions are passed via this helper as single-quoted
+# strings. Backticks inside double quotes would be command substitution
+# in bash, so the helper takes its argument unquoted and the call sites
+# use single quotes throughout.
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Pull one step's 'run:' body out of a workflow, dedented, so it can be
+# run. Same helper as the other tests in this directory: the point is
+# to exercise the script as it ships rather than a copy of it that can
+# drift.
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A caller of a required check" > "$WORK/caller-if.sh"
+check 'the caller-if assertion was extracted from the workflow' "1" \
+	"$(grep -c 'REQUIRED_REUSABLES' "$WORK/caller-if.sh" | awk '{print ($1>0)}')"
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# A fresh empty tree with '.github/workflows/', and the real reusables
+# copied across. The reusables are needed because the assertion walks
+# them to learn which required check names they emit; without them the
+# caller scan has nothing to look at.
+new() {
+	rm -rf "$WORK/t"
+	mkdir -p "$WORK/t/.github/workflows"
+	for r in \
+		reusable-rust-ci.yml \
+		reusable-dco.yml \
+		reusable-line-limit.yml \
+		reusable-main-guard.yml \
+		reusable-workflow-lint.yml; do
+		cp "$HERE/.github/workflows/$r" "$WORK/t/.github/workflows/"
+	done
+	printf '%s' "$WORK/t"
+}
+run_in() { # $1=dir $2=script -> stdout+stderr, status in $?
+	( cd "$1" && bash "$2" 2>&1 )
+}
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+# A caller of a required-emitting reusable with a placeholder if-value
+# or no 'if:' at all (when $2 is empty). The reusable referenced here
+# is one whose required names are listed in REQUIRED_REUSABLES; any of
+# the five will do for the assertions.
+caller() { # $1=dir $2=if-value (or empty) $3=reusable basename
+	if [ -n "$2" ]; then
+		ifline="    if: $2"
+	else
+		ifline=""
+	fi
+	cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  caller:
+$ifline
+    uses: ./.github/workflows/$3
+EOF
+}
+
+# A direct-emitting job: 'name: Supported Podman majors' on the
+# 'podman-majors' job, matching DIRECT_EMITTER_NAMES. The optional
+# 'if:' value sits between the 'name:' and 'runs-on:'.
+direct() { # $1=dir $2=if-value (or empty)
+	if [ -n "$2" ]; then
+		ifline="    if: $2"
+	else
+		ifline=""
+	fi
+	cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  podman-majors:
+    name: Supported Podman majors
+$ifline
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo green
+EOF
+}
+
+# ===========================================================================
+# Positive control: the real tree passes (the load-bearing if: always()
+# on the podman-lane gate stays allowed).
+# ===========================================================================
+
+out="$(cd "$HERE" && bash "$WORK/caller-if.sh")"; rc=$?
+check 'the real repository tree passes the caller-if assertion' "0" "$rc"
+check 'and the step prints the OK summary, not a refusal' "1" \
+	"$(said "$out" 'caller-if: every caller of a required check')"
+
+# ===========================================================================
+# Negative fixtures: each refusal is paired with a same-shape positive
+# control so the acceptance is not implicit.
+# ===========================================================================
+
+# --- a job-level if: false on a caller is refused ------------------------
+d="$(new)"; caller "$d" 'false' 'reusable-rust-ci.yml'
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'a job-level if: false on a reusable caller is refused' "1" "$rc"
+check 'and the message names the offending job' "1" \
+	"$(said "$out" 'job `caller` in')"
+check 'and the message names the reusable required checks' "1" \
+	"$(said "$out" 'required checks')"
+check 'and the message names the value as a switch, not a filter' "1" \
+	"$(said "$out" 'switch, not a filter')"
+check 'and the message points at always() as the blessed form' "1" \
+	"$(said "$out" 'Only `if: always()` is allowed')"
+
+# --- a job-level if: ${{ ... }} over github.event_name is refused --------
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/reusable-rust-ci.yml
+EOF
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'a switching if: over github.event_name is refused' "1" "$rc"
+check 'and the offending job is named' "1" "$(said "$out" '`caller`')"
+
+# --- a job-level if: inputs.X on a reusable caller is refused ------------
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    if: inputs.coverage-threshold > 0
+    uses: ./.github/workflows/reusable-rust-ci.yml
+EOF
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an if: inputs.X on a reusable caller is refused' "1" "$rc"
+
+# --- a direct-emitting job (podman-majors) with if: false is refused ----
+d="$(new)"; direct "$d" 'false'
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an if: false on the direct podman-majors job is refused' "1" "$rc"
+check 'and the message names the required check, not just the job' "1" \
+	"$(said "$out" 'required check `Supported Podman majors`')"
+
+# --- a direct-emitting job with if: success() is refused -----------------
+d="$(new)"; direct "$d" 'success()'
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an if: success() on a direct emitter is refused' "1" "$rc"
+
+# ===========================================================================
+# Positive controls inside the negative fixtures: each shape above is
+# accepted when the conditional is removed or replaced with always().
+# ===========================================================================
+
+# --- a caller with no if: at all is allowed ------------------------------
+d="$(new)"; caller "$d" '' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'a caller with no job-level if: is allowed' "0" "$rc"
+
+# --- a caller with if: always() is the blessed form ---------------------
+d="$(new)"; caller "$d" 'always()' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: always() on a reusable caller is allowed' "0" "$rc"
+out="$(run_in "$d" "$WORK/caller-if.sh")"
+check 'and the step says every caller passes' "1" \
+	"$(said "$out" 'every caller of a required check')"
+
+# --- the wrapped spelling of always() means the same thing ---------------
+# A bare if: is evaluated as an expression either way, so refusing the
+# wrapped form would refuse valid code. Its tail-carrying cousin can still
+# evaluate false and stays refused, which is what makes this a real seam
+# rather than a substring match.
+d="$(new)"; caller "$d" '${{ always() }}' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'the wrapped spelling of always() is allowed too' "0" "$rc"
+
+d="$(new)"; caller "$d" 'always() && needs.build.result == "success"' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'always() with a tail can still be false, so it is refused' "1" "$rc"
+
+# --- a direct-emitting job with if: always() is allowed -----------------
+d="$(new)"; direct "$d" 'always()'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: always() on the direct podman-majors job is allowed' "0" "$rc"
+
+# --- a direct-emitting job with no if: is allowed ------------------------
+d="$(new)"; direct "$d" ''
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'the direct podman-majors job with no if: is allowed' "0" "$rc"
+
+# ===========================================================================
+# Inside a reusable, if: configs the reusable. Refusing it would break
+# the whole repository. The assertion skips reusable-* files, so a
+# switching 'if:' inside reusable-rust-ci.yml stays accepted.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/some-job.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/reusable-rust-ci.yml
+EOF
+# Replace the test-extra job's 'if: inputs.extra-test-os != ...' with a
+# switching expression that would be refused on a caller. The reusable's
+# own job must stay accepted, because refusing it would take the
+# repository down.
+python3 - "$d/.github/workflows/reusable-rust-ci.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "  test-extra:\n    name: Test (${{ matrix.os }})\n    if: inputs.extra-test-os != '[]'",
+    "  test-extra:\n    name: Test (${{ matrix.os }})\n    if: ${{ github.event_name == 'pull_request' }}",
+    1,
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'a switching if: inside a reusable is still allowed' "0" "$rc"
+out="$(run_in "$d" "$WORK/caller-if.sh")"
+check 'and the step did not flag the reusable own job' "0" \
+	"$(said "$out" 'test-extra')"
+check 'and the step says every caller passes' "1" \
+	"$(said "$out" 'every caller of a required check')"
+
+# ===========================================================================
+# Edge: a non-required job carrying if: is not in scope. The assertion
+# only fires on jobs that emit a required check, so an if: on a
+# different job stays allowed. This is the seam that keeps the friction
+# local to the gate.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/some-job.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  unrelated:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo green
+EOF
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: on a non-required job is allowed' "0" "$rc"
+
+# ===========================================================================
+# Edge: a caller of a reusable that is NOT in REQUIRED_REUSABLES. The
+# callers of reusables not on the list are not gated, because the
+# assertion cannot prove their jobs are required.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/some-job.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    if: false
+    uses: ./.github/workflows/reusable-shell-ci.yml
+EOF
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: false on a non-required reusable caller is allowed' "0" "$rc"
+
+# ===========================================================================
+# Edge: an unparseable caller is a warning, not a silent skip. The
+# previous form of a check here would fail-closed on a YAML parse
+# error; this form follows tooling-isolation and reports it as a
+# ::warning so the silence is visible.
+# ===========================================================================
+
+d="$(new)"; printf 'name: [\n' > "$d/.github/workflows/broken.yml"
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an unparseable workflow does not fail the step' "0" "$rc"
+check 'but is reported as skipped' "1" "$(said "$out" '::warning')"
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Eleven status checks are required on `main` and ten on `develop`, and
every one is emitted by a job that a job-level `if:` can skip. GitHub
reports a skipped required check as success, so one line in a pull
request switches off coverage, the MSRV floor or the validation on both
supported Podman majors, and the ruleset still reports the gate as
satisfied. Nothing here asserted otherwise: this repository's
`reusable-workflow-lint.yml` carried no assertion of that kind at all.

The rule is not "no conditional on a caller", which is the shape the
channels prove and which would refuse this tree on day one:
`podman-lane.yml` carries `if: always()` on `podman-majors`, the job
that emits `Supported Podman majors`, and that is the gate pattern from

What matters is whether the conditional can SKIP the job. `always()`
never evaluates false, so the job runs and the check is reported.
Anything that can be false skips it, and a skipped required check
reports success. The wrapped spelling of `always()` is the same
expression to GitHub and is accepted too, while `always()` with a tail
keeps its tail, can still be false, and is refused.

The scan skips `reusable-*` files. The eleven conditionals inside the
reusables are how a reusable is configured, not a switch on a caller,
and eight of them are in `reusable-rust-ci.yml` alone.

The check names come from `gh pr checks --required` against a merged
pull request on each branch, deduplicated. That is also where the two
errors in what I wrote in the issue come from: the counts are eleven and
ten rather than twelve and eleven, and `rust / Format` does not exist,
since the job is named `Format & lint`.

28 assertions, each refusal paired with an acceptance of the same shape,
the real tree as the positive control, and a seam either side: a
switching conditional inside a reusable stays allowed, and so does one
on a job that emits nothing required.

One note for whoever edits this scanner next. A literal expression
delimiter written inside the `run:` block is parsed by actionlint as an
expression of this workflow and fails the lint, so the one this code
needs is built by concatenation and says why.

Closes #1718.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>