### PR TITLE
ci: guard the with: inputs, and say what a release gate must prove first

### DIFF
--- a/.github/scripts/check-caller-with-defaults.py
+++ b/.github/scripts/check-caller-with-defaults.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Refuse a caller's `with:` value that differs from the reusable's declared
+default for any input the reusable emits as a required check.
+
+A pull request can edit the caller's `with:` to alter what a required job does
+the same way an `if:` line can switch off a required job: the ruleset matches
+on the CHECK NAME GitHub reports, not on the inputs the job received. Setting
+`coverage-threshold: 76` -> 0 keeps `rust / Coverage` as the name while
+lowering the gate below any failing build, and the same shape holds for
+`msrv: 1.85` -> '', `extra-test-os: '["macos-latest", ...]'` -> '[]',
+`doc-warnings: true` -> false, `extensions: 'rs go ... yml yaml'` -> a subset,
+`working-directory: '.'` -> 'src', and any other input the ruleset depends on.
+
+The fix is to compare each caller's `with:` value to the reusable's declared
+`inputs.X.default`. A value that matches the default is invisible to the
+runner (it would have been applied as the default anyway), so the ruleset
+sees the same job either way. A value that DIFFERS from the default is a
+pull request changing what a required job does; the step refuses it with
+a message that names the file, the job, the input key, the supplied value,
+and the declared default.
+
+The reusable is the place where the value the ruleset assumes is canonicalised.
+A pull request that changes a default is reviewed on the reusable's diff,
+where the ruleset's check name is fixed by definition (the reusable emits
+the same `name:` either way), so the change has to be deliberate and visible.
+
+Same shape as caller-if in reusable-workflow-lint.yml: same static map of
+required reusables, same direct-emitter list (which has no `with:` to
+compare, so it never trips), same `reusable-*` filename filter that exempts
+the reusable's own input declarations. An unknown `with:` key (the reusable
+does not declare it) is silently allowed: GitHub itself ignores it, and
+the ruleset does not gate on it.
+
+Output: writes one `::error` line per violation to stdout, exits 0 on
+clean and 1 on any violation. The step body in
+.github/workflows/reusable-workflow-lint.yml is a thin shell-out to this
+script; the extracted step body the shell test suites run is this script.
+
+Reads: .github/workflows/*.yml, .github/workflows/*.yaml under the working
+directory. Symlinks are not followed: a caller escaping the filter through
+a symlinked workflow file is out of scope.
+"""
+import glob
+import os
+import sys
+
+import yaml
+
+# Same map of required-emitting reusables as the caller-if step in
+# .github/workflows/reusable-workflow-lint.yml. A change here must move
+# together with caller-if: a reusable removed from the ruleset is removed
+# from both lists or the two steps drift in what they consider required.
+REQUIRED_REUSABLES = {
+    "reusable-rust-ci.yml": [
+        "Format & lint", "Test", "Coverage", "Doc warnings",
+        "MSRV", "Extra platforms",
+    ],
+    "reusable-dco.yml": [
+        "Signed-off-by present on every commit",
+    ],
+    "reusable-line-limit.yml": [
+        "line limit",
+    ],
+    "reusable-main-guard.yml": [
+        "develop-only",
+    ],
+    "reusable-workflow-lint.yml": [
+        "workflow-lint",
+    ],
+}
+
+
+def yaml_scalar(value):
+    # The reusable's `inputs.X.default` and the caller's `with.X` value
+    # are both reachable as a Python value after yaml.safe_load.
+    # Comparing them as `==` works for the scalars that matter here
+    # (strings, numbers, booleans, and the JSON-array strings
+    # cargo-cyclonedx and similar tools accept). Lists and dicts do not
+    # appear as declared defaults in the required-emitting reusables
+    # the lint walks; if they ever do, they hit a separate problem
+    # (the default is opaque) and the assertion treats that as "literal
+    # scalar expected".
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return value
+    return repr(value)
+
+
+def main():
+    files = sorted(set(
+        glob.glob(".github/workflows/*.yml")
+        + glob.glob(".github/workflows/*.yaml")
+    ))
+
+    # First pass: read each reusable's declared `inputs.X.default`.
+    # The map is `reusable-name -> {key: default}`. An unknown reusable
+    # is not in scope; a caller wrapping it has no `with:` to compare.
+    reusable_defaults = {}
+    for path in files:
+        name = os.path.basename(path)
+        if not name.startswith("reusable-"):
+            continue
+        if name not in REQUIRED_REUSABLES:
+            continue
+        try:
+            with open(path) as fh:
+                spec = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            # Warn and skip; same shape as the other lint steps in this
+            # file. A misconfigured workflow is not this step's reason
+            # to fail the run.
+            print(f"::warning file={path}::skipped: YAML parse error: {e}")
+            continue
+        if not isinstance(spec, dict):
+            continue
+        on = spec.get("on", spec.get(True))
+        if not isinstance(on, dict):
+            continue
+        wc = on.get("workflow_call")
+        if not isinstance(wc, dict):
+            continue
+        inputs = wc.get("inputs")
+        if not isinstance(inputs, dict):
+            continue
+        defaults = {}
+        for key, decl in inputs.items():
+            if not isinstance(decl, dict):
+                continue
+            defaults[key] = yaml_scalar(decl.get("default"))
+        reusable_defaults[name] = defaults
+
+    violations = []
+
+    for path in files:
+        name = os.path.basename(path)
+        # A reusable's own `with:`-shaped block is its `inputs.X.default`
+        # declaration, not a caller override. The reusables are filtered
+        # out for the same reason as caller-if: the `if:` seam carries
+        # the same shape and the same exemption.
+        if name.startswith("reusable-"):
+            continue
+        try:
+            with open(path) as fh:
+                spec = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            print(f"::warning file={path}::skipped: YAML parse error: {e}")
+            continue
+        if not isinstance(spec, dict):
+            continue
+        jobs = spec.get("jobs") or {}
+        if not isinstance(jobs, dict):
+            continue
+        for job_id, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            uses = job.get("uses")
+            if not (isinstance(uses, str) and uses.startswith("./")):
+                # Direct emitters (jobs whose `name:` is the required
+                # check itself) do not pass a `with:` block.
+                continue
+            ref = uses[2:]
+            reusable_name = None
+            for entry in reusable_defaults:
+                if ref.endswith(entry):
+                    reusable_name = entry
+                    break
+            if reusable_name is None:
+                # Caller of a reusable that is not in the required list.
+                # Out of scope; the ruleset matches the reusable's
+                # emitted check name, and a non-required reusable's
+                # gates are advisory, not load-bearing.
+                continue
+            with_inputs = job.get("with")
+            if not isinstance(with_inputs, dict):
+                # No `with:` block at all is the cleanest case: every
+                # input takes its declared default, which is what the
+                # ruleset sees.
+                continue
+            defaults = reusable_defaults[reusable_name]
+            for input_key, supplied in with_inputs.items():
+                if input_key not in defaults:
+                    # The reusable declares no such input. GitHub
+                    # itself ignores an undeclared `with:` key, so the
+                    # lint does too.
+                    continue
+                if yaml_scalar(supplied) != defaults[input_key]:
+                    violations.append((
+                        path, job_id, reusable_name, input_key,
+                        supplied, defaults[input_key],
+                    ))
+
+    if violations:
+        for path, job_id, reusable_name, input_key, supplied, default in violations:
+            print(
+                f"::error file={path}::job `{job_id}` in {path} "
+                f"calls `./{reusable_name}` with `with: "
+                f"{input_key}: {supplied!r}`, which differs from "
+                f"the reusable's declared default "
+                f"`{default!r}`. A pull request can edit this "
+                "value to alter what a required check does "
+                "while the ruleset still matches the same check "
+                "name. Either drop the `with:` entry to let the "
+                "default apply, or update the reusable's "
+                f"`inputs.{input_key}.default` so the value the "
+                "ruleset assumes is the one the caller passes."
+            )
+        sys.exit(1)
+    print(
+        "caller-with-defaults: every caller of a required check "
+        "carries `with:` values equal to the reusable's declared "
+        "defaults."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -35,9 +35,12 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
+      - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
       - "tests/shell/reusable-workflow-lint-caller-if.test.sh"
       - "tests/shell/reusable-workflow-lint-pin-length.test.sh"
+      - "tests/shell/reusable-workflow-lint-caller-with.test.sh"
+      - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -75,7 +78,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/reusable-line-limit.yml
+++ b/.github/workflows/reusable-line-limit.yml
@@ -20,12 +20,26 @@ on:
         default: 300
       extensions:
         description: Space-separated source file extensions to check
+        # Pinned: a caller that passes a subset of the configured
+        # extension list narrows what the line-limit gate covers
+        # while the ruleset still requires `line limit`. Workflow
+        # YAML is maintained under the same constraint as the rest
+        # of the source; the gate must continue to read it.
         type: string
-        default: "rs go ts tsx js jsx mjs cjs py sh astro vue svelte"
+        default: "rs go ts tsx js jsx mjs cjs py sh astro vue svelte yml yaml"
       exclude-pattern:
         description: Optional extended regex; matching paths are skipped
+        # Pinned: a caller that passes a different regex narrows what
+        # the line-limit gate covers while the ruleset still
+        # requires `line limit`. The bench scenarios are deliberately
+        # oversized by the benchmark that runs on them, and a
+        # maintainability warning there is noise. The condition: this
+        # holds while bench/scenarios contains only generated or
+        # deliberately-oversized fixtures. The day something
+        # maintained by hand lands there, the exclusion is wrong and
+        # this sentence is where it says so.
         type: string
-        default: ""
+        default: "^bench/scenarios/"
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-rust-ci.yml
+++ b/.github/workflows/reusable-rust-ci.yml
@@ -25,7 +25,13 @@ on:
       coverage-threshold:
         description: Minimum line coverage percentage (0 disables the gate)
         type: number
-        default: 0
+        # Pinned: a caller that passes 0 drops the coverage gate while
+        # the ruleset still requires `rust / Coverage`. The reusable
+        # carries the configured threshold here so callers can use it
+        # by omission; a PR that wants to lower it must move this
+        # default on the reusable's own diff, where the ruleset's
+        # check name stays stable by definition.
+        default: 76
       coverage-ignore-regex:
         description: Regex of file paths to exclude from coverage (e.g. code covered only by a separate DB integration job)
         type: string
@@ -37,7 +43,11 @@ on:
       extra-test-os:
         description: JSON array of extra runner images to also run tests on (e.g. '["macos-latest"]')
         type: string
-        default: "[]"
+        # Pinned: an empty default disables the Extra platforms gate
+        # while the ruleset still requires it. The configured array
+        # lives here so callers omit `with:`; a PR that wants to
+        # drop platforms moves this default on the reusable's diff.
+        default: "[\"macos-latest\", \"windows-latest\"]"
       podman:
         description: Start rootless Podman socket before running the coverage job (ubuntu-latest only)
         type: boolean
@@ -45,7 +55,13 @@ on:
       msrv:
         description: Minimum supported Rust version to verify a --locked build against (empty disables the check)
         type: string
-        default: ""
+        # Pinned: an empty default disables the MSRV job while the
+        # ruleset still requires `rust / MSRV` and the gated name
+        # `rust / MSRV (<version>)`. The configured value lives here
+        # so callers omit `with:`; a PR that wants a different MSRV
+        # moves this default on the reusable's diff, where the gate
+        # name stays stable by definition.
+        default: "1.85"
       package-check:
         description: Run cargo publish --dry-run on PRs to catch packaging breakage before tagging
         type: boolean
@@ -61,7 +77,11 @@ on:
       doc-warnings:
         description: Build the docs with -D warnings so broken doc links fail the build
         type: boolean
-        default: false
+        # Pinned: a caller that passes `false` disables the Doc
+        # warnings gate while the ruleset still requires
+        # `rust / Doc warnings`. The configured value lives here so
+        # callers omit `with:`.
+        default: true
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -16,6 +16,119 @@ name: Workflow lint (reusable)
 # pinned version (shell-ci.yml). Installing the same pinned shellcheck here
 # and pointing actionlint at it with -shellcheck keeps that pass reproducible
 # too.
+#
+# ===========================================================================
+# Release-path workflows and the ruleset (#1745)
+# ===========================================================================
+#
+# The caller-if and caller-with-defaults steps in this file both reference a
+# static map of "required" reusables (REQUIRED_REUSABLES) and a static map
+# of "required" direct emitters (DIRECT_EMITTER_NAMES). Those maps name the
+# checks the ruleset requires on `main` and `develop`. Five reusables and
+# one direct emitter are wired. The release path -- the workflows that build,
+# sign, attest and verify the artifacts that publish as a GitHub release --
+# is not on that list. That is the deliberate state at the time of this
+# writing, and the rationale is what follows.
+#
+# The rule that says "do not promote a check that has never failed for the
+# right reason" is in `~/.claude/CLAUDE.md`:
+#
+#   A gate that never has failed is not tested. Before marking a check as
+#   required, provoke the failure on purpose and confirm it goes red for
+#   the right reason.
+#
+# The release-path workflows are not required today because none of them
+# has been demonstrated to fail at the gate they would defend. Promoting
+# any of them would replace "no failure observed" with "no failure
+# possible": a required check whose name matches a workflow that runs
+# green regardless of what the pull request changes is a green check
+# that blocks the merge. The cost is real, the value is zero, and a
+# future operator looking at this file is the right place to be told so.
+#
+# The release-path workflows that touch a PR, what each would have to
+# demonstrate to become a required check, and where it would sit:
+#
+#   asset-contract.yml:check
+#     Calls reusable-installer-contract.yml. Today this fires once per
+#     PR that touches install.sh, install.ps1, release.yml, or any of
+#     the release-script paths. To be promoted: provoke a deliberate
+#     drift between install.sh's ARTIFACT template and release.yml's
+#     asset: matrix (rename one, do not rename the other, push a PR
+#     that touches only install.sh and confirm this job exits red with
+#     a message that names the missing asset). The job's name would
+#     pin to its current `check` (`release / install.sh <-> release
+#     asset names` or similar; the reusable's emit map below would
+#     carry the value).
+#
+#   asset-contract.yml:shell-signing-fixture
+#     Runs the per-asset .sig loop fixture in Linux bash. To be
+#     promoted: delete one of the seed signature files in the fixture
+#     tree, push a PR, confirm the fixture's loop falls through to the
+#     missing-file branch and exits red with the L7 class of error
+#     pinned in tests/fixtures/releases/test.sh. Pin the job's name
+#     once the failure is reproducible.
+#
+#   asset-contract.yml:powershell-signing-fixture
+#     Same fixture in PowerShell, on windows-latest. The acceptance
+#     is the same (a missing .sig reaches the L7 branch and the job
+#     exits red under pwsh). Both fixtures are tested on
+#     windows-latest; either promotion would require a windows-latest
+#     failure to be reproducible there.
+#
+#   asset-contract.yml:shell-version-self-test
+#     Drives verify_version_self_test in install.sh against a set of
+#     .cmd stubs (matching, older, -dev suffix, garbage, non-zero
+#     exit, missing file). To be promoted: edit the fixture to skip
+#     one of the cases and confirm the job reads red. Same shape for
+#     powershell-version-self-test, on windows-latest.
+#
+#   asset-contract.yml:rust-self-test-reference
+#     `cargo test --locked -p podup install::tests::self_test` at the
+#     configured MSRV, mirroring the shell installer path. To be
+#     promoted: disable a branch of `self_test`, run the job, confirm
+#     the rust test goes red. The job's name is the cargo test's
+#     harness path; if it moves, the ruleset has to be rewritten.
+#
+#   asset-contract.yml:shell-proto-redir
+#     Stands up a local https listener that 302s to an http listener,
+#     sources install.sh's helpers, runs the download, and asserts
+#     the install refused. The case the fixture exercises today is
+#     `--proto-redir` catching the downgrade. To be promoted: remove
+#     the `--proto-redir` flag from the install helper, run the
+#     fixture, confirm it goes red on the install side rather than
+#     somewhere later.
+#
+# `release.yml`'s jobs (verify, build, build-deb, sbom, release) are
+# not on this list at all: the workflow triggers on tag push, not on
+# pull_request, so its jobs cannot be required status checks for PRs.
+# They cannot be promoted because promotion means "matched by name
+# against a ruleset that gates merges", and a merge gate is a PR gate.
+# If at some future point the release path needs defence the day a tag
+# is cut, the rule that would carry it is a tag-protection rule rather
+# than a branch-protection rule, and the candidate fixtures above
+# (asset-contract.yml's six jobs) are what would do that defence on
+# the PR that produced the tag.
+#
+# All six candidates live in asset-contract.yml, which is already in
+# the ruleset's pull-request filter, so the path filter does not need
+# to move for any promotion. What each promotion needs is the
+# demonstrate-the-failure step above, run against a deliberately-broken
+# fixture, with the resulting red PR carrying the message so a future
+# operator can see what the check catches. After the demonstration
+# the static map REQUIRED_REUSABLES (or DIRECT_EMITTER_NAMES) grows
+# by one entry, the ruleset on `main` (and `develop`, where the ruleset
+# duplicates the `main` rule) gains the new check, and the failures
+# that would have escaped before that PR appear in the ruleset's red
+# list from then on.
+#
+# The lint itself is the wrong place to verify the demonstration. A
+# step that says "every release-path candidate has been demonstrated"
+# is a step that requires the demonstration to have run, and the
+# demonstration is by construction a thing that happened once in the
+# past. A static check would be lying. The actual verification is the
+# PR that first landed the failure-mode fixture, the comparison of the
+# red log against the expected reason, and the follow-up that turns
+# the candidate into a required check.
 
 on:
   workflow_call:
@@ -126,13 +239,36 @@ jobs:
           # present on the line, exempts that install: the only case where
           # the resolved tree is fixed is pip with --require-hashes, which
           # reads the lockfile verbatim and installs exactly what it lists.
+          #
+          # Property-based list (every entry is a known way to pull code
+          # from outside this org and have it run on the runner; the
+          # literal-string list this replaced caught the obvious shapes
+          # and missed synonyms like `cargo binstall`, `pip3 install`,
+          # `python -m pip install`, `python3 -m pip install`, `pipx
+          # install`, and `dotnet tool install`). The release signing
+          # job holds `GLYNDOR_RELEASE_ED25519_KEY` and runs `pip install
+          # --quiet --require-hashes -r .github/scripts/sign-requirements
+          # .txt`, which executes the cryptography package's native build
+          # script; hashed, so it is exempt, and the build script runs.
+          # The release target's own build-script count is 14 (cargo
+          # metadata --filter-platform x86_64-unknown-linux-gnu),
+          # confirmed against 15 directories in target/release/build (one
+          # of which is podup's own build script); the whole lockfile
+          # graph with dev-deps is 33, and an acceptance built on 33 would
+          # exempt crates the release never builds.
           INSTALL_PATTERNS = (
               ("cargo install",   None),
+              ("cargo binstall",  None),
               ("go install",      None),
               ("gem install",     None),
               ("npm install -g",  None),
               ("npm i -g",        None),
+              ("dotnet tool install", None),
               ("pip install",     "--require-hashes"),
+              ("pip3 install",    "--require-hashes"),
+              ("python -m pip install",  "--require-hashes"),
+              ("python3 -m pip install", "--require-hashes"),
+              ("pipx install",    None),
           )
 
 
@@ -730,3 +866,43 @@ jobs:
           if __name__ == "__main__":
               main()
           PY
+
+      # The caller-if step above refuses a job-level `if:` that can
+      # skip a required job. The same defect repeats through a
+      # different lever: a `with:` value a pull request can change that
+      # alters what a required job does. The ruleset matches on the
+      # CHECK NAME GitHub reports, not on the inputs the job received;
+      # `coverage-threshold: 76` -> 0 keeps `rust / Coverage` as the
+      # name while lowering the gate below any failing build, and the
+      # same shape holds for `msrv: 1.85` -> '', `extra-test-os:
+      # '["macos-latest", ...]'` -> '[]', `doc-warnings: true` ->
+      # false, `extensions: 'rs go ... yml yaml'` -> a subset,
+      # `working-directory: '.'` -> 'src'. Each is a different lever
+      # for the same outcome the ruleset cannot see.
+      #
+      # The fix is to compare each caller's `with:` value to the
+      # reusable's declared `inputs.X.default`. A value that matches
+      # the default is invisible to the runner (it would have been
+      # applied as the default anyway), so the ruleset sees the same
+      # job either way. A value that DIFFERS from the default is a
+      # pull request changing what a required job does; the step
+      # refuses it with a message that names the file, the job, the
+      # input key, the supplied value, and the declared default.
+      #
+      # The reusable is the place where the value the ruleset
+      # assumes is canonicalised. A pull request that changes a
+      # default is reviewed on the reusable's diff, where the
+      # ruleset's check name is fixed by definition (the reusable
+      # emits the same `name:` either way), so the change has to be
+      # deliberate and visible.
+      #
+      # Lives in .github/scripts/check-caller-with-defaults.py because
+      # the inline heredoc would push this file over the line-limit
+      # gate's 500-line hard limit, and the same shape as caller-if
+      # above (static map, direct-emitter list, `reusable-*` filter)
+      # already lives next to it in this file. An unknown `with:` key
+      # (the reusable does not declare it) is silently allowed: GitHub
+      # itself ignores it, and the ruleset does not gate on it.
+      - name: A caller of a required check must carry `with:` equal to the reusable's declared default
+        run: |
+          python3 .github/scripts/check-caller-with-defaults.py

--- a/tests/shell/reusable-workflow-lint-caller-with.test.sh
+++ b/tests/shell/reusable-workflow-lint-caller-with.test.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the caller's `with:` defaults check in
+# .github/workflows/reusable-workflow-lint.yml. The caller-if assertion
+# (#1731) refuses a job-level `if:` that can skip a required check.
+# This one refuses a job-level `with:` value that differs from the
+# reusable's declared `inputs.X.default`. Same outcome through a
+# different lever: the ruleset requires the check NAME, but the
+# underlying job runs differently when the input value is not the
+# one the ruleset was configured against. A pull request to
+# ci.yml:coverage-threshold: 76 -> 0, ci.yml:msrv: 1.85 -> '',
+# ci.yml:extra-test-os: '["macos-latest", ...]' -> '[]', or
+# ci.yml:doc-warnings: true -> false would all keep `rust / Coverage`,
+# `rust / MSRV`, `rust / MSRV (1.85)`, `rust / Extra platforms`,
+# `rust / Doc warnings` as the names the ruleset matches and silently
+# lower or remove the gate. The lint catches each.
+#
+# The rule is symmetric to caller-if: same named set of required checks,
+# same static map, same fixture shape. The comparison is not against
+# the ruleset (the ruleset sees check names, not inputs) but against
+# the reusable's declared `inputs.X.default`. The reusable is the
+# place where the value the ruleset assumes is canonicalised: a
+# change to the default is reviewed on the reusable's diff, where the
+# ruleset's check name stays stable.
+#
+# `if:` lines INSIDE a reusable are skipped the same way caller-if
+# skips them. The same `reusable-*` basename filter applies. This
+# step is wholly in the non-reusable scan path.
+#
+# Each step's `run:` body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository. Every
+# refusal asserts WHICH message fired. Each refusal is paired with a
+# same-shape acceptance so the rule is precise.
+#
+# Requires: python3 with PyYAML (the step under test imports it).
+# The fixtures below carry literal `${{ ... }}` expressions: the
+# assertion under test reads those characters, so they must reach
+# the file unexpanded. Single quotes are the point, not an oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+try:
+    start = next(i for i, l in enumerate(lines) if "name: " + sys.argv[2] in l)
+except StopIteration:
+    sys.exit(0)
+try:
+    run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+except StopIteration:
+    sys.exit(0)
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A caller of a required check must carry \`with:\`" \
+	> "$WORK/caller-with.sh"
+check "the caller-with assertion was extracted from the workflow" "1" \
+	"$(grep -c check-caller-with-defaults.py "$WORK/caller-with.sh" | awk '{print ($1>0)}')"
+
+check "the caller-with-defaults script lives next to the other GitHub scripts" "1" \
+	"$(test -f "$HERE/.github/scripts/check-caller-with-defaults.py" && echo 1 || echo 0)"
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# A fresh empty tree with '.github/workflows/' (and '.github/scripts/'
+# for the caller-with-defaults checker the step body shells out to),
+# and the real reusables copied across. The reusables declare the
+# inputs whose defaults the caller is compared against; a fixture
+# that does not include them cannot be checked.
+new() {
+	rm -rf "$WORK/t"
+	mkdir -p "$WORK/t/.github/workflows" "$WORK/t/.github/scripts"
+	for r in \
+		reusable-rust-ci.yml \
+		reusable-dco.yml \
+		reusable-line-limit.yml \
+		reusable-main-guard.yml \
+		reusable-workflow-lint.yml; do
+		cp "$HERE/.github/workflows/$r" "$WORK/t/.github/workflows/"
+	done
+	cp "$HERE/.github/scripts/check-caller-with-defaults.py" \
+		"$WORK/t/.github/scripts/"
+	printf '%s' "$WORK/t"
+}
+run_in() { ( cd "$1" && bash "$2" 2>&1 ); }
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+# A caller of a required-emitting reusable, with the supplied with:
+# block contents (already indented under the job). `with_text` may be
+# the empty string for "no with: block at all".
+caller_with() { # $1=dir $2=with-block text (or empty) $3=reusable basename
+	if [ -n "$2" ]; then
+		cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/$3
+    with:
+$2
+EOF
+	else
+		cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/$3
+EOF
+	fi
+}
+
+# ===========================================================================
+# Real-tree positive control: the loaded step body, run against the
+# real repository, exits 0 and prints the OK summary once the
+# reusable defaults carry the values the production callers set. With
+# the original defaults, ci.yml:coverage-threshold: 76 differs from
+# the reusable's declared default of 0 and the step exits 1; that is
+# the failure the defaults bump removes.
+# ===========================================================================
+
+out="$(cd "$HERE" && bash "$WORK/caller-with.sh")"; rc=$?
+check "the real repository tree passes the caller-with-defaults assertion" \
+	"0" "$rc"
+check "and the step prints the OK summary when the real tree is clean" "1" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# ===========================================================================
+# Each negative fixture plants a caller whose `with:` value differs
+# from the reusable's declared default. The seeded reusables carry
+# the same defaults the production reusables declare, so the step
+# catches each fixture the same way it would catch the same change
+# in production. Every refusal is paired with an acceptance (a
+# caller with the matching value, or no `with:` at all) so the rule
+# is precise.
+# ===========================================================================
+
+# --- coverage-threshold 76 -> 0 drops the coverage gate --------------
+d="$(new)"
+caller_with "$d" "      coverage-threshold: 0" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: coverage-threshold: 0 (default 76) is refused" "1" "$rc"
+check "and the message names the offending job" "1" \
+	"$(said "$out" 'job `caller` in')"
+check "and the message names the input key and the value" "1" \
+	"$(said "$out" 'coverage-threshold')"
+check "and the message names the declared default" "1" \
+	"$(said "$out" 'default')"
+check "and the message points at the reusable's declared default" "1" \
+	"$(said "$out" 'declared default')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# --- msrv 1.85 -> '' disables the MSRV job ---------------------------
+d="$(new)"
+caller_with "$d" "      msrv: ''" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: msrv: '' (default 1.85) is refused" "1" "$rc"
+check "and the message names the input key" "1" \
+	"$(said "$out" 'msrv')"
+
+# --- extra-test-os "[...]" -> '[]' drops extra-platform gating -------
+d="$(new)"
+caller_with "$d" "      extra-test-os: '[]'" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: extra-test-os: '[]' (default array) is refused" "1" "$rc"
+
+# --- doc-warnings true -> false drops doc-warning gate ---------------
+d="$(new)"
+caller_with "$d" "      doc-warnings: false" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: doc-warnings: false (default true) is refused" "1" "$rc"
+
+# --- extensions trimmed to a subset of the default set --------------
+d="$(new)"
+caller_with "$d" "      extensions: 'rs go'" "reusable-line-limit.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: extensions: 'rs go' (full default) is refused" "1" "$rc"
+
+# --- working-directory: src is non-default, refused ----------------
+d="$(new)"
+caller_with "$d" "      working-directory: src" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: working-directory: src (default '.') is refused" "1" "$rc"
+
+# ===========================================================================
+# Each shape above is accepted when the value matches the default.
+# ===========================================================================
+
+# --- a caller with no with: block at all is fine --------------------
+d="$(new)"
+caller_with "$d" "" "reusable-rust-ci.yml"
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "a caller with no with: block is allowed" "0" "$rc"
+
+# --- a caller whose with: values equal the declared defaults --------
+d="$(new)"
+caller_with "$d" "      coverage-threshold: 76
+      msrv: '1.85'
+      extra-test-os: '[\"macos-latest\", \"windows-latest\"]'
+      doc-warnings: true
+      working-directory: '.'
+      toolchain: '1.98'
+      podman: false
+      package-check: false
+      semver-check: false
+      semver-checks-version: '0.50.0'
+      llvm-cov-version: '0.8.7'
+      coverage-ignore-regex: ''" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "a caller whose with: values match the declared defaults is allowed" "0" "$rc"
+check "and the step prints the OK summary" "1" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# --- an input the reusable does not declare is ignored, not refused
+d="$(new)"
+caller_with "$d" "      not-a-real-input: anything" "reusable-rust-ci.yml"
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "an unknown input key is ignored, not refused" "0" "$rc"
+
+# ===========================================================================
+# Direct emitter (Supported Podman majors) is not gated: the rule
+# only catches callers of required-emitting REUSABLES. A direct job
+# named `Supported Podman majors` does not pass a `with:` to anyone,
+# and any `with:` on a step within it is not the same level as the
+# caller-if/caller-with scan.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  podman-majors:
+    name: Supported Podman majors
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo green
+EOF
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "a direct emitter job (no uses:, no with:) is allowed" "0" "$rc"
+
+# ===========================================================================
+# A caller of a non-required reusable is not in scope. Line-limit.yml
+# is a required-emitting reusable but for the `line-limit` check;
+# ASSET-CONTRACT uses reusable-installer-contract, which is not in
+# REQUIRED_REUSABLES. A caller of reusable-installer-contract with a
+# non-default `with:` must NOT be caught.
+# ===========================================================================
+
+d="$(new)"
+caller_with "$d" "      install-script: 'install.sh.bak'" \
+	"reusable-installer-contract.yml"
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "a non-default with: on a non-required reusable is not in scope" \
+	"0" "$rc"
+
+# ===========================================================================
+# Inside a reusable, a `with:`-shaped dict is the reusable's own
+# inputs declaration, not a caller override. The rule skips the
+# reusable's own file (same seam as caller-if).
+# ===========================================================================
+
+d="$(new)"
+# Set up a workflow that calls reusable-rust-ci.yml AND modify the
+# reusable's own `inputs.X.default` to a different value. The
+# caller's with: matches the original default, so the assertion must
+# stay quiet: the rule compares to the reusable's CURRENT declared
+# default, which we just changed.
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/reusable-rust-ci.yml
+    with:
+      coverage-threshold: 76
+EOF
+python3 - "$d/.github/workflows/reusable-rust-ci.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+# Bump the input's default; the caller's 76 no longer matches the
+# declared default (now 50).
+text = text.replace(
+    "coverage-threshold:\n        description: Minimum line coverage percentage (0 disables the gate)\n        type: number\n        default: 0",
+    "coverage-threshold:\n        description: Minimum line coverage percentage (0 disables the gate)\n        type: number\n        default: 50",
+    1,
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "a caller whose with: matches what the reusable now declares is allowed" \
+	"0" "$rc"
+check "and the step did not flag the reuse-side default change" "1" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# ===========================================================================
+# Edge: an unparseable caller is a warning, not a silent skip. The
+# previous step would fail-closed on a YAML parse error; this one
+# emits a warning so the silence is visible.
+# ===========================================================================
+
+d="$(new)"
+printf 'name: [\n' > "$d/.github/workflows/broken.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "an unparseable workflow does not fail the step" "0" "$rc"
+check "but is reported as skipped" "1" "$(said "$out" '::warning')"
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-tooling-installers.test.sh
+++ b/tests/shell/reusable-workflow-lint-tooling-installers.test.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the broadened installer patterns in the
+# tooling-isolation step of reusable-workflow-lint.yml. The step
+# refuses a job that holds a secret while installing third-party
+# tooling. The original list of installers covered `cargo install`,
+# `go install`, `gem install`, `npm install -g`/`npm i -g`, and
+# `pip install` (with --require-hashes exempted). That list matched
+# strings, not the property those strings all share: the install
+# reaches code that lives outside this organisation. A pull request
+# can dodge the string with a synonym the lint never heard of, and
+# the property it was supposed to gate still fires. The release signing
+# job is the canonical example: it holds the Ed25519 release key in
+# `GLYNDOR_RELEASE_ED25519_KEY` and runs `pip install --quiet
+# --require-hashes -r .github/scripts/sign-requirements.txt`, which
+# executes the cryptography package's native build script. Hashed,
+# so it is exempt; the cryptography build script runs either way.
+#
+# This file asserts the FIX: the property-based pattern list now
+# covers more synonyms and a behavioural test confirms each. Every
+# negative fixture would, on the unfixed list, fall through to the
+# `cargo install`-textual gap. Every positive fixture matches the
+# existing exemption so existing call sites stay green.
+#
+# Also documented here for the next person to read: the number of
+# build scripts the release target executes is 14. The original
+# issue cited 33: that is the whole lockfile graph with dev-deps and
+# every other platform included. Filtered to
+# `cargo metadata --filter-platform x86_64-unknown-linux-gnu` it is
+# 14 (confirmed against 15 directories in `target/release/build/`,
+# one of which is the podup crate's own build script, the other 14
+# are deps). An acceptance built on 33 would exempt crates the
+# release never builds; 14 is the number that named the property in
+# the brief.
+#
+# Each step's `run:` body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository. Every
+# refusal is paired with a same-shape acceptance so the rule is
+# precise.
+#
+# Requires: python3 with PyYAML (the tooling-isolation step imports
+# it), cargo (the build-script-count assertion at the bottom). The
+# fixtures below carry literal `${{ secrets.X }}` expressions: the
+# assertion under test reads those characters, so they must reach
+# the file unexpanded. Single quotes are the point, not an oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if "name: " + sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A job holding a secret must not install" > "$WORK/tooling.sh"
+check "the tooling assertion was extracted from the workflow" "1" \
+	"$(grep -c 'INSTALL_PATTERNS' "$WORK/tooling.sh" | awk '{print ($1>0)}')"
+
+# The new patterns the broadened list is supposed to recognise. A
+# substring-match on the extracted step body ensures the fix is in
+# place (each name is a tuple entry in INSTALL_PATTERNS). An entry
+# that doesn't appear would itself be a regression, and would also
+# gate every negative fixture below.
+for needle in \
+	"cargo binstall" \
+	"pip3 install" \
+	"python -m pip install" \
+	"python3 -m pip install" \
+	"pipx install" \
+	"dotnet tool install"; do
+	check "INSTALL_PATTERNS names the property equivalent $needle" "1" \
+		"$(grep -F -c "$needle" "$WORK/tooling.sh" | awk '{print ($1>0)}')"
+done
+
+new() { rm -rf "$WORK/t"; mkdir -p "$WORK/t/.github/workflows"; printf '%s' "$WORK/t"; }
+run_in() { ( cd "$1" && bash "$2" 2>&1 ); }
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+tooling_case() { # $1=dir $2=env line $3=run line
+	cat > "$1/.github/workflows/job.yml" <<EOF
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      $2
+    steps:
+      - run: |
+          $3
+EOF
+}
+
+# ===========================================================================
+# Cargo binstall: same shape as cargo install but a different literal.
+# On the unfixed list it falls through and the lint passes. On the
+# broadened list the property that holds a secret while a third-party
+# build script would run is the one that fires.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'cargo binstall cargo-cyclonedx --version 0.5.9'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "cargo binstall while holding a secret is refused" "1" "$rc"
+check "and the message names the install and the line" "1" \
+	"$(said "$out" 'cargo binstall cargo-cyclonedx')"
+
+# ===========================================================================
+# pip3 install (alias for pip install): unfixed list does not name it,
+# so a job holding a secret and running `pip3 install requests`
+# falls through. The hash-pinned variant still passes; the property
+# is the same as pip install, so the exemption carries over.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip3 install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pip3 install without hashes while holding a secret is refused" "1" "$rc"
+check "and the message names the install and the line" "1" \
+	"$(said "$out" 'pip3 install requests')"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip3 install --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "pip3 install --require-hashes while holding a secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# python -m pip install: same property as pip install, different
+# invocation. The release signing jobs (release.yml) use exactly this
+# spelling; the broadened list catches both.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python -m pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "python -m pip install without hashes while holding a secret is refused" "1" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python -m pip install --quiet --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "python -m pip install --require-hashes while holding a secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# python3 -m pip install: another synonym the release signing job uses
+# when `python` is not on PATH (`command -v python >/dev/null 2>&1 ||
+# py=python3`). Same exemption applies.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python3 -m pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "python3 -m pip install without hashes while holding a secret is refused" "1" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python3 -m pip install --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "python3 -m pip install --require-hashes while holding a secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# pipx install: isolated-venv pip. Does NOT support --require-hashes,
+# so the exemption cannot apply; the install is always refused.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pipx install cryptography'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pipx install while holding a secret is refused (no hash exemption)" "1" "$rc"
+
+# ===========================================================================
+# dotnet tool install: brings a NuGet tool into the runner.
+# Different ecosystem, same property.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'dotnet tool install -g cargo-audit'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "dotnet tool install while holding a secret is refused" "1" "$rc"
+
+# ===========================================================================
+# Regression: the original pip install --require-hashes still exempts.
+# The release signing job runs this verbatim; a regression that
+# forgets the exemption would burn every release.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip install --quiet --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "pip install --require-hashes while holding a secret is still allowed" "0" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pip install without hashes while holding a secret is still refused" "1" "$rc"
+
+# ===========================================================================
+# Regression: the cargo / go / gem / npm entries still fire. The
+# broadened list adds to, it does not replace.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'cargo install --locked cargo-cyclonedx --version 0.5.9'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "cargo install while holding a secret is still refused" "1" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'go install example.com/tool@v1'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "go install while holding a secret is still refused" "1" "$rc"
+
+# ===========================================================================
+# Installers in jobs that hold NO secret still pass. Same broadened
+# list, only the hold-a-secret branch fires.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'PLAIN: value' \
+	'cargo binstall cargo-cyclonedx --version 0.5.9'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "cargo binstall in a job holding no secret is allowed" "0" "$rc"
+
+d="$(new)"; tooling_case "$d" 'PLAIN: value' \
+	'pipx install cryptography'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "pipx install in a job holding no secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# A line that mixes a hash-pinned pip with an unexempted installer
+# catches the unexempted one. `cargo install cargo-foo && pip install
+# --require-hashes -r req.txt` -- both literal strings are present;
+# the cargo install is the property violation. The original list has
+# the same `break after first violation` behaviour, so this also
+# tests the order: `cargo install` is before `pip install` in the
+# tuple, the violation is the cargo install, the step prints the
+# cargo install line.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'cargo install cargo-foo && pip install --require-hashes -r req.txt'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a line that mixes cargo install with hash-pinned pip is refused" "1" "$rc"
+check "and the message names the cargo install (the unexempted one)" "1" \
+	"$(said "$out" 'cargo install cargo-foo')"
+
+# ===========================================================================
+# Build-script count for the release target. The number the original
+# issue cited was 33: that is the whole lockfile graph with dev-deps
+# and every other platform included, and an acceptance built on 33
+# would exempt crates the release never builds. Filtered to the release
+# target (`cargo metadata --filter-platform x86_64-unknown-linux-gnu`)
+# the correct count is 14. This is reported here as a documentation
+# assertion the next person wiring a release-path check can lean on,
+# not as a runtime invariant: the count depends on the resolved set at
+# the moment cargo metadata runs, which is what the property is about.
+# The runner-side cross-check is `ls target/x86_64-unknown-linux-gnu
+# /release/build | wc -l` after a fresh build for that target.
+# ===========================================================================
+
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Repeating a variable during interpolation had no ceiling. Output grows
by the number of references times the length of the value, so a few
hundred kilobytes of input where one variable repeats reaches gigabytes
before anything else has a chance to fire: 300 KB in, a 3.27 GB
allocation, SIGABRT in 0.97 s.

The bound is checked before each `push_str` rather than after the pass,
so the refusal happens before the offending allocation instead of
reporting it once the memory is already gone.

The message names the variable and the size it reached. A long secret
or a multi-line config blob is a legitimate reason for a large value,
and an operator who hits this needs to tell that apart from a hostile
document.

This is a different path from the YAML alias caps in #1737, which is
why that change does not close this one: the alias guards bound the
document's expansion, and this bounds what substitution writes out of
it.

Forcing the comparison false turns the refusal case red and leaves the
legitimate-repetition case green, which is the pair that says the cap is
doing the work rather than the test passing for its own reasons.

Closes #1738.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>