### PR TITLE
fix(libpod): bound the reassembly buffer, not the bytes ever seen

### DIFF
--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -116,11 +116,41 @@ pub fn take_json_line(buf: &mut BytesMut) -> Option<Bytes> {
 /// Emits [`LogOutput`] items as frames arrive. The returned stream ends when
 /// the response body is fully consumed.
 pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
+	parse_multiplexed_body(body)
+}
+
+/// Generic body form of [`parse_multiplexed`]. Public surface stays
+/// `parse_multiplexed(body: Incoming)`; the generic form is the test seam
+/// so the accounting this file is responsible for can be driven against
+/// an in-memory body without standing up a Podman socket.
+fn parse_multiplexed_body<B>(body: B) -> BoxStream<LogOutput>
+where
+	B: hyper::body::Body<Data = Bytes, Error = hyper::Error> + Send + Unpin + 'static,
+{
 	Box::pin(futures_util::stream::try_unfold(
 		(body, BytesMut::new(), 0u64),
 		|(mut body, mut buf, mut total_received)| async move {
 			loop {
 				if let Some((stream_type, payload)) = parse_frame(&mut buf)? {
+					// The frame header (8 bytes) plus its payload have just
+					// been split off the front of `buf`; account for the freed
+					// space so the counter tracks "bytes still owed to the
+					// parser", not "bytes ever seen". The sibling
+					// `parse_json_lines` does the same on `take_json_line`.
+					//
+					// Without this the cap is a running tally of received
+					// bytes rather than a bound on the reassembly buffer,
+					// and a stream of many small frames that exceeds
+					// MAX_STREAM_BUF cumulatively trips `StreamTooLarge` near
+					// 1024 frames in and `podup logs` exits 0 (#1739).
+					//
+					// The cap stays: it is the safety net against a
+					// daemon-controlled allocation on a slow consumer
+					// (moby bounds per-frame payloads at the same mark), and
+					// per-frame overruns are still caught one level down by
+					// `parse_frame`'s `size > MAX_STREAM_BUF` check.
+					let consumed = (8 + payload.len()) as u64;
+					total_received = total_received.saturating_sub(consumed);
 					let output = match stream_type {
 						1 => LogOutput::StdOut { message: payload },
 						2 => LogOutput::StdErr { message: payload },

--- a/internal/libpod/types/stream_tests.rs
+++ b/internal/libpod/types/stream_tests.rs
@@ -209,3 +209,77 @@ fn at_cap_buffer_is_accepted() {
 	// buffer strictly greater than MAX_STREAM_BUF.
 	assert!(cap_check(MAX_STREAM_BUF).is_none());
 }
+
+// ---------------------------------------------------------------------------
+// parse_multiplexed accounting (issue #1739)
+// ---------------------------------------------------------------------------
+
+/// Operator-facing regression for #1739: `podup logs` used to truncate
+/// silently around 1 MiB and exit 0. The cap is a safety net against an
+/// unbounded reassembly buffer, not against a cumulative byte count, so a
+/// stream of many small frames that exceeds the cap cumulatively must keep
+/// flowing. The sibling `parse_json_lines` decrements the same counter when
+/// it drains a record; `parse_multiplexed` must do the same when `parse_frame`
+/// drains a frame.
+///
+/// Driving it with a constructed body sidesteps the Podman socket dependency
+/// in the engine integration suite and pins the contract in the file the
+/// parser lives in. The body yields 2048 complete multiplexed frames, each
+/// carrying a 1 KiB stdout payload: 2 MiB of payload in total, well past the
+/// 1 MiB cap. The buggy accounting trips `StreamTooLarge` near the
+/// 1024th frame and the test fails at "no error" before the count and
+/// total byte assertions ever run. A silent truncation at any other size
+/// loses either count or bytes and fails those.
+#[tokio::test]
+async fn parse_multiplexed_handles_cumulative_payloads_above_max_stream_buf() {
+	use bytes::Bytes;
+	use futures_util::{stream, StreamExt};
+	use http_body_util::StreamBody;
+	use hyper::body::Frame;
+
+	const PAYLOAD: usize = 1024;
+	const COUNT: usize = 2048;
+
+	let mut chunks: Vec<Result<Frame<Bytes>, hyper::Error>> = Vec::with_capacity(COUNT);
+	for _ in 0..COUNT {
+		// One stdout frame: 8-byte header (type=1, size=PAYLOAD) + payload.
+		let mut frame = Vec::with_capacity(8 + PAYLOAD);
+		frame.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+		frame.extend_from_slice(&(PAYLOAD as u32).to_be_bytes());
+		frame.resize(8 + PAYLOAD, 0x78);
+		chunks.push(Ok(Frame::data(Bytes::from(frame))));
+	}
+	let source = stream::iter(chunks);
+	let body = StreamBody::new(source);
+
+	let mut parser = super::parse_multiplexed_body(body);
+	let mut received_bytes: usize = 0;
+	let mut received_count: usize = 0;
+	let mut first_err: Option<PodmanError> = None;
+	while let Some(item) = parser.next().await {
+		match item {
+			Ok(LogOutput::StdOut { message }) => {
+				received_bytes += message.len();
+				received_count += 1;
+			}
+			Ok(LogOutput::StdErr { .. }) => {}
+			Err(e) => {
+				first_err = Some(e);
+				break;
+			}
+		}
+	}
+	assert!(
+		first_err.is_none(),
+		"parser must not error on cumulative payload > MAX_STREAM_BUF; got {first_err:?}"
+	);
+	assert_eq!(
+		received_count, COUNT,
+		"parser must surface every frame, not silently truncate (got {received_count}/{COUNT})"
+	);
+	assert_eq!(
+		received_bytes,
+		COUNT * PAYLOAD,
+		"every payload byte must reach the caller, with no truncation (got {received_bytes})"
+	);
+}


### PR DESCRIPTION
`podup logs` stopped at about 1 MiB and exited 0. An operator reading
logs to diagnose an incident got a short answer and a success code,
which is worse than an error because they act on it.

`total_received` was a running tally of everything the stream had
delivered rather than a bound on the buffer still owed to the parser.
Frames were split off the front of `buf` and the counter never learned
they were gone, so a stream of many small frames tripped
`StreamTooLarge` around a thousand frames in regardless of how much was
actually held.

The counter now subtracts what each frame consumed, which is what the
sibling `parse_json_lines` already did on `take_json_line`. The cap
itself stays: it is the safety net against a daemon-controlled
allocation on a slow consumer, and per-frame overruns are still caught
one level down by `parse_frame`.

`parse_multiplexed` keeps its public shape and gains a generic body form
underneath it, so the accounting can be driven against an in-memory body
instead of a Podman socket.

Dropping the subtraction turns the new case red on its own, and the full
suite is green with it in place.

Closes #1739.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>