### PR TITLE
fix(quadlet): quote the values we interpolate into PodmanArgs=

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -233,9 +233,9 @@ data into a process or onto disk:
   a filesystem path from it.
 - **URL paths** go through `urlencoded` so container names, project names,
   and tags with arbitrary bytes reach libpod as a single encoded segment.
-- **Quadlet values** are filtered through `escape_unit_value` /
-  `safe_unit_stem`; the unit filename is checked again by `write_units` so
-  a poisoned value cannot break out of the output directory.
+- **Quadlet values** are filtered through `escape_unit_value` and the dedicated
+  `PodmanArgs=` interpolations use `quote_podman_arg_value`; the unit filename is
+  checked again by `write_units` so a poisoned value cannot break out of the output directory.
 - **Signal names** are resolved to numbers through `resolve_stop_signal`:
   the libpod endpoint is a number, a string returns HTTP 500.
 - **Pull policies** are normalised through `libpod_pull_policy`; an

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -134,6 +134,7 @@ pub fn install_quadlet<S: SystemCtl>(
 		)));
 	}
 
+	quadlet::validate_for_quadlet(file)?;
 	let result = quadlet::generate_at(file, project, base_dir);
 	if let Some(dup) = result.duplicate_filename() {
 		return Err(ComposeError::Autostart(format!(

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -4,8 +4,6 @@
 use std::io::Write;
 use std::path::Path;
 
-use podup::compose::types::ComposeFile;
-
 /// Quadlet units are systemd unit files; they only run on Linux hosts (where
 /// systemd consumes them from `~/.config/containers/systemd/`). Generating them
 /// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
@@ -17,43 +15,6 @@ fn quadlet_platform_advisory(os: &str) -> Option<String> {
 		"quadlet units require systemd (Linux); generated files will not run on this host"
 			.to_string()
 	})
-}
-
-/// Validate the compose file before emitting Quadlet units, applying the same
-/// rules `up`/`create`/`config` enforce so `generate quadlet` is not more
-/// permissive than the commands that actually run the stack. Rejecting here keeps
-/// the generator from emitting structurally invalid units (a `.container` with
-/// no `Image=`, an out-of-range `PublishPort=`, a `--memory` flag with a
-/// malformed size) or a systemd ordering cycle.
-fn validate_for_quadlet(file: &ComposeFile) -> podup::Result<()> {
-	// `depends_on` cycles would emit mutually `After=`/`Requires=` units that
-	// systemd rejects as an ordering cycle; reject them as `up`/`create` do.
-	// A missing dependency is *not* fatal here: an `After=` may legitimately
-	// reference a unit managed outside this project.
-	if let Err(e @ podup::ComposeError::CircularDependency(_)) = podup::compose::resolve_order(file)
-	{
-		return Err(e);
-	}
-	for (name, svc) in &file.services {
-		// Every service must declare an image or a build, the same rule
-		// `config`/`up` enforce; without it the unit would have no `Image=`.
-		if svc.image.is_none() && svc.build.is_none() {
-			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
-		}
-		// Reject malformed/out-of-range ports instead of re-emitting them as an
-		// invalid `PublishPort=`.
-		podup::ports::parse_ports(&svc.ports)?;
-		// Reject a malformed memory limit rather than passing it through to a
-		// `--memory` flag systemd/Podman would choke on.
-		if let Some(mem) = &svc.mem_limit {
-			if podup::size::parse_memory(mem).is_none() {
-				return Err(podup::ComposeError::Unsupported(format!(
-					"service '{name}': mem_limit '{mem}' is not a valid memory size"
-				)));
-			}
-		}
-	}
-	Ok(())
 }
 
 /// Write to stdout, treating a closed pipe (e.g. `podup generate quadlet | head`)
@@ -79,7 +40,7 @@ pub(crate) fn write_quadlet(
 	no_warn: bool,
 ) -> podup::Result<()> {
 	// Reject configs the running commands would reject, before emitting anything.
-	validate_for_quadlet(file)?;
+	podup::quadlet::validate_for_quadlet(file)?;
 
 	// The Quadlet path's host-binding / privilege-escalation warnings are
 	// gated on `--no-warn` (issue #1358). The flag lives on a thread-local

--- a/internal/generate_tests.rs
+++ b/internal/generate_tests.rs
@@ -1,5 +1,6 @@
-use super::{quadlet_platform_advisory, validate_for_quadlet, write_quadlet};
+use super::{quadlet_platform_advisory, write_quadlet};
 use podup::parse_str;
+use podup::quadlet::validate_for_quadlet;
 
 #[test]
 fn quadlet_advisory_only_on_non_linux() {

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -18,7 +18,30 @@ mod warnings;
 use std::cell::Cell;
 
 use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::ports::parse_ports;
 use unit::{build_unit, container_unit, network_unit, volume_unit, UnitContext};
+
+/// Validate compose data before writing Quadlet units.
+pub fn validate_for_quadlet(file: &ComposeFile) -> Result<()> {
+	if let Err(e @ ComposeError::CircularDependency(_)) = crate::compose::resolve_order(file) {
+		return Err(e);
+	}
+	for (name, svc) in &file.services {
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(ComposeError::NoImageOrBuild(name.clone()));
+		}
+		parse_ports(&svc.ports)?;
+		if let Some(mem) = &svc.mem_limit {
+			if crate::size::parse_memory(mem).is_none() {
+				return Err(ComposeError::Unsupported(format!(
+					"service '{name}': mem_limit '{mem}' is not a valid memory size"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
 
 thread_local! {
 	/// CLI `--no-warn` flag honoured by the Quadlet path's host-binding /

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -231,6 +231,31 @@ pub(super) fn sanitize_value(value: &str) -> String {
 	value.chars().filter(|c| !c.is_control()).collect()
 }
 
+/// Quote a compose value that is interpolated into a `PodmanArgs=` template
+/// (one of the seven [`crate::quadlet::render`] sites), so the resulting
+/// `PodmanArgs=` line cannot smuggle additional `podman run` flags into the
+/// argv the quadlet generator hands to `podman`.
+///
+/// Three things happen, in order:
+///
+/// 1. Control characters are stripped, the same rule as [`sanitize_value`], so
+///    an embedded newline cannot split the directive or inject a sibling
+///    line.
+/// 2. `%` is doubled, because systemd specifiers like `%h` or `%U` would otherwise
+///    be expanded at unit activation, and a value like `%h/mem` would become
+///    `<hostname>/mem` inside the podman flag. `Environment=` already does
+///    this; the seven `PodmanArgs=` interpolation sites were not, which is
+///    why the brief calls it out.
+/// 3. The result is wrapped in double quotes (with `"` and `\` escaped),
+///    which is the systemd word-splitting syntax for "these characters are
+///    one token". A hostile value carrying whitespace stays inside the
+///    quoted group; podman sees one argv element and rejects it.
+pub(super) fn quote_podman_arg_value(value: &str) -> String {
+	let stripped = sanitize_value(value);
+	let escaped = stripped.replace('%', "%%");
+	format!("\"{}\"", escaped.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
 /// Keys whose value Quadlet/systemd splits on whitespace (a `KEY=VALUE` option
 /// list): an unquoted space would split a single value into a truncated value
 /// plus bogus extra entries, so such values are quoted when they contain

--- a/internal/quadlet/render_tests.rs
+++ b/internal/quadlet/render_tests.rs
@@ -282,6 +282,46 @@ fn escape_arg_line_keys_are_left_intact() {
 	);
 }
 
+// --- quote_podman_arg_value (smuggle guard for the seven sites) ---
+
+#[test]
+fn quote_podman_arg_value_always_quotes_and_doubles_percent() {
+	// The seven interpolation sites call this on a raw compose value before
+	// splicing it into a `--flag=value` template. The result must be one
+	// systemd-token, regardless of whether the value has whitespace.
+	assert_eq!(quote_podman_arg_value("512m"), "\"512m\"");
+	// A value carrying whitespace must still be one quoted token; the
+	// smuggled `--privileged` would otherwise become its own argv element.
+	let quoted = quote_podman_arg_value("0 --privileged -v /:/hostfs2");
+	assert_eq!(quoted, "\"0 --privileged -v /:/hostfs2\"");
+}
+
+#[test]
+fn quote_podman_arg_value_strips_control_characters() {
+	// A newline injection must be flattened; the sanitiser strips it so the
+	// value stays one physical line inside the PodmanArgs= directive.
+	assert_eq!(
+		quote_podman_arg_value("ok\nExecStartPre=/bin/rm -rf /"),
+		"\"okExecStartPre=/bin/rm -rf /\""
+	);
+}
+
+#[test]
+fn quote_podman_arg_value_doubles_percent_for_literal() {
+	// systemd specifiers like %h must not be expanded; doubling to %%h is
+	// what Environment= does (#1734). podman receives the literal `%h`.
+	assert_eq!(quote_podman_arg_value("%h/mem"), "\"%%h/mem\"");
+}
+
+#[test]
+fn quote_podman_arg_value_escapes_backslash_and_quote() {
+	// A backslash inside the quoted group would fold the next physical
+	// line, swallowing whatever directive follows; an unescaped `"` would
+	// terminate the quoted group early.
+	assert_eq!(quote_podman_arg_value("back\\slash"), "\"back\\\\slash\"");
+	assert_eq!(quote_podman_arg_value("with\"quote"), "\"with\\\"quote\"");
+}
+
 #[test]
 fn safe_unit_stem_strips_leading_dash() {
 	// A name starting with `-`/`--` must not yield a file name beginning with

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -229,7 +229,7 @@ services:
 		"AddHost=db:10.0.0.2",
 		"Annotation=run.oci.keep=1",
 		"Network=host",
-		"PodmanArgs=--memory=512m",
+		"PodmanArgs=--memory=\"512m\"",
 		"HealthCmd=curl -f http://localhost",
 		"HealthInterval=5s",
 		"HealthRetries=3",
@@ -334,7 +334,7 @@ networks:
 		"LogDriver=journald",
 		"LogOpt=tag=mytag",
 		"NetworkAlias=web-alias",
-		"PodmanArgs=--memory=256m",
+		"PodmanArgs=--memory=\"256m\"",
 	] {
 		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
 	}

--- a/internal/quadlet/tests/fields_resources.rs
+++ b/internal/quadlet/tests/fields_resources.rs
@@ -10,6 +10,7 @@
 //! or a `deploy:` key into a Podman argument or a systemd directive, which is
 //! one question; the rest of `fields.rs` maps compose fields to Quadlet keys.
 
+use super::assert_argv_has_no_token;
 use super::unit_named;
 use crate::parse_str;
 use crate::quadlet::generate_at;
@@ -32,11 +33,11 @@ services:
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("PodmanArgs=--memory=512m"),
+		c.contains("PodmanArgs=--memory=\"512m\""),
 		"mem_limit must route through PodmanArgs in:\n{c}"
 	);
 	assert!(
-		c.contains("PodmanArgs=--security-opt apparmor=my-profile"),
+		c.contains("PodmanArgs=--security-opt apparmor=\"my-profile\""),
 		"apparmor must route through PodmanArgs in:\n{c}"
 	);
 	for forbidden in ["Memory=512m", "AppArmor=my-profile"] {
@@ -65,8 +66,8 @@ services:
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	for expected in [
-		"PodmanArgs=--cpus=1.5",
-		"PodmanArgs=--cpuset-cpus=0,1",
+		"PodmanArgs=--cpus=\"1.5\"",
+		"PodmanArgs=--cpuset-cpus=\"0,1\"",
 		"PodmanArgs=--cpu-shares=512",
 		"PodmanArgs=--cpu-quota=50000",
 		"PodmanArgs=--cpu-period=100000",
@@ -92,7 +93,7 @@ services:
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("PodmanArgs=--cpus=2"),
+		c.contains("PodmanArgs=--cpus=\"2\""),
 		"missing deploy cpus PodmanArgs in:\n{c}"
 	);
 }
@@ -142,4 +143,169 @@ fn deploy_restart_condition_none_maps_to_no() {
 	assert!(unit_named(&out, "p-s.container")
 		.contents
 		.contains("Restart=no"));
+}
+
+// ---------------------------------------------------------------------------
+// #1734: PodmanArgs= argv safety at the seven interpolation sites
+//
+// `escape_unit_value` returns early for `PodmanArgs` (treating it like
+// `Exec`/`Entrypoint`), so the seven `format!()` sites that interpolate a
+// compose value into a podman-flag template were emitting raw bytes. A
+// hostile compose value containing whitespace would smuggle additional
+// `podman run` flags onto the same `PodmanArgs=` line; the unit text reads as
+// one innocent line, but systemd's word-splitter and podman's parser see two
+// argv elements. The only assertion worth pinning is the argv podman would
+// actually build, not the line that produced it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mem_limit_cannot_smuggle_extra_flags() {
+	// `mem_limit: "512m --privileged -v /:/hostfs"` is the canonical case
+	// from the issue. The smuggled `--privileged` and `-v /:/hostfs` must
+	// land inside ONE argv element via quoting, not become separate podman
+	// arguments.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    mem_limit: "512m --privileged -v /:/hostfs"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+	assert_argv_has_no_token(c, "-v");
+}
+
+#[test]
+fn cpus_cannot_smuggle_extra_flags() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    cpus: "1.5 --privileged"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+}
+
+#[test]
+fn cpuset_cannot_smuggle_extra_flags() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    cpuset: "0 --privileged -v /:/hostfs2"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+	assert_argv_has_no_token(c, "-v");
+}
+
+#[test]
+fn deploy_memory_cannot_smuggle_extra_flags() {
+	// `deploy.resources.limits.memory` is the modern equivalent of
+	// `mem_limit`; both interpolation sites need the same protection.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    deploy:
+      resources:
+        limits:
+          memory: "256m --privileged"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+}
+
+#[test]
+fn apparmor_profile_cannot_smuggle_extra_flags() {
+	// The apparmor arm routes through PodmanArgs too (`AppArmor=` would be
+	// dropped by Quadlet). A hostile profile like
+	// "my-profile --privileged -v /:/hostfs" must stay one argv element.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    security_opt:
+      - "apparmor=my-profile --privileged"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+}
+
+#[test]
+fn build_arg_value_cannot_smuggle_extra_flags() {
+	// The smoke-test from the issue: a build service with a `build:` block
+	// emits a `.build` unit that carries `--build-arg` through PodmanArgs.
+	// A value with whitespace must not become two podman args.
+	let yaml = r#"
+services:
+  app:
+    build:
+      context: .
+      args:
+        EVIL: "v --privileged -v /:/hostfs"
+    image: app:1.0
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let b = &unit_named(&out, "p-app.build").contents;
+	assert_argv_has_no_token(b, "--privileged");
+	assert_argv_has_no_token(b, "-v");
+}
+
+#[test]
+fn build_arg_bare_key_cannot_smuggle_extra_flags() {
+	// A `--build-arg` with no value is just the key. Smuggling still has to
+	// be impossible: a hostile key like `BAD --privileged` must end up as
+	// one argv element, not the literal "--privileged" plus the key.
+	let yaml = r#"
+services:
+  app:
+    build:
+      context: .
+      args:
+        - "BAD --privileged"
+    image: app:1.0
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let b = &unit_named(&out, "p-app.build").contents;
+	assert_argv_has_no_token(b, "--privileged");
+}
+
+#[test]
+fn podman_args_doubles_percent_specifiers() {
+	// systemd specifiers like `%h` would otherwise be expanded at unit
+	// activation time (the same behaviour `Environment=` already escapes).
+	// After the fix a value carrying `%h` is doubled to `%%h` in the
+	// interpolated podman arg, so podman receives `%h` literally and systemd
+	// does not substitute it for the unit's hostname.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    mem_limit: "%h/mem"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	// After systemd unescapes `%%` to `%`, podman would receive the
+	// literal `%h/mem` from the quoted value, which is harmless; before
+	// the fix, podman would receive `mem` with `%h` expanded to the host's
+	// hostname.
+	assert!(
+		c.contains("PodmanArgs=--memory=\"%%h/mem\""),
+		"`%%h` must be doubled on the PodmanArgs path; got:\n{c}"
+	);
 }

--- a/internal/quadlet/tests/mod.rs
+++ b/internal/quadlet/tests/mod.rs
@@ -5,7 +5,10 @@ mod fields_logging;
 mod fields_resources;
 mod health;
 mod network_volume;
+mod podman_argv;
 mod units;
+
+pub(super) use podman_argv::assert_argv_has_no_token;
 
 fn unit_named<'a>(out: &'a QuadletOutput, filename: &str) -> &'a QuadletUnit {
 	out.units

--- a/internal/quadlet/tests/podman_argv.rs
+++ b/internal/quadlet/tests/podman_argv.rs
@@ -1,0 +1,134 @@
+//! Argv-tokenisation helpers used by tests to assert that a generated unit's
+//! `PodmanArgs=` value cannot smuggle an extra `podman run` flag into the argv
+//! quadlet's generator would build from it.
+//!
+//! The unit text alone is not enough: `PodmanArgs=--memory=512m --privileged`
+//! is what `escape_unit_value` produced on the unfixed tree for a hostile
+//! `mem_limit: "512m --privileged"`, and it reads as one innocent-looking
+//! line. Podman, however, would receive `--memory=512m` and `--privileged` as
+//! two separate argv elements. That is the security property the bug breaks,
+//! and the only one worth asserting.
+//!
+//! systemd's `systemd.syntax(7)` word-splitter is the authoritative divider:
+//! the directive value after `PodmanArgs=` is tokenised on whitespace while
+//! honouring `"`-quoted groups (single quotes and C-style escapes are also
+//! honoured by systemd, but the seven interpolation sites have no reason to
+//! emit those, so a faithful `PodmanArgs=-side only needs the double-quote
+//! form to be tested).
+
+/// Tokenise one `PodmanArgs=` value the way systemd does.
+///
+/// Returns the argv podman would receive. Tokens coming out of a `"..."`
+/// group have their quotes stripped, the way systemd does (the consumed
+/// double quotes are not preserved as characters).
+pub fn tokenise_podman_argv(value: &str) -> Vec<String> {
+	let mut out = Vec::new();
+	let mut current = String::new();
+	let mut in_quotes = false;
+	let mut chars = value.chars().peekable();
+	while let Some(c) = chars.next() {
+		if in_quotes {
+			match c {
+				'"' => in_quotes = false,
+				'\\' if chars.peek() == Some(&'"') => {
+					current.push('"');
+					chars.next();
+				}
+				_ => current.push(c),
+			}
+			continue;
+		}
+		match c {
+			'"' => in_quotes = true,
+			c if c.is_whitespace() => {
+				if !current.is_empty() {
+					out.push(std::mem::take(&mut current));
+				}
+			}
+			_ => current.push(c),
+		}
+	}
+	if !current.is_empty() {
+		out.push(current);
+	}
+	out
+}
+
+/// Parse every `PodmanArgs=` line out of a unit body, concatenate the values
+/// the way systemd does (`PodmanArgs=` is multi-valued by design), and
+/// tokenise the combined string. Returns the argv podman would receive when
+/// the generator feeds it to `podman run`.
+///
+/// Comment lines (`#`) are skipped so a unit file's ownership marker does not
+/// confuse the parser; the `# podup-owner: <project>` line lives at the top
+/// of every generated unit and would otherwise contribute empty tokens.
+pub fn podman_argv_from_unit(unit_contents: &str) -> Vec<String> {
+	let mut combined = String::new();
+	for raw in unit_contents.lines() {
+		let line = raw.trim_end();
+		if line.starts_with('#') {
+			continue;
+		}
+		if let Some(rest) = line.strip_prefix("PodmanArgs=") {
+			if !combined.is_empty() {
+				combined.push('\n');
+			}
+			combined.push_str(rest);
+		}
+	}
+	tokenise_podman_argv(&combined)
+}
+
+/// Assert that no `PodmanArgs=` line in `unit_contents` produces `needle` as
+/// its own argv element after systemd tokenisation. Used by the seven
+/// per-site tests to pin the property the bug breaks.
+pub fn assert_argv_has_no_token(unit_contents: &str, needle: &str) {
+	let argv = podman_argv_from_unit(unit_contents);
+	assert!(
+		!argv.iter().any(|tok| tok == needle),
+		"unit produces {needle:?} as its own argv element; argv = {argv:#?}; unit:\n{unit_contents}"
+	);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn tokenise_splits_on_whitespace() {
+		assert_eq!(
+			tokenise_podman_argv("--memory=512m --privileged"),
+			vec!["--memory=512m", "--privileged"]
+		);
+	}
+
+	#[test]
+	fn tokenise_respects_double_quotes() {
+		// `--cpuset-cpus="0 --privileged"` is ONE argv element. That is what
+		// the seven-site fix must produce, and what this helper proves.
+		assert_eq!(
+			tokenise_podman_argv(r#"--cpuset-cpus="0 --privileged""#),
+			vec!["--cpuset-cpus=0 --privileged"]
+		);
+	}
+
+	#[test]
+	fn multiple_podman_args_lines_concatenate() {
+		// systemd accepts multiple `PodmanArgs=` lines; their values merge.
+		let unit = "\
+PodmanArgs=--memory=512m
+PodmanArgs=--cpuset-cpus=0,1
+";
+		assert_eq!(
+			podman_argv_from_unit(unit),
+			vec!["--memory=512m", "--cpuset-cpus=0,1"]
+		);
+	}
+
+	#[test]
+	fn comments_are_ignored() {
+		// The podup ownership marker is the first line of every unit.
+		let unit = "# podup-owner: p\nPodmanArgs=--privileged\n";
+		assert_eq!(podman_argv_from_unit(unit), vec!["--privileged"]);
+	}
+}

--- a/internal/quadlet/tests/podman_argv.rs
+++ b/internal/quadlet/tests/podman_argv.rs
@@ -90,45 +90,40 @@ pub fn assert_argv_has_no_token(unit_contents: &str, needle: &str) {
 	);
 }
 
-#[cfg(test)]
-mod tests {
-	use super::*;
+#[test]
+fn tokenise_splits_on_whitespace() {
+	assert_eq!(
+		tokenise_podman_argv("--memory=512m --privileged"),
+		vec!["--memory=512m", "--privileged"]
+	);
+}
 
-	#[test]
-	fn tokenise_splits_on_whitespace() {
-		assert_eq!(
-			tokenise_podman_argv("--memory=512m --privileged"),
-			vec!["--memory=512m", "--privileged"]
-		);
-	}
+#[test]
+fn tokenise_respects_double_quotes() {
+	// `--cpuset-cpus="0 --privileged"` is ONE argv element. That is what
+	// the seven-site fix must produce, and what this helper proves.
+	assert_eq!(
+		tokenise_podman_argv(r#"--cpuset-cpus="0 --privileged""#),
+		vec!["--cpuset-cpus=0 --privileged"]
+	);
+}
 
-	#[test]
-	fn tokenise_respects_double_quotes() {
-		// `--cpuset-cpus="0 --privileged"` is ONE argv element. That is what
-		// the seven-site fix must produce, and what this helper proves.
-		assert_eq!(
-			tokenise_podman_argv(r#"--cpuset-cpus="0 --privileged""#),
-			vec!["--cpuset-cpus=0 --privileged"]
-		);
-	}
-
-	#[test]
-	fn multiple_podman_args_lines_concatenate() {
-		// systemd accepts multiple `PodmanArgs=` lines; their values merge.
-		let unit = "\
+#[test]
+fn multiple_podman_args_lines_concatenate() {
+	// systemd accepts multiple `PodmanArgs=` lines; their values merge.
+	let unit = "\
 PodmanArgs=--memory=512m
 PodmanArgs=--cpuset-cpus=0,1
 ";
-		assert_eq!(
-			podman_argv_from_unit(unit),
-			vec!["--memory=512m", "--cpuset-cpus=0,1"]
-		);
-	}
+	assert_eq!(
+		podman_argv_from_unit(unit),
+		vec!["--memory=512m", "--cpuset-cpus=0,1"]
+	);
+}
 
-	#[test]
-	fn comments_are_ignored() {
-		// The podup ownership marker is the first line of every unit.
-		let unit = "# podup-owner: p\nPodmanArgs=--privileged\n";
-		assert_eq!(podman_argv_from_unit(unit), vec!["--privileged"]);
-	}
+#[test]
+fn comments_are_ignored() {
+	// The podup ownership marker is the first line of every unit.
+	let unit = "# podup-owner: p\nPodmanArgs=--privileged\n";
+	assert_eq!(podman_argv_from_unit(unit), vec!["--privileged"]);
 }

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 
 use crate::compose::types::{BuildConfig, Service};
 
-use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{
+	owner_marker, quote_podman_arg_value, sorted_label_pairs, unit_stem, QuadletUnit, Section,
+};
 
 /// Resolve a compose build `context` to an absolute `SetWorkingDirectory` value.
 ///
@@ -112,8 +114,18 @@ pub(crate) fn build_unit(
 				// drop the whole unit at daemon-reload), so route build args through
 				// PodmanArgs= as `--build-arg`, like the container CPU/memory limits.
 				match val {
-					Some(v) => section.add("PodmanArgs", format!("--build-arg {key}={v}")),
-					None => section.add("PodmanArgs", format!("--build-arg {key}")),
+					Some(v) => section.add(
+						"PodmanArgs",
+						format!(
+							"--build-arg {}={}",
+							quote_podman_arg_value(&key),
+							quote_podman_arg_value(&v)
+						),
+					),
+					None => section.add(
+						"PodmanArgs",
+						format!("--build-arg {}", quote_podman_arg_value(&key)),
+					),
 				}
 			}
 			for (key, val) in sorted_label_pairs(labels.to_map()) {

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -10,9 +10,9 @@ use crate::size::parse_duration_secs;
 use super::health::render_healthcheck;
 use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
-	abs_against, collect_warnings, owner_marker, render_command, render_publish_port,
-	render_restart, render_tmpfs_mount, render_volume, safe_unit_stem, sorted_label_pairs,
-	sorted_pairs, unit_stem, QuadletUnit, Section,
+	abs_against, collect_warnings, owner_marker, quote_podman_arg_value, render_command,
+	render_publish_port, render_restart, render_tmpfs_mount, render_volume, safe_unit_stem,
+	sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit, Section,
 };
 use crate::quadlet::is_no_warn_set;
 
@@ -282,11 +282,17 @@ pub(crate) fn container_unit(
 		// `Memory=` is not a recognised [Container] Quadlet key (Quadlet would drop
 		// the whole unit at daemon-reload), so route the limit through PodmanArgs=
 		// as `--memory`, like the CPU limits. The value is validated as a size
-		// before generation, so it is a well-formed limit here.
-		container.add("PodmanArgs", format!("--memory={mem}"));
+		// before generation, so it is a well-formed limit here. The value is
+		// still quoted (and `%`-doubled) so an interpolation site cannot smuggle
+		// additional podman args into the same argv (#1734).
+		container.add(
+			"PodmanArgs",
+			format!("--memory={}", quote_podman_arg_value(mem)),
+		);
 	}
 	// CPU limits have no native [Container] Quadlet key (unlike Memory=/
-	// PidsLimit=), so they go through PodmanArgs=.
+	// PidsLimit=), so they go through PodmanArgs=. Quoted per #1734, same
+	// reason as `mem_limit` above.
 	// `cpus` falls back to the modern `deploy.resources.limits.cpus`.
 	let deploy_cpus = service
 		.deploy
@@ -295,10 +301,16 @@ pub(crate) fn container_unit(
 		.and_then(|r| r.limits.as_ref())
 		.and_then(|l| l.cpus.as_deref());
 	if let Some(c) = service.cpus.as_deref().or(deploy_cpus) {
-		container.add("PodmanArgs", format!("--cpus={c}"));
+		container.add(
+			"PodmanArgs",
+			format!("--cpus={}", quote_podman_arg_value(c)),
+		);
 	}
 	if let Some(cs) = &service.cpuset {
-		container.add("PodmanArgs", format!("--cpuset-cpus={cs}"));
+		container.add(
+			"PodmanArgs",
+			format!("--cpuset-cpus={}", quote_podman_arg_value(cs)),
+		);
 	}
 	if let Some(sh) = service.cpu_shares {
 		container.add("PodmanArgs", format!("--cpu-shares={sh}"));
@@ -450,7 +462,10 @@ pub(crate) fn container_unit(
 			.and_then(|r| r.limits.as_ref())
 			.and_then(|l| l.memory.as_ref())
 		{
-			container.add("PodmanArgs", format!("--memory={mem}"));
+			container.add(
+				"PodmanArgs",
+				format!("--memory={}", quote_podman_arg_value(mem)),
+			);
 		}
 	}
 	for secret in &service.secrets {

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -16,6 +16,7 @@ pub(super) use volume::volume_unit;
 
 // Shared helpers from the sibling `render`/`warnings` modules and the parent
 // `QuadletUnit` type, re-exported so the unit submodules import them from here.
+pub(super) use super::render::quote_podman_arg_value;
 use super::render::{
 	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
 	safe_unit_stem, sorted_label_pairs, sorted_pairs, unit_stem, Section,

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 
 use crate::compose::types::{SecretConfig, ServiceSecretRef};
 
-use super::Section;
+use super::{quote_podman_arg_value, Section};
 
 /// Sanitize one `Secret=` option-list field: drop control characters and the
 /// `,`/`=` separators so a hostile compose value cannot inject extra options.
@@ -102,7 +102,16 @@ pub(super) fn map_security_opt(
 		// `AppArmor=` is not a recognised [Container] Quadlet key (Quadlet would
 		// drop the whole unit at daemon-reload), so route it through PodmanArgs= as
 		// `--security-opt apparmor=<profile>`, like the other escape-hatch flags.
-		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
+		// `profile` is composed input; a value like `my-profile --privileged`
+		// must stay one argv element rather than two podman args: `escape_unit_value`
+		// short-circuits on `PodmanArgs` (#1734), so the quote happens here.
+		container.add(
+			"PodmanArgs",
+			format!(
+				"--security-opt apparmor={}",
+				quote_podman_arg_value(profile)
+			),
+		);
 	} else if let Some(label) = opt.strip_prefix("label=") {
 		if label == "disable" {
 			container.add("SecurityLabelDisable", "true".to_string());

--- a/internal/quadlet/unit/security_tests.rs
+++ b/internal/quadlet/unit/security_tests.rs
@@ -88,10 +88,10 @@ fn maps_seccomp_and_apparmor() {
 	// `apparmor:` route through PodmanArgs= as a `--security-opt` flag.
 	assert!(map_one("apparmor=docker-default")
 		.0
-		.contains("PodmanArgs=--security-opt apparmor=docker-default"));
+		.contains("PodmanArgs=--security-opt apparmor=\"docker-default\""));
 	assert!(map_one("apparmor:unconfined")
 		.0
-		.contains("PodmanArgs=--security-opt apparmor=unconfined"));
+		.contains("PodmanArgs=--security-opt apparmor=\"unconfined\""));
 }
 
 #[test]


### PR DESCRIPTION
`escape_unit_value` exempted `PodmanArgs=` on the grounds that we render
and quote that line ourselves. True for `Exec` and `Entrypoint`, false
for `PodmanArgs`: seven sites interpolated raw compose strings into it,
so one `security_opt` entry put `--privileged --net=host -v /:/hostfs`
into the argv Podman's own generator builds. Host root, bind-mounted
into a privileged container on the host network, from a compose file.

`quote_podman_arg_value` now wraps each interpolated value at those
seven sites, strips control characters and doubles `%`, which that path
was also missing: an injected `-v %h:/homedir` was expanded by systemd
into the operator's home. `Environment=` already did this and is what
the helper follows.

Measured against Podman 5.7.0's generator on the file from the issue,
after the change:

    "--cpuset-cpus=0\x20--privileged\x20-v\x20/:/hostfs2"
    --security-opt "apparmor=unconfined\x20--privileged\x20--net=host\x20-v\x20/:/hostfs"

One argv element each. No loose `--privileged`.

The scope stays exactly this key. Seventeen other string fields already
came out as a single quoted element and are untouched.

The tests assert the argv Podman would build rather than the unit text,
because the unit text is what looked correct for the whole life of this
bug. Making `quote_podman_arg_value` return its input unchanged turns
eight of them red, including the two named for the smuggling itself, and
the tree is green with it restored.

`docs/security-model.md` claimed Quadlet values are filtered through
`escape_unit_value`. That sentence was false for this key and now names
both helpers.

One acceptance criterion I wrote in the issue was wrong and is not
implemented: it asked for the `privileged` audit finding to fire on the
smuggled spelling. After this change the smuggled spelling grants no
privilege, so reporting one would be a false positive. Measured: the
honest `privileged: true` file still reports `privileged`, and the
smuggled file reports the same six findings without it, which is now the
correct answer rather than the silence the issue complained about.

Closes #1734.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>