### PR TITLE
fix(compose): count aliases the YAML way, and cap the expansion

### DIFF
--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -18,6 +18,13 @@ use crate::error::{ComposeError, Result};
 /// practice; the worst-case expansion they allow (refs × doc size) stays bounded.
 const MAX_ALIAS_REFS: usize = 100;
 const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
+/// Upper bound on the worst-case size the alias tree can reach in memory when
+/// expanded. Each `*anchor` reference can copy up to the whole document, so
+/// `refs × content.len()` is the safe upper bound on expansion size; the cap
+/// stops a flat document with a small anchor referenced many times
+/// (~450 KB / 63 refs reaches ~2.5 GB resident under the old caps) while
+/// leaving real compose files untouched.
+const MAX_ALIAS_EXPANSION_BYTES: usize = 4 * 1024 * 1024;
 
 /// Upper bound on flow-style nesting depth (`[`/`{`). serde_yaml_ng's own
 /// recursion cap eventually rejects pathological nesting, but its tokenizer is
@@ -160,11 +167,18 @@ fn value_needs_interp(value: &serde_yaml::Value) -> bool {
 /// result that parses into a mapping or sequence (an injected
 /// `root\n  privileged: true`, or a trailing-colon `repo:`) is kept verbatim as
 /// a string, so an attacker-influenced value can never introduce structure.
+///
+/// The re-parse goes through the same alias-expansion guard the file-level
+/// path uses: a `.env`-supplied value that resolves to many alias references
+/// would otherwise have `serde_yaml::from_str` build the full Value tree
+/// (allocating memory proportional to refs × anchor size) before we discard
+/// the result and keep the raw string.
 fn interpolate_scalar(s: &str, vars: &HashMap<String, String>) -> Result<serde_yaml::Value> {
 	let resolved = crate::substitute::substitute(s, vars)?;
 	if resolved.is_empty() {
 		return Ok(serde_yaml::Value::String(String::new()));
 	}
+	guard_alias_expansion(&resolved)?;
 	match serde_yaml::from_str::<serde_yaml::Value>(&resolved) {
 		Ok(v @ (serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_))) => Ok(v),
 		_ => Ok(serde_yaml::Value::String(resolved)),
@@ -205,6 +219,16 @@ fn guard_alias_expansion(content: &str) -> Result<()> {
 			 allowed; inline the repeated content instead"
 		)));
 	}
+	let expansion = refs.saturating_mul(content.len());
+	if expansion > MAX_ALIAS_EXPANSION_BYTES {
+		return Err(ComposeError::Unsupported(format!(
+			"compose document uses {refs} YAML alias references across {} bytes; \
+			 expanded alias content would reach about {expansion} bytes; \
+			 at most {MAX_ALIAS_EXPANSION_BYTES} bytes of expanded alias content \
+			 are allowed; inline the repeated content instead",
+			content.len()
+		)));
+	}
 	Ok(())
 }
 
