### PR TITLE
fix(audit): read the value the runtime will use, and name the dangerous capabilities

### DIFF
--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -7,6 +7,11 @@
 //! that turns the eleven named checks into a flat `Vec<Finding>`.
 
 use podup::compose::types::{ComposeFile, Service};
+use podup::size;
+// The audit must read the runtime value a `security_opt` entry resolves to,
+// not the raw compose-side text (#1743). `podup::effective_no_new_privileges`
+// calls the engine's own `parse_security_opts` so the two cannot drift again.
+use podup::effective_no_new_privileges;
 
 use super::Finding;
 
@@ -153,21 +158,52 @@ fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> V
 	out
 }
 
-/// `cap_add: [SYS_ADMIN]` or `cap_add: [ALL]`, Linux capabilities that
-/// effectively grant root inside the container.
+/// `cap_add: [SYS_ADMIN]`, `cap_add: [SYS_MODULE]`, or any other capability
+/// in the curated dangerous list. The runtime honours exactly what was
+/// asked for, so reading the resolved value cannot narrow the audit; this
+/// check exists because the spec has no opinion about which capabilities
+/// are dangerous, and the operator who ships `--strict` in CI needs one
+/// (`#1743`).
 fn check_dangerous_capability(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
 	let mut out = Vec::new();
 	for cap in &service.cap_add {
-		let cap = normalized_capability(cap);
-		if cap == "SYS_ADMIN" || cap == "ALL" {
+		if let Some(reason) = dangerous_capability_reason(&normalized_capability(cap)) {
 			out.push(finding(
 				name,
 				"dangerous_capability",
-				&format!("cap_add: {cap} grants root-equivalent capability"),
+				&format!("cap_add: {cap}: {reason}"),
 			));
 		}
 	}
 	out
+}
+
+/// Returns the reason a normalised capability (`CAP_` stripped,
+/// upper-cased) is on the dangerous list, or `None` when it is not. The
+/// list is curated against the CIS Docker Benchmark and the Podman
+/// hardening notes: each entry either grants a path to host-level
+/// compromise (kernel / syscall / audit), breaks the container's file
+/// or device isolation, or subverts networking in a way that lets one
+/// container attack another. `SYS_ADMIN` and `ALL` are the obvious
+/// root-equivalents; the rest are the narrower capabilities an attacker
+/// chains into the same outcome.
+fn dangerous_capability_reason(cap: &str) -> Option<&'static str> {
+	Some(match cap {
+		"ALL" => "every capability, equivalent to root",
+		"SYS_ADMIN" => "broad kernel administration, effectively root",
+		"SYS_MODULE" => "load or unload kernel modules (root-equivalent)",
+		"DAC_READ_SEARCH" => "bypass file read and directory search permission checks",
+		"SYS_RAWIO" => "raw I/O port access, can crash or compromise the host kernel",
+		"SYS_PTRACE" => "ptrace any process, including those in other containers",
+		"NET_ADMIN" => "arbitrary network interface and routing changes",
+		"SYS_BOOT" => "reboot or halt the host from inside the container",
+		"MKNOD" => "create device nodes that mimic host block devices",
+		"SYSLOG" => "read the kernel ring buffer (information disclosure)",
+		"AUDIT_CONTROL" => "configure the kernel audit subsystem",
+		"AUDIT_WRITE" => "tamper with the audit log",
+		"SETFCAP" => "set arbitrary file capabilities on host binaries",
+		_ => return None,
+	})
 }
 
 /// `read_only` not set to `true`, the container's rootfs is writable.
@@ -207,18 +243,13 @@ fn check_no_cap_drop_all(name: &str, service: &Service, _file: &ComposeFile) -> 
 
 /// `security_opt` without `no-new-privileges:true`. Podman spells it
 /// `no-new-privileges` (no `:true`); both spellings are accepted. The check
