### PR TITLE
fix(cp): stop following a symlink planted in the archive

### DIFF
--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -57,8 +57,22 @@ pub(super) fn pack_path(
 /// - `dst` does not exist and the source is a directory: `dst` is created and the
 ///   source's *contents* are copied into it (matching `docker cp`).
 pub(super) fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
-	if dst.is_dir() {
-		return extract_tar_guarded(tar_bytes, dst);
+	// `symlink_metadata` rather than `is_dir` so a destination that is a
+	// symlink is recognised as a symlink, not the directory it points at.
+	// Following the symlink here would extract the archive into the wrong
+	// place (the target directory) and, once `flatten_single_wrapper_dir`
+	// runs over the extracted contents, move the target's files out of it
+	// (#1736). Refuse before anything touches the filesystem.
+	if let Ok(meta) = std::fs::symlink_metadata(dst) {
+		if meta.file_type().is_symlink() {
+			return Err(ComposeError::Copy(format!(
+				"cp: refusing symlink destination: {}",
+				dst.display()
+			)));
+		}
+		if meta.is_dir() {
+			return extract_tar_guarded(tar_bytes, dst);
+		}
 	}
 	// `dst` is not an existing directory.
 	if !archive_contains_dir(tar_bytes)? {
@@ -141,12 +155,25 @@ fn archive_contains_dir(tar_bytes: &[u8]) -> Result<bool> {
 /// basename (`srcdir/...`). When that lands in a freshly-created `dst`, docker
 /// puts the source's *contents* directly in `dst`, so collapse the lone wrapper
 /// level. A no-op unless `dst` holds exactly one entry and it is a directory.
+///
+/// The directory check goes through `symlink_metadata` so a wrapper that is
+/// a symlink is recognised as a symlink, not the directory it points at. A
+/// compromised container can plant such an entry: following the symlink would
+/// read the target's contents and rename them into `dst`, emptying an
+/// out-of-archive directory (#1736). The wrapper is left in place.
 fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
 	let mut children: Vec<std::path::PathBuf> = std::fs::read_dir(dst)
 		.map_err(ComposeError::Io)?
 		.filter_map(|e| e.ok().map(|e| e.path()))
 		.collect();
-	if children.len() != 1 || !children[0].is_dir() {
+	if children.len() != 1 {
+		return Ok(());
+	}
+	let wrapper = &children[0];
+	if !std::fs::symlink_metadata(wrapper)
+		.map(|m| m.is_dir())
+		.unwrap_or(false)
+	{
 		return Ok(());
 	}
 	let wrapper = children.remove(0);
@@ -302,3 +329,7 @@ fn sanitize_extracted_mode(_path: &Path, _mode: u32) {}
 #[cfg(test)]
 #[path = "archive_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "archive_symlink_tests.rs"]
+mod symlink_tests;

--- a/internal/engine/copy/archive_symlink_tests.rs
+++ b/internal/engine/copy/archive_symlink_tests.rs
@@ -1,0 +1,83 @@
+//! Tests for #1736: `cp` must not follow a symlink planted inside the
+//! archive being extracted, or rename the contents of an out-of-archive
+//! directory into the destination.
+//!
+//! The flat `cp svc:/` archive libpod returns for a container whose source
+//! is a directory can carry an entry that is itself a symlink pointing
+//! outside. After `extract_tar_guarded` lands the bytes, the destination
+//! holds that symlink as its only child. The flatten step then ran
+//! `is_dir()` on the child, which followed the symlink, called
+//! `read_dir` on the target, and renamed each file out of it: an
+//! out-of-archive directory was emptied into the destination. The fix
+//! uses `symlink_metadata` so the symlink stays a symlink.
+
+#[cfg(unix)]
+#[test]
+fn extract_archive_does_not_empty_victim_through_planted_symlink() {
+	// Victim lives outside the destination and holds private material.
+	let dir = tempfile::tempdir().expect("tempdir");
+	let victim = dir.path().join("victim");
+	std::fs::create_dir(&victim).expect("mkdir");
+	std::fs::write(victim.join("id_ed25519"), b"key").expect("write");
+	std::fs::write(victim.join("known_hosts"), b"hosts").expect("write");
+
+	let dst = dir.path().join("dst");
+
+	// Build the archive shape that triggers the defect: a single
+	// directory entry naming the destination itself (so
+	// `archive_contains_dir` reports true and `extract_archive` reaches
+	// the flatten path), followed by a single symlink entry whose name
+	// has no parent and whose target points at the victim. After
+	// `extract_tar_guarded` lands the bytes, `dst` holds exactly one
+	// child: the symlink.
+	let mut builder = tar::Builder::new(Vec::new());
+	let mut d = tar::Header::new_gnu();
+	d.set_size(0);
+	d.set_mode(0o755);
+	d.set_entry_type(tar::EntryType::Directory);
+	d.set_path("./").expect("path");
+	d.set_cksum();
+	builder.append(&d, std::io::empty()).expect("dir");
+	let mut s = tar::Header::new_gnu();
+	s.set_size(0);
+	s.set_mode(0o755);
+	s.set_entry_type(tar::EntryType::Symlink);
+	s.set_path("w").expect("path");
+	// The symlink target has to land in the GNU linkname field; the safe
+	// `set_link_name` helper accepts the value, but writing the header
+	// field directly matches what the production extractor has to
+	// survive (an archive a hostile container could craft).
+	let target = victim.to_str().expect("utf-8");
+	{
+		let gnu = s.as_gnu_mut().expect("gnu header");
+		let name = &mut gnu.linkname;
+		name.iter_mut().for_each(|b| *b = 0);
+		let bytes = target.as_bytes();
+		name[..bytes.len()].copy_from_slice(bytes);
+	}
+	s.set_cksum();
+	builder.append(&s, std::io::empty()).expect("symlink");
+	let bytes = builder.into_inner().expect("finish");
+
+	// The call's return value is irrelevant; the safety invariant is that
+	// nothing in the victim directory has moved, regardless of whether the
+	// extraction succeeded or errored out.
+	let _ = super::extract_archive(&bytes, &dst);
+
+	assert!(
+		victim.join("id_ed25519").exists(),
+		"id_ed25519 was moved out of the victim directory through a symlink planted in the archive"
+	);
+	assert_eq!(
+		std::fs::read(victim.join("id_ed25519")).expect("read"),
+		b"key"
+	);
+	assert!(
+		victim.join("known_hosts").exists(),
+		"known_hosts was moved out of the victim directory through a symlink planted in the archive"
+	);
+	assert_eq!(
+		std::fs::read(victim.join("known_hosts")).expect("read"),
+		b"hosts"
+	);
+}


### PR DESCRIPTION
`podup cp` container to host moved the operator's files out of a
directory that was never part of the copy. `flatten_single_wrapper_dir`
called `is_dir()` on the extracted wrapper, `is_dir()` follows symlinks,
and a compromised container can plant one: the flatten step then read
the target's contents and renamed them into the destination. Reproduced
end to end with the real binary, with `~/.ssh` as the target: the
directory ends empty and the error surfaces after the move.

The check now goes through `symlink_metadata` at both sites, so a
symlink is a symlink and not the thing it points at, and a destination
that is itself a symlink is refused before anything touches the
filesystem.

The trigger I wrote in the issue was wrong, and the test that came with
it passed on the unfixed tree: a destination that is a symlink returns
at the `dst.is_dir()` branch above and never reaches flatten. The
symlink has to arrive out of the tar. The test here builds that archive
in memory, plants a victim directory beside the destination, and
asserts the victim still holds its files. On the tree before this
change it fails with `id_ed25519 was moved out of the victim directory
through a symlink planted in the archive`, and reverting only the
flatten half brings that failure back.

Closes #1736.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>