### PR TITLE
chore(release): bump to 5.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.9.1"
+version = "5.9.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.9.1"
+version = "5.9.2"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+podup (5.9.2) unstable; urgency=medium
+
+  * `audit` stops reporting `unpinned_image` against a tag the service builds
+    itself: a `build:` section makes the tag a local output, not an unpinned
+    pull, so the finding was noise on every compose file that builds.
+  * `audit` matches `secret_in_environment` on name segments rather than
+    substrings, so a variable whose name merely contains a flagged word, for
+    example `PASSWORD_FILE_PATH` alongside `NOT_A_PASSWORD_HINT`, is no longer
+    reported on the substring alone.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 07 Sep 2026 00:05:00 -0500
+
 podup (5.9.1) unstable; urgency=medium
 
   * `up --build` draws one board: the image rows sit at the top and are


### PR DESCRIPTION
Two user-visible fixes to `audit` landed since 5.9.1 and no published
binary carries them, so they go out as a patch.

All three files that stamp a version move together: `Cargo.toml`,
`debian/changelog` and `Cargo.lock`. The release workflow refuses to
build when they disagree, and the reason is 1.9.0, which shipped
`podup_1.8.0_*.deb` because only `Cargo.toml` had been touched: apt saw
the version it already had and reported nothing to upgrade.

The changelog entry is what the two fixes do to somebody running the
tool, not the shape of the code that does it.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>