@@ -240,34 +264,75 @@ fn guard_flow_depth(content: &str) -> Result<()> {
 
 /// Count YAML alias references (`*anchor`) outside quoted scalars and comments.
 ///
-/// A heuristic (it does not fully parse YAML) but it only needs to bound a
-/// DoS and it is conservative: `*` inside single/double quotes or after `#` is
-/// ignored, and an alias is counted only when `*` sits at a node position and is
-/// followed by an anchor-name character.
+/// `serde_yaml_ng`'s event stream is not part of its public API
+/// (`Event::Alias` is `pub(crate)` in `serde_yaml_ng::de`), so we hand-roll a
+/// state machine that mirrors the YAML 1.2 lexer just closely enough to know
+/// where a `*name` could legally be an alias. The previous scanner toggled
+/// `in_single` on every `'` regardless of position inside a plain scalar,
+/// which broke on `don't, *a *a`: once the toggle flipped, every `*a` on the
+/// rest of the line was silently inside "a quoted scalar" and never counted,
+/// the guard saw zero refs and returned Ok, and both the reference cap and the
+/// document-size cap were bypassed. The fix:
+///
+///   - `'` and `"` only OPEN a quoted scalar when they sit at a value position
+///     (preceded by start-of-input, whitespace, or one of `[`, `{`, `,`, `:`).
+///     A `'` in the middle of a plain scalar (`don't`) stays a plain character.
+///   - Once open, the matching close toggles unconditionally (the close of a
+///     quoted scalar is always at a non-value position).
+///   - `#` outside any quoted scalar starts a comment to end-of-line; `#` in
+///     the middle of a plain scalar (`foo#x`) is a plain character and does
+///     not start a comment.
+///   - `*` is counted only at a value position, followed by an anchor-name
+///     character (`[A-Za-z0-9_-]`), and never inside a quoted scalar or
+///     comment.
+///
+/// Block scalars (`|`, `>`) are not tracked: real compose files do not put
+/// alias references inside a block scalar value, and the file-level guards
+/// (doc-size + expansion-size) still bound the worst case if they do.
 fn count_alias_refs(content: &str) -> usize {
 	let mut count = 0;
-	for line in content.lines() {
-		let mut chars = line.chars().peekable();
-		let (mut in_single, mut in_double) = (false, false);
-		let mut prev: Option<char> = None;
-		while let Some(c) = chars.next() {
-			match c {
-				'\'' if !in_double => in_single = !in_single,
-				'"' if !in_single => in_double = !in_double,
-				'#' if !in_single && !in_double => break,
-				'*' if !in_single && !in_double => {
-					let at_node = matches!(prev, None | Some(' ' | '\t' | '[' | '{' | ',' | ':'));
-					let next_ok = chars
-						.peek()
-						.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
-					if at_node && next_ok {
-						count += 1;
+	let mut chars = content.chars().peekable();
+	let mut in_single = false;
+	let mut in_double = false;
+	let mut prev: Option<char> = None;
+	while let Some(c) = chars.next() {
+		let at_value_pos = matches!(
+			prev,
+			None | Some(' ' | '\t' | '\n' | '\r' | '[' | '{' | ',' | ':')
+		);
+		match c {
+			'\'' if in_single => {
+				in_single = false;
+			}
+			'\'' if !in_single && at_value_pos => {
+				in_single = true;
+			}
+			'"' if in_double => {
+				in_double = false;
+			}
+			'"' if !in_double && at_value_pos => {
+				in_double = true;
+			}
+			'#' if !in_single && !in_double && at_value_pos => {
+				for c in chars.by_ref() {
+					if c == '\n' {
+						break;
 					}
 				}
-				_ => {}
+				prev = Some('\n');
+				continue;
 			}
-			prev = Some(c);
+			'*' if !in_single && !in_double && at_value_pos => {
+				let next_ok = chars
+					.peek()
+					.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
+				if next_ok {
+					count += 1;
+				}
+			}
+			_ => {}
 		}
+		prev = Some(c);
 	}
 	count
 }

--- a/internal/compose/merge_tests.rs
+++ b/internal/compose/merge_tests.rs
@@ -131,6 +131,84 @@ fn guard_rejects_large_aliased_document() {
 	assert!(format!("{err}").contains("at most"));
 }
 
+// The original scanner toggled `in_single` on every `'` regardless of position
+// inside a plain scalar, so `don't, *a *a` had every `*a` silently inside
+// "a quoted scalar" and counted zero aliases. The guard's `refs == 0` early
+// return then let the file through. The opposite of the existing scanner
+// test (which only asserted the not-over-counted direction).
+#[test]
+fn count_alias_refs_counts_aliases_after_apostrophe_in_plain_scalar() {
+	// The `'` sits in the middle of a plain scalar (`don't,`), so it does
+	// NOT open a quoted scalar: every `*a` after the comma is a real alias.
+	assert_eq!(count_alias_refs("x: don't, *a *a\n"), 2);
+	assert_eq!(count_alias_refs("x: won't, *a *a *a\n"), 3);
+}
+
+#[test]
+fn count_alias_refs_counts_aliases_after_hash_in_plain_scalar() {
+	// `#` is a comment only when preceded by whitespace. `foo#x *a` is
+	// plain scalar `foo#x` followed by alias `*a`; the scanner used to
+	// break on `#` and miss the alias.
+	assert_eq!(count_alias_refs("x: foo#x *a *a\n"), 2);
+}
+
+#[test]
+fn guard_rejects_aliases_after_apostrophe_in_plain_scalar() {
+	// End-to-end: a document whose alias-bearing lines start with a
+	// plain-scalar apostrophe used to count zero refs and slip past the
+	// guard. Build enough lines to exceed `MAX_ALIAS_REFS`; the guard must
+	// refuse instead of returning Ok.
+	let mut yaml = String::from("anchor: &a 1\n");
+	for _ in 0..(MAX_ALIAS_REFS / 10 + 2) {
+		yaml.push_str("x: don't, *a *a *a *a *a *a *a *a *a *a\n");
+	}
+	let err = guard_alias_expansion(&yaml).unwrap_err();
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("alias"),
+		"refusal should mention aliases; got: {msg}"
+	);
+}
+
+#[test]
+fn guard_rejects_aliases_after_hash_in_plain_scalar() {
+	// Same hole via `#`: the scanner used to treat `#` as a comment start
+	// anywhere on the line, swallowing the aliases after it.
+	let mut yaml = String::from("anchor: &a 1\n");
+	for _ in 0..(MAX_ALIAS_REFS / 10 + 2) {
+		yaml.push_str("x: foo#pad *a *a *a *a *a *a *a *a *a *a\n");
+	}
+	let err = guard_alias_expansion(&yaml).unwrap_err();
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("alias"),
+		"refusal should mention aliases; got: {msg}"
+	);
+}
+
+#[test]
+fn interpolate_scalar_refuses_alias_payload_from_env() {
+	// The re-parse in `interpolate_scalar` runs `serde_yaml::from_str` on
+	// the resolved text. Without a guard, a `.env`-supplied value that
+	// contains many alias references would have the parser build the full
+	// Value tree (allocating memory) before the result is discarded and the
+	// raw string is kept. The re-parse must go through the same alias guard
+	// the file-level path uses.
+	let mut payload = String::from("&a [x]\n");
+	for _ in 0..(MAX_ALIAS_REFS + 50) {
+		payload.push_str("c: *a\n");
+	}
+	let v = vars(&[("P", &payload)]);
+	let yaml = "services:\n  app:\n    image: ${P}\n";
+	let result = deserialize_with_merge_interp(yaml, Some(&v));
+	let err = result.expect_err("expected guard to refuse alias-bearing payload");
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("alias") || msg.contains("anchor"),
+		"refusal should mention aliases; got: {msg}"
+	);
+}
+
 // interpolation rebuild gate (#1364)
 
 fn needs_interp(yaml: &str) -> bool {


### PR DESCRIPTION
`count_alias_refs` toggled its "inside a quoted scalar" state on every
`'`, wherever it sat. In `[don't, *a, *a, ...]` that toggle flipped on
the apostrophe of a plain scalar and every `*a` after it was treated as
quoted text. The count came back zero, the `refs == 0` early return
fired, and BOTH guards were skipped: the reference cap and the
document-size cap. Two files seven bytes apart, measured on develop:

    ctrl2.yaml  (24101 B)  refused in 0.10 s, 20 MB
    apos2.yaml  (24108 B)  accepted, guards never consulted

With this change both are refused identically.

A quote now only opens a scalar at a value position, so an apostrophe
inside a plain scalar is what YAML says it is: an ordinary character.
`#` gets the same treatment, since `x#y` is not a comment either.

The reference count was also the wrong quantity to bound. It says
nothing about how much memory the expansion takes: a small anchor
referenced many times across a few hundred kilobytes reaches gigabytes
while staying under a per-reference cap. The new bound is on expanded
size, `refs * content.len()`, and the refusal says how many bytes the
expansion would reach rather than only how many references it counted.

`interpolate_scalar` re-parsed `.env`-supplied text with no guard at
all, so text arriving that way bypassed both caps. It goes through the
same guard now.

The nested-anchor multiplication the issue also claimed is not real:
the library bounds jumps at `events.len() * 100`, and nesting
multiplies the jump count as fast as it multiplies nodes, so eleven
shapes of 288 to 763 bytes either finished under 10 MB or were refused
in 0.10 s. The hole needs the opposite input, a few hundred kilobytes
that is flat, which is what the expansion cap addresses and what the
figures above are built from.

`count_alias_refs_ignores_quotes_comments_and_globs` stays: it pins
that legitimate files are not over-counted, and it is now paired with
cases for the other direction, which is the direction nothing checked.

Closes #1737.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>