### PR TITLE
fix(substitute): cap the output a single interpolation pass produces

### DIFF
--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -18,6 +18,16 @@ use parse::{collect_var_name, is_var_start, parse_braced_var, resolve_modifier};
 /// cap turns a pathological chain into a clean error instead of a stack overflow.
 const MAX_INTERP_DEPTH: usize = 64;
 
+/// Upper bound on the cumulative size of the output of a single [`substitute`]
+/// pass. The output grows by `count(refs_in_input) × len(value_of_VAR)`, with
+/// no natural ceiling: a few hundred kilobytes of input where one variable
+/// repeats many times reaches gigabytes before anything else has a chance to
+/// fire (#1738). The bound is checked as `out` grows (before each `push_str`)
+/// so the refusal happens before the offending allocation, and the message
+/// names the variable and the size so a legitimate large payload (a long
+/// secret, a multi-line config blob) can be told apart from a hostile one.
+const MAX_INTERP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -63,7 +73,8 @@ pub(super) fn substitute_depth(
 			Some('{') => {
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
-				let value = resolve_modifier(var, modifier, vars, depth)?;
+				let value = resolve_modifier(var.clone(), modifier, vars, depth)?;
+				check_output_cap(&out, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
@@ -78,6 +89,7 @@ pub(super) fn substitute_depth(
 						String::new()
 					}
 				};
+				check_output_cap(&out, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(_) => {
@@ -87,6 +99,22 @@ pub(super) fn substitute_depth(
 	}
 
 	Ok(out)
+}
+
+/// Refuse a variable expansion that would push the cumulative interpolation
+/// output past [`MAX_INTERP_OUTPUT_BYTES`]. Called before the `push_str` so the
+/// refusal fires before the offending allocation, with a message naming the
+/// variable and the size it had reached.
+fn check_output_cap(out: &str, value: &str, var: &str) -> Result<()> {
+	let new_len = out.len().saturating_add(value.len());
+	if new_len > MAX_INTERP_OUTPUT_BYTES {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"variable '{var}' would expand to {new_len} bytes of output; at most \
+			 {MAX_INTERP_OUTPUT_BYTES} bytes of interpolated output are allowed; the value \
+			 may repeat too many times in the document"
+		)));
+	}
+	Ok(())
 }
 
 /// Load a `.env` file from `dir`.

--- a/internal/substitute/tests.rs
+++ b/internal/substitute/tests.rs
@@ -480,3 +480,44 @@ fn strict_build_vars_allows_multiline_and_tab_values() {
 	);
 	assert_eq!(vars.get("TABBED").map(String::as_str), Some("a\tb"));
 }
+
+// variable-repetition cap (#1738)
+
+#[test]
+fn interpolation_cap_refuses_variable_repetition_in_one_scalar() {
+	// 300 KB of `${PAYLOAD}` references in one scalar with a moderately sized
+	// PAYLOAD value would otherwise produce hundreds of MB of output and
+	// (on the host from the issue) SIGABRT in under a second. The cap is
+	// checked as `out` grows inside `substitute_depth`, so the refusal
+	// fires before the offending allocation is committed, and names both
+	// the variable and the size so a legitimate large value can be told
+	// apart from a hostile one (#1738).
+	let payload = "x".repeat(2 * 1024);
+	let mut input = String::new();
+	while input.len() < 300 * 1024 {
+		input.push_str("${PAYLOAD}");
+	}
+	let v = vars(&[("PAYLOAD", &payload)]);
+	let err = substitute(&input, &v)
+		.expect_err("expected the interpolation cap to refuse variable repetition");
+	let msg = format!("{err}");
+	assert!(
+		matches!(err, crate::error::ComposeError::InvalidSubstitution(_)),
+		"refusal should be InvalidSubstitution; got: {msg}"
+	);
+	assert!(
+		msg.contains("PAYLOAD"),
+		"refusal should name the variable; got: {msg}"
+	);
+	assert!(
+		msg.contains("bytes"),
+		"refusal should name the size reached; got: {msg}"
+	);
+}
+
+#[test]
+fn interpolation_cap_allows_legitimate_repetition() {
+	// A handful of repetitions of a small value stay well under the cap.
+	let v = vars(&[("TAG", "v1")]);
+	assert_eq!(substitute("${TAG}-${TAG}-${TAG}", &v).unwrap(), "v1-v1-v1");
+}


### PR DESCRIPTION
Repeating a variable during interpolation had no ceiling. Output grows
by the number of references times the length of the value, so a few
hundred kilobytes of input where one variable repeats reaches gigabytes
before anything else has a chance to fire: 300 KB in, a 3.27 GB
allocation, SIGABRT in 0.97 s.

The bound is checked before each `push_str` rather than after the pass,
so the refusal happens before the offending allocation instead of
reporting it once the memory is already gone.

The message names the variable and the size it reached. A long secret
or a multi-line config blob is a legitimate reason for a large value,
and an operator who hits this needs to tell that apart from a hostile
document.

This is a different path from the YAML alias caps in #1737, which is
why that change does not close this one: the alias guards bound the
document's expansion, and this bounds what substitution writes out of
it.

Forcing the comparison false turns the refusal case red and leaves the
legitimate-repetition case green, which is the pair that says the cap is
doing the work rather than the test passing for its own reasons.

Closes #1738.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>