-/// iterates each entry and looks for a prefix match on either spelling; a
-/// bare `no-new-privileges` (no value) also passes.
+/// asks the engine's own `parse_security_opts` for the resolved value
+/// (`#1743`): the engine splits on `:` or `=` and last-wins, so an audit
+/// that splits on `:` only disagrees with the runtime on every docker-form
+/// `=true` and on contradictory multi-entry lists like
+/// `[no-new-privileges:true, no-new-privileges:false]`.
 fn check_no_new_privileges_off(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
-	// Podman spells it `no-new-privileges` alone or `no-new-privileges:true`;
-	// `no-new-privileges:false` is the option being switched off, not on.
-	let has = service.security_opt.iter().any(|opt| {
-		let mut parts = opt.splitn(2, ':');
-		let head = parts.next().unwrap_or(opt);
-		let value = parts.next().unwrap_or("true");
-		head == "no-new-privileges" && value == "true"
-	});
-	if has {
+	if effective_no_new_privileges(service) == Some(true) {
 		Vec::new()
 	} else {
 		vec![finding(
@@ -245,18 +276,25 @@ fn check_no_pids_limit(name: &str, service: &Service, _file: &ComposeFile) -> Ve
 
 /// Neither `mem_limit` nor `deploy.resources.limits.memory` set, no upper
 /// bound on memory. A misbehaving service can OOM the host.
+///
+/// Reads both fields through the same `parse_memory` the engine uses to
+/// build `LinuxResources` (`#1743`): a value like `mem_limit: not-a-size`
+/// keeps the compose field non-empty, so an `.is_none()` audit reads it
+/// as a limit, but `parse_memory` returns `None` and the runtime applies
+/// no limit at all. The audit must agree with what the engine will build.
 fn check_no_memory_limit(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let mem_top = service.mem_limit.as_deref().and_then(size::parse_memory);
 	let deploy_limit = service
 		.deploy
 		.as_ref()
 		.and_then(|d| d.resources.as_ref())
 		.and_then(|r| r.limits.as_ref())
-		.and_then(|l| l.memory.as_ref());
-	if service.mem_limit.is_none() && deploy_limit.is_none() {
+		.and_then(|l| l.memory.as_deref().and_then(size::parse_memory));
+	if mem_top.is_none() && deploy_limit.is_none() {
 		vec![finding(
 			name,
 			"no_memory_limit",
-			"neither mem_limit nor deploy.resources.limits.memory is set: a leak can OOM the host",
+			"neither mem_limit nor deploy.resources.limits.memory is parseable: a leak can OOM the host",
 		)]
 	} else {
 		Vec::new()

--- a/internal/audit/checks_more_tests.rs
+++ b/internal/audit/checks_more_tests.rs
@@ -181,3 +181,65 @@ fn audit_no_new_privileges_off_flags_an_explicit_false() {
 	);
 	assert!(report.iter().any(|f| f.check == "no_new_privileges_off"));
 }
+
+// ---------------------------------------------------------------------------
+// #1743: audit must read the resolved value the engine will use
+// ---------------------------------------------------------------------------
+//
+// Each of the three tests below targets one of the issue's findings and is
+// built from a compose file that `audit --strict` accepted on the unfixed
+// tree but must not afterwards. They are the issue's acceptance criterion,
+// and were failing when the brief was written. Keeping them in a single
+// section so the file's `grep "1743"` lands the reviewer on the lot.
+
+/// `mem_limit: not-a-size` keeps the compose field non-empty, so an
+/// `.is_none()` audit reads it as a limit, but `parse_memory` returns
+/// `None` and the runtime applies no limit. The audit must agree.
+#[test]
+fn audit_no_memory_limit_flags_an_unparseable_limit() {
+	let report =
+		report_for("services:\n  web:\n    image: alpine:3.20\n    mem_limit: not-a-size\n");
+	assert!(
+		report.iter().any(|f| f.check == "no_memory_limit"),
+		"a mem_limit the runtime cannot parse must still fire: {report:#?}"
+	);
+}
+
+/// `security_opt: [no-new-privileges:true, no-new-privileges:false]`: the
+/// engine last-wins (resolves to disabled), the unfixed audit iterates and
+/// finds the first entry matches (resolves to enabled). The two must agree.
+#[test]
+fn audit_no_new_privileges_off_flags_contradictory_entries() {
+	let report = report_for(
+		"services:\n  web:\n    image: alpine:3.20\n    security_opt:\n      - no-new-privileges:true\n      - no-new-privileges:false\n",
+	);
+	assert!(
+		report.iter().any(|f| f.check == "no_new_privileges_off"),
+		"contradictory security_opt entries where the engine disables the \
+		 protection must fire: {report:#?}"
+	);
+}
+
+/// The runtime honours exactly what was asked for in `cap_add:`. The audit
+/// must reject the curated dangerous list (`SYS_MODULE` and friends)
+/// regardless of what the engine does with them.
+#[test]
+fn audit_dangerous_capability_flags_the_curated_list() {
+	let report = report_for(
+		"services:\n  web:\n    image: alpine:3.20\n    cap_add: [SYS_MODULE, DAC_READ_SEARCH, SYS_RAWIO]\n",
+	);
+	assert!(
+		report.iter().any(|f| f.check == "dangerous_capability"),
+		"SYS_MODULE / DAC_READ_SEARCH / SYS_RAWIO must fire: {report:#?}"
+	);
+	// Every entry in the curated list is its own finding, so the count
+	// pins the list rather than just any-of.
+	assert_eq!(
+		report
+			.iter()
+			.filter(|f| f.check == "dangerous_capability")
+			.count(),
+		3,
+		"three distinct dangerous_capability findings expected: {report:#?}"
+	);
+}

--- a/internal/audit/checks_tests.rs
+++ b/internal/audit/checks_tests.rs
@@ -151,12 +151,12 @@ fn audit_dangerous_capability_flags_sys_admin_and_all() {
 }
 
 #[test]
-fn audit_dangerous_capability_passes_when_empty() {
+fn audit_dangerous_capability_passes_when_safe() {
 	let yaml = r#"
 services:
   web:
     image: alpine:3.20
-    cap_add: [NET_ADMIN]
+    cap_add: [CHOWN]
 "#;
 	let findings = report_for(yaml);
 	assert!(

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -31,7 +31,11 @@ use super::network::resolve_network_mode;
 use super::volume_mounts::build_mounts_all;
 use super::Engine;
 use fields::{build_blkio_config, warn_swarm_only_deploy};
-use security::parse_security_opts;
+// Re-exported at the container root so `crate::engine::container::*` is a
+// valid path inside the crate (lib.rs's `effective_no_new_privileges`
+// wrapper reaches it for the audit module, #1743). Private here would shadow
+// the `pub(crate)` visibility into private.
+pub(crate) use security::parse_security_opts;
 
 impl Engine {
 	pub(super) async fn create_and_start(

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -3,7 +3,7 @@
 //! Translates a parsed [`ComposeFile`](crate::compose::types::ComposeFile) into Podman API calls via the libpod REST API.
 
 mod build;
-mod container;
+pub(crate) mod container;
 /// `pub(crate)` so the fuzz harness behind the `test-helpers` feature can
 /// reach `archive::extract_tar_guarded` without widening the published API:
 /// the chain stays `engine → copy → archive` all `pub(crate)` (or stricter),

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -64,6 +64,14 @@ pub use engine::{
 	PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesDisplayOptions,
 	VolumesOptions, DEFAULT_LOG_TAIL,
 };
+/// Return the runtime value of `security_opt`'s `no-new-privileges` key:
+/// `Some(true)` when the engine will apply it, `Some(false)` when an entry
+/// explicitly disables it, `None` when no entry matched. Surfaced for the
+/// audit module, which must read the resolved value rather than the
+/// compose-side text (`#1743`).
+pub fn effective_no_new_privileges(service: &crate::compose::types::Service) -> Option<bool> {
+	crate::engine::container::parse_security_opts(service).no_new_privileges
+}
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.
 pub use error::{ComposeError, Result};


### PR DESCRIPTION
Two different defects, not three instances of one, which is why this
does not use a single mechanism the way I asked for in the issue.

Drift, closed by reading the resolved value. `no_memory_limit` asked
whether `mem_limit` was set; the engine parses it, and `parse_memory`
returns `None` for junk. So `mem_limit: not-a-size` produced no limit at
runtime while `audit --strict` called the service constrained. Both
checks now read through the same parser the engine uses, and
`no_new_privileges_off` reads the resolved `security_opt` rather than
the compose-side text, so an entry that cancels the protection is seen.

A missing check, which reading the resolved value would not have fixed.
`cap_add: [SYS_MODULE, ...]` is honoured exactly as written, so nothing
has drifted: what was absent is an opinion about which capabilities are
dangerous. `dangerous_capability_reason` is that opinion, and it carries
the reason for each entry rather than a bare list, because the next
person to edit it needs to know why `MKNOD` is on it and `CHOWN` is not.

Verified by breaking each half separately: removing `SYS_MODULE` from
the list turns the curated-list case red, and making the memory check
look at presence again turns the unparseable-limit case red. Each
sabotage takes down its own case and leaves the other three green.

`audit_dangerous_capability_passes_when_empty` used `NET_ADMIN` as its
safe sample, which is no longer a safe answer, so its sample moved.

Closes #1743.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>