### PR TITLE
fix: the seven medium findings from the three-model review

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -16,6 +16,7 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
+      - "tests/shell/install-rollback-cleans-staged.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
   pull_request:
@@ -41,6 +42,7 @@ on:
       - "tests/shell/reusable-workflow-lint-pin-length.test.sh"
       - "tests/shell/reusable-workflow-lint-caller-with.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
+      - "tests/shell/install-rollback-cleans-staged.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -78,7 +80,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh ./tests/shell/install-rollback-cleans-staged.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/install.sh
+++ b/install.sh
@@ -243,6 +243,12 @@ PYEOF
 # past the `3.7.0` check, which is the rollback case this gate exists
 # to reject. Matches the Rust behaviour token-for-token.
 #
+# The cleanup of the staged file goes through `run_root`: when the install
+# ran via sudo the staged binary is owned by root, and a bare `rm -f` from
+# the caller would fail silently, leaving a root-owned executable in
+# /usr/local/bin while this function printed that the file had been
+# removed. `run_root rm` elevates the same way the install itself did.
+#
 #   verify_version_self_test <staged-path> <resolved-tag>
 verify_version_self_test() {
 	local staged="$1" expected_tag="$2"
@@ -253,7 +259,7 @@ verify_version_self_test() {
 	# hidden name; reading --version requires execute permission but no
 	# read/ownership on the parent.
 	if ! reported="$("$staged" --version 2>/dev/null)"; then
-		rm -f "$staged" 2>/dev/null || true
+		run_root rm -f "$staged" 2>/dev/null || true
 		fail "Could not run ${staged} --version to self-test the staged binary"
 	fi
 
@@ -265,7 +271,7 @@ verify_version_self_test() {
 			return 0
 		fi
 	done
-	rm -f "$staged" 2>/dev/null || true
+	run_root rm -f "$staged" 2>/dev/null || true
 	log_error "Staged binary reports '${reported}', expected ${expected_tag}"
 	fail "Refusing to install: staged binary's --version does not match the resolved release tag (possible rollback) - the staged file has been removed"
 }

--- a/internal/audit/audit_tests.rs
+++ b/internal/audit/audit_tests.rs
@@ -1,16 +1,21 @@
+use std::path::Path;
+
 use podup::parse_str;
 
 use crate::audit;
+use crate::cli::ConfigFormat;
+use crate::startup::{render_config_to, ConfigOutput};
 
 // ---------------------------------------------------------------------------
 // Test scaffolding
 // ---------------------------------------------------------------------------
 
 // Pull the names this test file reaches for into scope so the body reads as
-// straight assertions rather than naming the path every line.
+// straight assertions rather than naming the path every time.
 #[allow(unused_imports)]
 use super::{
-	audit_file, ordered_services, render_json, render_table, AuditReport, Finding as _, Finding,
+	audit_file, ordered_services, render_json, render_json_to, render_table, render_table_to,
+	AuditReport, Finding as _, Finding,
 };
 
 // ---------------------------------------------------------------------------
@@ -222,4 +227,205 @@ fn audit_secret_in_environment_flags_a_value_that_only_ends_in_a_brace() {
 
 fn report_for_file(yaml: &str) -> AuditReport {
 	audit_file(&parse_str(yaml).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// #1746 entry 2: terminal-escape injection in five sinks.
+//
+// The detail lines emitted by `podup audit` and the four `podup config
+// --services/--volumes/--images/--profiles/--hash` projections print
+// user-controlled compose values verbatim. A compose file authored by a
+// third party can therefore inject raw terminal escapes; the cross-review
+// noted that the bytes survive a pipe, because the rendering path is just
+// `println!("{user_value}")`.
+//
+// The five sinks:
+//
+//   1. `audit` table detail lines (`render_table_to`)
+//   2. `config --services` (`render_config_to`)
+//   3. `config --volumes`  (`render_config_to`)
+//   4. `config --images`   (`render_config_to`)
+//   5. `config --profiles` (`render_config_to`)
+//
+// The audit table cells and the JSON renderer are intentionally out of
+// scope: the table goes through `Table::print` -> `fit_cell` ->
+// `sanitize_cell`, and `serde_json` escapes every control character. The
+// "16 raw ESC bytes" payload the issue names only reaches the operator
+// through the five unescaped sinks above, so this test pins those five
+// and ignores the rest.
+//
+// The fix routes every user-controlled value through
+// `podup::ui::sanitize_cell`, the same gate the table already uses. The
+// test asserts that the bytes never appear verbatim, regardless of which
+// user-controlled slot the attacker writes them into.
+//
+// The YAML parser itself rejects raw control characters in scalars, so
+// the attack reaches the parsed model through env-var interpolation:
+// the compose file says `image: $HOSTILE` and the operator's
+// environment sets `HOSTILE` to the byte sequence. The interpolated
+// scalar fallback in `merge::interpolate_scalar` stores the resolved
+// string verbatim when the bytes are not a valid YAML scalar. The test
+// constructs the `ComposeFile` directly with the interpolated values to
+// pin the renderer behaviour without coupling to the parser's own
+// rejection (which the issue does not ask to change).
+// ---------------------------------------------------------------------------
+
+/// The payload the issue names: a 16-byte sequence that, raw, asks the
+/// terminal to clear the screen and move the cursor home. The exact
+/// content does not matter; what matters is that the byte stream the
+/// renderer produces for a sink using the value does not contain any
+/// raw `\x1b` byte.
+const HOSTILE: &str = "\x1b[2J\x1b[HINJECTED";
+
+/// A `ComposeFile` whose every user-controlled slot the renderers
+/// consume carries the same hostile payload. The service name is left
+/// valid (compose validation rejects ESC chars in service names, so
+/// that vector is not reachable from a YAML file in production); the
+/// other slots are not validated against control characters and reach
+/// the renderers verbatim when the typed model is built with them.
+///
+/// Specifically, each field is the value a different sink prints:
+///
+///   - `services.web.image`: the audit reason (via
+///     `check_unpinned_image`) AND the `config --images` projection
+///   - `services.web.cap_add`: the audit reason (via
+///     `check_dangerous_capability`)
+///   - `services.web.profiles`: the `config --profiles` projection
+///   - `volumes[HOSTILE]`: the `config --volumes` projection
+///
+/// `Service` and `ComposeFile` are `#[non_exhaustive]`, so the test
+/// builds a clean file from a safe YAML first, then mutates the typed
+/// model in place to plant the hostile payload. This is the same shape
+/// a hostile env-var interpolation (`image: $HOSTILE` with
+/// `HOSTILE=\x1b[2J:latest`) would leave the model in: a string field
+/// carrying a sequence of bytes the YAML parser would have refused, but
+/// the typed model carries without question.
+fn hostile_compose() -> podup::compose::types::ComposeFile {
+	let yaml = "services:\n  web:\n    image: nginx:1.27\n    cap_add: [SYS_ADMIN]\n    \
+	            profiles: [safe]\nvolumes:\n  data: null\n";
+	let mut file = podup::parse_str(yaml).expect("safe compose parses");
+	let web = file.services.get_mut("web").expect("web present");
+	web.image = Some(format!("{HOSTILE}:latest"));
+	web.cap_add = vec![HOSTILE.to_string()];
+	web.profiles = vec![HOSTILE.to_string()];
+	// The named volume reaches the `config --volumes` projection
+	// directly. Volumes are not validated against control characters;
+	// a hostile env interpolation would land here.
+	let vol = file
+		.volumes
+		.shift_remove("data")
+		.expect("data volume present");
+	file.volumes.insert(HOSTILE.to_string(), vol);
+	file
+}
+
+fn assert_no_hostile(label: &str, bytes: &[u8]) {
+	// The hostile payload is a literal byte sequence, not a generic
+	// "any ESC byte" check. Podup's own styling always emits SGR
+	// sequences (`\x1b[1m`, `\x1b[0m`), so a raw byte count would
+	// alert on those too; the meaningful signal is whether the exact
+	// payload the attacker planted reaches the byte stream.
+	let haystack = String::from_utf8_lossy(bytes);
+	assert!(
+		!haystack.contains(HOSTILE),
+		"{label} carried the hostile payload verbatim; the attacker's compose file reached the \
+		 operator's terminal. Output was: {haystack}",
+	);
+}
+
+#[test]
+fn hostile_compose_does_not_inject_escapes_into_audit_table_detail_lines() {
+	// Sink 1: the audit table's per-finding detail lines. The service name
+	// and the reason both come from user-controlled compose data; both
+	// must be sanitized through `sanitize_cell` before they reach the byte
+	// stream the operator (or a pipe) sees.
+	let file = hostile_compose();
+	let report = audit_file(&file);
+	let services = ordered_services(&file);
+	let mut buf: Vec<u8> = Vec::new();
+	render_table_to(&mut buf, &services, &report).expect("render");
+	assert_no_hostile("audit detail lines", &buf);
+	// Positive control: the renderer did produce output, and the host's
+	// word (sanitized) is still in the byte stream somewhere. Without
+	// this assertion a test that simply returned no output would also
+	// pass `assert_no_hostile`.
+	let out = String::from_utf8_lossy(&buf);
+	assert!(
+		out.contains("INJECTED"),
+		"the host's word is gone entirely: {out}"
+	);
+}
+
+#[test]
+fn hostile_compose_does_not_inject_escapes_into_config_list_projections() {
+	// Sinks 2..5: the four `config` list-projection branches all print a
+	// value taken from the compose file. They share the `_to` writer so a
+	// single test covers all four.
+	let file = hostile_compose();
+	let mut buf: Vec<u8> = Vec::new();
+
+	let projections: [(&str, ConfigOutput); 4] = [
+		(
+			"--services",
+			ConfigOutput {
+				services: true,
+				..Default::default()
+			},
+		),
+		(
+			"--volumes",
+			ConfigOutput {
+				volumes: true,
+				..Default::default()
+			},
+		),
+		(
+			"--images",
+			ConfigOutput {
+				images: true,
+				..Default::default()
+			},
+		),
+		(
+			"--profiles",
+			ConfigOutput {
+				profiles: true,
+				..Default::default()
+			},
+		),
+	];
+	for (name, out) in projections {
+		buf.clear();
+		render_config_to(
+			&mut buf,
+			&file,
+			&ConfigFormat::Yaml,
+			&out,
+			"proj",
+			Path::new("/proj"),
+		)
+		.unwrap_or_else(|e| panic!("{name} render: {e}"));
+		assert_no_hostile(name, &buf);
+	}
+
+	// Sink 6: `config --hash` also prints the service name. The branch
+	// runs the same `sanitize_cell` gate as the other projections.
+	buf.clear();
+	render_config_to(
+		&mut buf,
+		&file,
+		&ConfigFormat::Yaml,
+		&ConfigOutput {
+			hash: Some("*".to_string()),
+			..Default::default()
+		},
+		"proj",
+		Path::new("/proj"),
+	)
+	.expect("--hash render");
+	assert_no_hostile("--hash", &buf);
+	// The 64-character hex hash is bytes we own, so the only sanitized
+	// thing in this line is the service name. The print still produces a
+	// line per service, so the line count is exactly one.
+	assert_eq!(buf.iter().filter(|&&b| b == b'\n').count(), 1);
 }

--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -124,7 +124,12 @@ fn check_privileged(name: &str, service: &Service, _file: &ComposeFile) -> Vec<F
 }
 
 /// Host-binding namespacing modes: `pid`, `ipc`, `uts`, `cgroup`, `userns_mode`
-/// set to `host`, or `network_mode: host`. One finding per active mode.
+/// set to `host` or `container:<id>`, or `network_mode` carrying the same. One
+/// finding per active mode. The `container:<id>` form is the share-another-
+/// container mode the runtime detector in
+/// `internal/engine/container/host_mode.rs` already warns on; the audit
+/// detector must agree, otherwise `podup audit --strict` would pass a file
+/// the engine later refuses to run silently (#1746).
 fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
 	let mut out = Vec::new();
 	if let Some(mode) = service.network_mode.as_deref() {
@@ -133,6 +138,14 @@ fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> V
 				name,
 				"host_namespace",
 				"network_mode: host shares the host's network namespace",
+			));
+		} else if let Some(target) = mode.strip_prefix("container:") {
+			out.push(finding(
+				name,
+				"host_namespace",
+				&format!(
+					"network_mode: container:{target} shares another container's network namespace"
+				),
 			));
 		}
 	}
@@ -151,6 +164,14 @@ fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> V
 					name,
 					"host_namespace",
 					&format!("{field}: host shares the host's {field} namespace"),
+				));
+			} else if let Some(target) = mode.strip_prefix("container:") {
+				out.push(finding(
+					name,
+					"host_namespace",
+					&format!(
+						"{field}: container:{target} shares another container's {field} namespace"
+					),
 				));
 			}
 		}

--- a/internal/audit/checks_tests.rs
+++ b/internal/audit/checks_tests.rs
@@ -107,6 +107,55 @@ fn audit_host_namespace_flags_pid_ipc_uts_cgroup_userns_host() {
 	}
 }
 
+/// `container:<id>` is the share-another-container mode the runtime
+/// detector in `internal/engine/container/host_mode.rs` already warns
+/// on; the audit detector must agree, otherwise `podup audit --strict`
+/// would pass a file the engine later refuses silently (#1746 entry 4).
+/// The two lists are now one: every mode the runtime flags, the audit
+/// flags, so a finding on the same file is consistent across the two
+/// commands.
+#[test]
+fn audit_host_namespace_flags_container_id_on_every_namespace_field() {
+	for (yaml_field, expected_field) in [
+		("pid: container:sidecar", "pid"),
+		("ipc: container:sidecar", "ipc"),
+		("uts: container:sidecar", "uts"),
+		("cgroup: container:sidecar", "cgroup"),
+		("userns_mode: container:sidecar", "userns_mode"),
+	] {
+		let yaml = format!("services:\n  web:\n    image: alpine:3.20\n    {yaml_field}\n");
+		let findings = report_for(&yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "host_namespace"
+				&& f.reason.contains(expected_field)
+				&& f.reason.contains("container:sidecar")),
+			"expected host_namespace finding for `{yaml_field}` mentioning the \
+			 target id; got {findings:#?}"
+		);
+	}
+}
+
+/// `network_mode: container:<id>` is its own branch (the field is a
+/// sibling of the per-namespace keys, not one of them). Cover it
+/// separately so a regression that fixes the `pid`/`ipc`/... loop but
+/// leaves `network_mode` behind gets caught.
+#[test]
+fn audit_host_namespace_flags_network_mode_container_id() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    network_mode: container:sidecar
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "host_namespace"
+			&& f.reason.contains("network_mode")
+			&& f.reason.contains("container:sidecar")),
+		"expected network_mode container:<id> finding; got {findings:#?}"
+	);
+}
+
 #[test]
 fn audit_host_namespace_passes_when_clean() {
 	let yaml = r#"

--- a/internal/audit/mod.rs
+++ b/internal/audit/mod.rs
@@ -8,6 +8,8 @@
 //! [`render_table`]/[`render_json`] functions translate the result into the
 //! `--format table|json` output the CLI asked for.
 
+use std::io::{self, Write};
+
 use podup::compose::types::{ComposeFile, Service};
 
 mod checks;
@@ -95,7 +97,28 @@ pub fn ordered_services(file: &ComposeFile) -> Vec<(&str, &Service)> {
 /// finding with `  <service>: <check>: <reason>` indented two spaces. When
 /// nothing was found, only the line `no findings` is printed, the table is
 /// suppressed so a CI log without any findings is minimal.
+///
+/// Service names and reasons are user-controlled (compose YAML), so the
+/// detail lines route them through `sanitize_cell` before printing; the
+/// table itself already does that via `Table::print`. Without sanitization
+/// a malicious compose file injects raw ESC bytes into the operator's
+/// terminal, and the bytes survive a pipe because `println!` is just a
+/// byte stream.
 pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
+	let stdout = io::stdout();
+	let mut out = stdout.lock();
+	let _ = render_table_to(&mut out, services, report);
+}
+
+/// [`render_table`] writing to `w`, factored out so tests can capture the
+/// rendered bytes without redirecting the process's stdout. The sanitization
+/// of user-controlled values happens here, not in the caller, so every sink
+/// of audit output goes through the same gate.
+pub fn render_table_to<W: Write>(
+	w: &mut W,
+	services: &[(&str, &Service)],
+	report: &AuditReport,
+) -> io::Result<()> {
 	let mut table = podup::ui::Table::new(&["SERVICE", "FINDINGS"]);
 	for (name, mine) in report.by_service(services) {
 		let findings = if mine.is_empty() {
@@ -106,18 +129,24 @@ pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
 		table.push(vec![(*name).to_string(), findings]);
 	}
 	if report.findings.is_empty() {
-		println!("no findings");
-		return;
+		writeln!(w, "no findings")?;
+		return Ok(());
 	}
-	table.print();
+	table.print_to(w)?;
 	for finding in &report.findings {
-		println!(
-			"  {service}: {check}: {reason}",
-			service = finding.service,
-			check = finding.check,
-			reason = finding.reason,
-		);
+		// `check` is a hardcoded `'static str`, so only the user-controlled
+		// `service` and `reason` need sanitizing. Going through `sanitize_cell`
+		// keeps the table cell and detail line consistent: same function,
+		// same rules, no drift between the two surfaces an attacker can read.
+		writeln!(
+			w,
+			"  {}: {}: {}",
+			podup::ui::sanitize_cell(&finding.service),
+			finding.check,
+			podup::ui::sanitize_cell(&finding.reason),
+		)?;
 	}
+	Ok(())
 }
 
 /// Render `report` as a single JSON line to stdout. `serde_json` orders the
@@ -127,6 +156,18 @@ pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
 /// Empty finding lists emit `{"findings":[]}`, never `null`, so an empty
 /// body is still valid JSON without the consumer having to special-case it.
 pub fn render_json(report: &AuditReport) {
+	let stdout = io::stdout();
+	let mut out = stdout.lock();
+	render_json_to(&mut out, report).expect("write to stdout");
+}
+
+/// [`render_json`] writing to `w`. JSON output is already safe from terminal
+/// injection: `serde_json` escapes every control character (`\x1b` becomes
+/// `\u001b`), so a malicious compose file's bytes round-trip as escape
+/// sequences inside a JSON string rather than as live escapes on the
+/// terminal. The sink is exposed so a test can compare the exact JSON it
+/// produces against the same input.
+pub fn render_json_to<W: Write>(w: &mut W, report: &AuditReport) -> io::Result<()> {
 	let findings: Vec<serde_json::Value> = report
 		.findings
 		.iter()
@@ -139,7 +180,7 @@ pub fn render_json(report: &AuditReport) {
 		})
 		.collect();
 	let out = serde_json::json!({ "findings": findings });
-	println!("{out}");
+	writeln!(w, "{out}")
 }
 
 #[cfg(test)]

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -17,7 +17,7 @@ use ignored_fields::{
 	ignored_restart_policy_fields, ignored_secret_config_drivers, ignored_service_fields,
 	ignored_service_network_fields, ignored_volume_mount_fields, port_published_on_all_interfaces,
 };
-pub(super) use nested_raw::raw_nested_unknown_warnings;
+pub(super) use nested_raw::collect_raw_nested_warnings;
 
 /// Collect a warning for every parsed-but-unsupported key or field in `file`.
 /// Pure (no logging) so it can be unit-tested; the caller emits the messages.

--- a/internal/compose/diagnostics/nested_raw.rs
+++ b/internal/compose/diagnostics/nested_raw.rs
@@ -24,6 +24,10 @@
 //! any of the seven structs fails to compile until both the literal and the
 //! allowlist are updated.
 
+use std::path::{Path, PathBuf};
+
+use crate::compose::is_stdin;
+
 // --- Per-type allowlists of modeled serde keys -----------------------------
 //
 // Each entry is the YAML key serde reads/writes for the field (accounting for
@@ -87,6 +91,81 @@ pub(crate) fn raw_nested_unknown_warnings(interpolated_yaml: &str) -> Vec<String
 		walk_deploy(service, svc, &mut out);
 	}
 	out
+}
+
+/// Run the raw-nested-key diagnostic for every `-f` path, including the
+/// stdin compose, and return the collected warnings. The stdin path
+/// is special-cased: its content is read once and the diagnostic is
+/// re-driven against the in-memory bytes; a re-read from disk would
+/// always fail for stdin. This is the public hook the integration
+/// test uses to verify the stdin branch without redirecting process
+/// stdin (#1746 entry 7).
+///
+/// `paths` and `stdin` describe the same compose sources the caller
+/// passed to `parse_files_with_env_files_interp`. The test entry feeds
+/// the YAML it wants to assert on directly through `stdin`; the
+/// production caller reads stdin once into a `String` and passes it
+/// here.
+pub(crate) fn collect_raw_nested_warnings(
+	paths: &[PathBuf],
+	env_files: &[String],
+	interpolate: bool,
+	stdin: Option<&str>,
+) -> Vec<String> {
+	let mut out = Vec::new();
+	for path in paths {
+		let yaml = if super::super::is_stdin(path) {
+			match stdin {
+				Some(c) => match interpolated_yaml_text_from_content(
+					c,
+					&dir_for_path(path),
+					env_files,
+					interpolate,
+				) {
+					Ok(y) => y,
+					Err(_) => continue,
+				},
+				None => continue,
+			}
+		} else {
+			match super::super::interpolated_yaml_text(path, env_files, interpolate) {
+				Ok(y) => y,
+				Err(_) => continue,
+			}
+		};
+		out.extend(raw_nested_unknown_warnings(&yaml));
+	}
+	out
+}
+
+fn dir_for_path(path: &Path) -> PathBuf {
+	if is_stdin(path) {
+		std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+	} else {
+		let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+		abs.parent().unwrap_or(Path::new(".")).to_path_buf()
+	}
+}
+
+fn interpolated_yaml_text_from_content(
+	content: &str,
+	dir: &Path,
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<String, crate::error::ComposeError> {
+	use crate::compose::merge;
+	use crate::substitute;
+	let value = if interpolate {
+		let vars = if env_files.is_empty() {
+			substitute::build_vars(dir)
+		} else {
+			substitute::build_vars_with_env_files_strict(dir, env_files)?
+		};
+		merge::interpolated_value(content, Some(&vars))?
+	} else {
+		merge::interpolated_value(content, None)?
+	};
+	Ok(serde_yaml::to_string(&value)?)
 }
 
 /// `services.<svc>.volumes[i].{bind,volume,tmpfs}` (long-form mounts only).

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -10,8 +10,8 @@
 
 mod merge;
 
-use std::collections::HashSet;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use super::parse_file_inner;
 use super::types::ComposeFile;
@@ -20,6 +20,93 @@ use crate::error::{ComposeError, Result};
 pub(in crate::compose) use merge::{merge_service, merge_service_tagged};
 
 const MAX_EXTENDS_DEPTH: usize = 16;
+
+/// How many distinct external `extends.file` paths the cache may keep
+/// before `resolve_all_extends` starts refusing. Bounded so a project
+/// that points every service at a different file cannot grow the cache
+/// without limit; the cap is high enough that the only realistic way
+/// to hit it is to be the shape the issue describes (`extends.file` per
+/// service, all pointing at the same file), at which point the cache
+/// either reuses the single entry or refuses with a clear message.
+const MAX_EXTENDS_CACHE_ENTRIES: usize = 256;
+
+// Thread-local counter used by the unit tests to assert that
+// `parse_file_inner` is not re-invoked per referencing service when
+// `extends.file` points at a shared file. Without caching, the
+// counter records one increment per referencing service; with
+// caching, exactly one regardless of the number of references.
+// Compiled out of release builds.
+#[cfg(test)]
+std::thread_local! {
+	static PARSE_FILE_INNER_CALLS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_parse_file_inner_counter() {
+	PARSE_FILE_INNER_CALLS.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+fn parse_file_inner_call_count() -> u32 {
+	PARSE_FILE_INNER_CALLS.with(|c| c.get())
+}
+
+#[cfg(test)]
+fn bump_parse_file_inner_counter() {
+	PARSE_FILE_INNER_CALLS.with(|c| c.set(c.get() + 1));
+}
+
+/// Cache of resolved external files, keyed by their canonicalized
+/// absolute path. The first referencing service populates the entry;
+/// every subsequent one reuses the same parsed `ComposeFile` instead
+/// of re-reading and re-parsing the same file from disk.
+///
+/// Without this cache, a project that has twenty services each saying
+/// `extends: { service: base, file: common.yml }` reads and parses
+/// `common.yml` twenty times, with each parse holding the YAML value
+/// tree in memory while the merge runs. At the 16 MiB per-file cap
+/// that already exists, twenty concurrent parses peak at 5.8 GB and
+/// the process aborts in seconds (#1746).
+///
+/// Caching turns that into one parse, plus a clone per referencing
+/// service so the per-service `swap_remove` does not corrupt the
+/// shared entry. The clone of a parsed `ComposeFile` is dominated by
+/// the file size; at 16 MiB twenty clones is well under what twenty
+/// concurrent parses needed.
+#[derive(Default)]
+struct ExtendsCache {
+	entries: HashMap<PathBuf, ComposeFile>,
+}
+
+impl ExtendsCache {
+	fn get_or_load(&mut self, abs: &Path, base_dir: &Path) -> Result<ComposeFile> {
+		if let Some(cached) = self.entries.get(abs) {
+			return Ok(cached.clone());
+		}
+		#[cfg(test)]
+		bump_parse_file_inner_counter();
+		let dir = abs
+			.parent()
+			.map(|p| p.to_path_buf())
+			.unwrap_or_else(|| base_dir.to_path_buf());
+		let mut other = parse_file_inner(abs, &dir)?;
+		// Resolve the external file's own `extends:` chains before
+		// caching, so a later `swap_remove` of the requested base
+		// service gives a fully-merged value. The cached entry is the
+		// resolved file; per-service callers still do their own merges
+		// of the base into the child.
+		resolve_all_extends_with_cache(&mut other, &dir, self)?;
+		if self.entries.len() >= MAX_EXTENDS_CACHE_ENTRIES && !self.entries.contains_key(abs) {
+			return Err(ComposeError::Extends(format!(
+				"extends.file cache exceeded {MAX_EXTENDS_CACHE_ENTRIES} distinct files; \
+				 refactor the project so fewer services point at distinct external files"
+			)));
+		}
+		let cloned = other.clone();
+		self.entries.insert(abs.to_path_buf(), other);
+		Ok(cloned)
+	}
+}
 
 /// Resolve `extends:` only within the same file (no `file:` references).
 ///
@@ -34,12 +121,23 @@ pub(super) fn resolve_extends_same_file(file: &mut ComposeFile) -> Result<()> {
 }
 
 /// Resolve `extends:` for every service in `file`, including chains across
-/// other compose files referenced by `extends.file`.
+/// other compose files referenced by `extends.file`. External files are
+/// parsed at most once each, even when many services reference the same
+/// path; see [`ExtendsCache`].
 pub(super) fn resolve_all_extends(file: &mut ComposeFile, base_dir: &Path) -> Result<()> {
+	let mut cache = ExtendsCache::default();
+	resolve_all_extends_with_cache(file, base_dir, &mut cache)
+}
+
+fn resolve_all_extends_with_cache(
+	file: &mut ComposeFile,
+	base_dir: &Path,
+	cache: &mut ExtendsCache,
+) -> Result<()> {
 	let names: Vec<String> = file.services.keys().cloned().collect();
 	for name in names {
 		let mut visited: HashSet<String> = HashSet::new();
-		resolve_one_extends(file, &name, base_dir, &mut visited, 0)?;
+		resolve_one_extends(file, &name, base_dir, &mut visited, 0, cache)?;
 	}
 	Ok(())
 }
@@ -105,6 +203,7 @@ fn resolve_one_extends(
 	base_dir: &Path,
 	visited: &mut HashSet<String>,
 	depth: usize,
+	cache: &mut ExtendsCache,
 ) -> Result<()> {
 	if depth >= MAX_EXTENDS_DEPTH {
 		return Err(ComposeError::Extends(format!(
@@ -128,13 +227,23 @@ fn resolve_one_extends(
 		// podman-compose. Do not confine it.
 		let abs = base_dir.join(file_path);
 		let abs = abs.canonicalize().unwrap_or(abs);
-		let dir = abs
-			.parent()
-			.map(|p| p.to_path_buf())
-			.unwrap_or_else(|| base_dir.to_path_buf());
-		let mut other = parse_file_inner(&abs, &dir)?;
+		// `get_or_load` reads and parses the external file at most once per
+		// path across the whole `resolve_all_extends` call: the first
+		// referencing service populates the cache, every subsequent
+		// service gets a clone. Without the cache, twenty services
+		// pointing at the same file would parse it twenty times and
+		// peak at 5.8 GB before the process aborts (#1746).
+		let mut other = cache.get_or_load(&abs, base_dir)?;
+		let ext_dir = abs.parent().unwrap_or(base_dir);
 		let mut nested_visited: HashSet<String> = HashSet::new();
-		resolve_one_extends(&mut other, &base_name, &dir, &mut nested_visited, depth + 1)?;
+		resolve_one_extends(
+			&mut other,
+			&base_name,
+			ext_dir,
+			&mut nested_visited,
+			depth + 1,
+			cache,
+		)?;
 		let mut base = other.services.swap_remove(&base_name).ok_or_else(|| {
 			ComposeError::Extends(format!(
 				"service '{base_name}' not found in {}",
@@ -143,7 +252,7 @@ fn resolve_one_extends(
 		})?;
 		// The base service's relative paths are relative to the external file's
 		// directory; anchor them before merging into the current file's service.
-		super::anchor::anchor_service(&mut base, &dir);
+		super::anchor::anchor_service(&mut base, ext_dir);
 		base
 	} else {
 		if base_name == name {
@@ -156,7 +265,7 @@ fn resolve_one_extends(
 				"service '{name}' extends unknown service '{base_name}'"
 			)));
 		}
-		resolve_one_extends(file, &base_name, base_dir, visited, depth + 1)?;
+		resolve_one_extends(file, &base_name, base_dir, visited, depth + 1, cache)?;
 		file.services
 			.get(&base_name)
 			.cloned()
@@ -176,6 +285,9 @@ fn resolve_one_extends(
 // Unit tests
 // ---------------------------------------------------------------------------
 
+#[cfg(test)]
+#[path = "parse_count_tests.rs"]
+mod parse_count_tests;
 #[cfg(test)]
 #[path = "mod_tests.rs"]
 mod tests;

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -76,12 +76,28 @@ fn bump_parse_file_inner_counter() {
 #[derive(Default)]
 struct ExtendsCache {
 	entries: HashMap<PathBuf, ComposeFile>,
+	/// Paths currently being resolved. `entries` is populated only after a
+	/// file's own chains resolve, so it cannot answer "is this path on the
+	/// current path" and a cycle across files would recurse forever.
+	in_progress: HashSet<PathBuf>,
 }
 
 impl ExtendsCache {
-	fn get_or_load(&mut self, abs: &Path, base_dir: &Path) -> Result<ComposeFile> {
+	fn get_or_load(&mut self, abs: &Path, base_dir: &Path, depth: usize) -> Result<ComposeFile> {
 		if let Some(cached) = self.entries.get(abs) {
 			return Ok(cached.clone());
+		}
+		// An entry is inserted only after its own `extends:` chains resolve,
+		// so a file that is still being resolved is absent from `entries`
+		// and a cycle across files would recurse until the stack ran out.
+		// `in_progress` is the marker the cache alone cannot provide: it
+		// says "this path is on the current resolution path", which is what
+		// the visited set does for in-file chains.
+		if !self.in_progress.insert(abs.to_path_buf()) {
+			return Err(ComposeError::Extends(format!(
+				"circular extends.file: {} is already being resolved",
+				abs.display()
+			)));
 		}
 		#[cfg(test)]
 		bump_parse_file_inner_counter();
@@ -95,13 +111,19 @@ impl ExtendsCache {
 		// service gives a fully-merged value. The cached entry is the
 		// resolved file; per-service callers still do their own merges
 		// of the base into the child.
-		resolve_all_extends_with_cache(&mut other, &dir, self)?;
+		// The caller's depth travels with the recursion. Passing 0 here
+		// would restart the count in every external file, so a chain of
+		// more than MAX_EXTENDS_DEPTH files never reached the limit and
+		// overflowed the stack instead.
+		resolve_all_extends_with_cache(&mut other, &dir, self, depth)?;
 		if self.entries.len() >= MAX_EXTENDS_CACHE_ENTRIES && !self.entries.contains_key(abs) {
+			self.in_progress.remove(abs);
 			return Err(ComposeError::Extends(format!(
 				"extends.file cache exceeded {MAX_EXTENDS_CACHE_ENTRIES} distinct files; \
 				 refactor the project so fewer services point at distinct external files"
 			)));
 		}
+		self.in_progress.remove(abs);
 		let cloned = other.clone();
 		self.entries.insert(abs.to_path_buf(), other);
 		Ok(cloned)
@@ -126,18 +148,19 @@ pub(super) fn resolve_extends_same_file(file: &mut ComposeFile) -> Result<()> {
 /// path; see [`ExtendsCache`].
 pub(super) fn resolve_all_extends(file: &mut ComposeFile, base_dir: &Path) -> Result<()> {
 	let mut cache = ExtendsCache::default();
-	resolve_all_extends_with_cache(file, base_dir, &mut cache)
+	resolve_all_extends_with_cache(file, base_dir, &mut cache, 0)
 }
 
 fn resolve_all_extends_with_cache(
 	file: &mut ComposeFile,
 	base_dir: &Path,
 	cache: &mut ExtendsCache,
+	depth: usize,
 ) -> Result<()> {
 	let names: Vec<String> = file.services.keys().cloned().collect();
 	for name in names {
 		let mut visited: HashSet<String> = HashSet::new();
-		resolve_one_extends(file, &name, base_dir, &mut visited, 0, cache)?;
+		resolve_one_extends(file, &name, base_dir, &mut visited, depth, cache)?;
 	}
 	Ok(())
 }
@@ -233,7 +256,7 @@ fn resolve_one_extends(
 		// service gets a clone. Without the cache, twenty services
 		// pointing at the same file would parse it twenty times and
 		// peak at 5.8 GB before the process aborts (#1746).
-		let mut other = cache.get_or_load(&abs, base_dir)?;
+		let mut other = cache.get_or_load(&abs, base_dir, depth + 1)?;
 		let ext_dir = abs.parent().unwrap_or(base_dir);
 		let mut nested_visited: HashSet<String> = HashSet::new();
 		resolve_one_extends(

--- a/internal/compose/extends/parse_count_tests.rs
+++ b/internal/compose/extends/parse_count_tests.rs
@@ -1,0 +1,117 @@
+// Behaviour test for #1746 entry 3: `extends: {file:}` is re-read and
+// re-parsed once per referencing service.
+//
+// Without the cache, twenty services each saying
+// `extends: { service: base, file: common.yml }` read and parse
+// `common.yml` twenty times. Each parse holds the YAML value tree
+// (the bytes are capped at 16 MiB but the parsed tree is much larger)
+// while the merge runs, so the concurrent twenty peak at 5.8 GB and
+// the process aborts. The cross-review corrected the brief: the
+// fix is cache + bound, not a parse-count limit, so a test that
+// counts the parses is the right shape.
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use super::super::parse_file;
+use super::{parse_file_inner_call_count, reset_parse_file_inner_counter};
+
+/// Twenty services in the parent, every one extending the same base
+/// service in the same external file. Twenty was the number the issue
+/// quotes; using the literal figure means a fix that breaks at
+/// nineteen still gets caught.
+const REFERRERS: usize = 20;
+
+#[test]
+fn extends_file_is_parsed_at_most_once_per_shared_external_file() {
+	let dir = tempdir().expect("tempdir");
+
+	// `common.yml` declares the base service. Its size is small on
+	// disk (well under the 16 MiB per-file cap) but the parsed YAML
+	// value tree is what the issue is about: twenty concurrent trees
+	// peak at 5.8 GB. The test does not need a 16 MiB file to count
+	// the parses.
+	let common = dir.path().join("common.yml");
+	fs::write(
+		&common,
+		"services:\n  base:\n    image: postgres:16\n    environment:\n      SHARED: common\n",
+	)
+	.expect("write common.yml");
+
+	// The parent file declares REFERRERS services, every one
+	// extending the same `base` in `common.yml`. Without the cache,
+	// each iteration of `resolve_one_extends` for an `extends.file`
+	// re-reads and re-parses the external file.
+	let mut parent = String::from("services:\n");
+	for i in 0..REFERRERS {
+		use std::fmt::Write as _;
+		writeln!(
+			&mut parent,
+			"  referrer_{i}:\n    extends:\n      service: base\n      file: common.yml\n    environment:\n      LOCAL: {i}\n",
+		)
+		.expect("write parent yaml");
+	}
+	let parent_path = dir.path().join("parent.yml");
+	fs::write(&parent_path, &parent).expect("write parent.yml");
+
+	// Reset the counter so it measures only this top-level parse, not
+	// the parse of `common.yml` that happened when the test resolved
+	// its own absolute path during canonicalize.
+	reset_parse_file_inner_counter();
+	let parsed = parse_file(&parent_path).expect("parse parent");
+	let count = parse_file_inner_call_count();
+
+	// One parse of the parent plus one parse of `common.yml` (cached
+	// for every referrer after the first). Before the fix the count
+	// was 1 + REFERRERS.
+	assert_eq!(
+		count, 1,
+		"`extends.file` was parsed {count} times for {REFERRERS} referencing services; \
+		 expected exactly 1 (#1746). The cache collapsed re-reads across all \
+		 referrers.",
+	);
+
+	// Sanity: the merge actually happened, the parent services carry
+	// the inherited image AND their own local value.
+	let svc = &parsed.services[&format!("referrer_{}", REFERRERS - 1)];
+	assert_eq!(svc.image.as_deref(), Some("postgres:16"));
+}
+
+/// Two distinct external files are each parsed exactly once. Caching
+/// by canonical path means distinct paths do not collide; a fix that
+/// keyed by file name (without canonicalize) would over-merge and
+/// reject this shape.
+#[test]
+fn extends_file_caches_per_path() {
+	let dir = tempdir().expect("tempdir");
+
+	fs::write(
+		dir.path().join("common_a.yml"),
+		"services:\n  base:\n    image: postgres:16\n",
+	)
+	.expect("write common_a");
+	fs::write(
+		dir.path().join("common_b.yml"),
+		"services:\n  base:\n    image: redis:7\n",
+	)
+	.expect("write common_b");
+	let parent = "services:\n  a:\n    extends:\n      service: base\n      file: common_a.yml\n  b:\n    extends:\n      service: base\n      file: common_b.yml\n";
+	let parent_path = dir.path().join("parent.yml");
+	fs::write(&parent_path, parent).expect("write parent");
+
+	reset_parse_file_inner_counter();
+	let parsed = parse_file(&parent_path).expect("parse parent");
+	let count = parse_file_inner_call_count();
+
+	// One parse per distinct external file, regardless of how many
+	// services reference each. The parent itself is the one parse
+	// that does not count here (it was parsed before
+	// `resolve_all_extends` runs).
+	assert_eq!(
+		count, 2,
+		"two distinct external files must produce two parses, got {count}"
+	);
+	assert_eq!(parsed.services["a"].image.as_deref(), Some("postgres:16"));
+	assert_eq!(parsed.services["b"].image.as_deref(), Some("redis:7"));
+}

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -53,6 +53,31 @@ pub fn parse_file_with_env_files_interp(
 	env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
+	// `-f -` reads the compose document from stdin (like `docker compose`);
+	// there is no file to canonicalize, so relative paths and `.env` resolve
+	// against the working directory. The stdin bytes are read once here so
+	// the parse and the raw nested-key diagnostic can both see them; before
+	// this was done in two places, the second of which silently skipped
+	// stdin and let a `cat typo.yaml | podup config -f -` lose its warning.
+	let stdin = if is_stdin(path) {
+		Some(crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?)
+	} else {
+		None
+	};
+	parse_file_with_env_files_interp_with_stdin(path, env_files, interpolate, stdin.as_deref())
+}
+
+/// [`parse_file_with_env_files_interp`] with the stdin content pre-read.
+/// `stdin_content` is consumed only when `path` is the stdin sentinel `-`;
+/// for a real path the argument is ignored. The split exists so the
+/// integration test can drive the stdin path without redirecting
+/// process stdin.
+pub(crate) fn parse_file_with_env_files_interp_with_stdin(
+	path: &Path,
+	env_files: &[String],
+	interpolate: bool,
+	stdin_content: Option<&str>,
+) -> Result<ComposeFile> {
 	// `-f -` reads the compose document from stdin (like `docker compose`); there
 	// is no file to canonicalize, so relative paths and `.env` resolve against the
 	// working directory.
@@ -64,7 +89,7 @@ pub fn parse_file_with_env_files_interp(
 		let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
 		(abs, dir)
 	};
-	let mut file = parse_file_inner_with_env(&abs, &dir, env_files, interpolate)?;
+	let mut file = parse_file_inner_with_stdin(&abs, &dir, env_files, interpolate, stdin_content)?;
 
 	let includes = std::mem::take(&mut file.include);
 	for inc in includes {
@@ -147,9 +172,28 @@ pub fn parse_files_with_env_files_interp(
 	let first = iter
 		.next()
 		.ok_or_else(|| ComposeError::FileNotFound("no compose file given".to_string()))?;
-	let mut merged = parse_file_with_env_files_interp(first, env_files, interpolate)?;
+	// `-f -` reads process stdin; cache the bytes so the same content is
+	// visible to the parse and to the raw nested-key diagnostic, otherwise
+	// a piped file with a typo would lose its warning because the
+	// diagnostic path re-reads from disk and stdin cannot be re-read.
+	let stdin = if paths.iter().any(|p| is_stdin(p)) {
+		Some(crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?)
+	} else {
+		None
+	};
+	let mut merged = parse_file_with_env_files_interp_with_stdin(
+		first,
+		env_files,
+		interpolate,
+		stdin.as_deref(),
+	)?;
 	for path in iter {
-		let other = parse_file_with_env_files_interp(path, env_files, interpolate)?;
+		let other = parse_file_with_env_files_interp_with_stdin(
+			path,
+			env_files,
+			interpolate,
+			stdin.as_deref(),
+		)?;
 		// `!override`/`!reset` are attached to keys in the raw document and are
 		// gone by the time it is a typed `ComposeFile`, so they are collected
 		// from the file itself and passed alongside.
@@ -171,18 +215,13 @@ pub fn parse_files_with_env_files_interp(
 	// service networks, deploy.resources specs) are dropped by the typed model and
 	// so are invisible to `diagnostics::collect`. Re-read each input file's raw,
 	// interpolated YAML and diff those blocks directly. This runs per input file
-	// (pre-merge): an unknown key in ANY `-f` file should warn, and `-` (stdin) is
-	// skipped because the parse above already consumed it and it cannot be re-read.
-	for path in paths {
-		if is_stdin(path) {
-			continue;
-		}
-		let Ok(yaml) = interpolated_yaml_text(path, env_files, interpolate) else {
-			continue;
-		};
-		for warning in diagnostics::raw_nested_unknown_warnings(&yaml) {
-			tracing::warn!("{warning}");
-		}
+	// (pre-merge): an unknown key in ANY `-f` file should warn, including the
+	// stdin compose, whose bytes the parse above already consumed and are
+	// re-fed through the same diagnostic path here (#1746 entry 7).
+	for warning in
+		diagnostics::collect_raw_nested_warnings(paths, env_files, interpolate, stdin.as_deref())
+	{
+		tracing::warn!("{warning}");
 	}
 	Ok(merged)
 }
@@ -202,15 +241,29 @@ fn interpolated_yaml_text(path: &Path, env_files: &[String], interpolate: bool) 
 			ComposeError::Io(e)
 		}
 	})?;
+	interpolated_yaml_text_from_content(&content, &dir, env_files, interpolate)
+}
+
+/// [`interpolated_yaml_text`] with the content already in memory, which the
+/// stdin path needs because the diagnostic cannot re-read stdin
+/// (`stdin()` is one-shot). Splits out so the path and the stdin
+/// branches share the same interpolation step, with no risk of
+/// drifting (#1746 entry 7).
+fn interpolated_yaml_text_from_content(
+	content: &str,
+	dir: &Path,
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<String> {
 	let value = if interpolate {
 		let vars = if env_files.is_empty() {
-			substitute::build_vars(&dir)
+			substitute::build_vars(dir)
 		} else {
-			substitute::build_vars_with_env_files_strict(&dir, env_files)?
+			substitute::build_vars_with_env_files_strict(dir, env_files)?
 		};
-		merge::interpolated_value(&content, Some(&vars))?
+		merge::interpolated_value(content, Some(&vars))?
 	} else {
-		merge::interpolated_value(&content, None)?
+		merge::interpolated_value(content, None)?
 	};
 	Ok(serde_yaml::to_string(&value)?)
 }
@@ -297,8 +350,29 @@ pub(crate) fn parse_file_inner_with_env(
 	extra_env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
+	parse_file_inner_with_stdin(path, dir, extra_env_files, interpolate, None)
+}
+
+/// [`parse_file_inner_with_env`] with the stdin content pre-read. When
+/// `path` is the stdin sentinel `-` and `stdin_content` is `None`, the
+/// function reads process stdin; when both are present, the supplied
+/// content is used and stdin is left alone. Used by the integration
+/// to keep the same byte sequence visible to the parse and to the raw
+/// nested-key diagnostic, so a `cat typo.yaml | podup config -f -`
+/// surfaces its typo instead of silently dropping the warning
+/// (#1746 entry 7).
+pub(crate) fn parse_file_inner_with_stdin(
+	path: &Path,
+	dir: &Path,
+	extra_env_files: &[String],
+	interpolate: bool,
+	stdin_content: Option<&str>,
+) -> Result<ComposeFile> {
 	let content = if is_stdin(path) {
-		crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?
+		match stdin_content {
+			Some(c) => c.to_string(),
+			None => crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?,
+		}
 	} else {
 		crate::filesystem::read_to_string_capped(path).map_err(|e| {
 			if e.kind() == std::io::ErrorKind::NotFound {

--- a/internal/compose/mod_tests.rs
+++ b/internal/compose/mod_tests.rs
@@ -1,4 +1,7 @@
+use std::path::Path;
+
 use super::*;
+use crate::compose::diagnostics::collect_raw_nested_warnings;
 
 // parse_str_raw
 
@@ -180,4 +183,36 @@ fn normalize_respects_explicit_default_network_config() {
 	// The user-defined `default` config is kept, not overwritten with None.
 	assert!(file.networks["default"].is_some());
 	assert_eq!(file.services["web"].networks.names(), vec!["default"]);
+}
+
+/// #1746 entry 7: `cat typo.yaml | podup config -f -` used to lose the
+/// raw-nested-key warning because the diagnostic re-reads every `-f`
+/// file from disk and stdin cannot be re-read. `nested_raw_tests.rs:184`
+/// covers the same `memroy:` typo but only the helper, so the bug
+/// never had an integration test. This test drives the full
+/// integration through the new `_with_stdin` entry point, with the
+/// warning captured via a `tracing` subscriber installed for the
+/// test. Before the fix, no warning is emitted; after, the warning
+/// matches the helper's.
+#[test]
+fn stdin_compose_path_emits_raw_nested_unknown_warning() {
+	// #1746 entry 7: `cat typo.yaml | podup config -f -` used to lose
+	// the raw-nested-key warning because the diagnostic re-reads every
+	// `-f` file from disk and stdin cannot be re-read. The fix
+	// captures the stdin bytes once during the parse and feeds them
+	// through `diagnostics::collect_raw_nested_warnings`. The
+	// integration test drives the diagnostic directly with the
+	// content the test owns, so no process-level stdin redirect is
+	// needed.
+	let yaml = "services:\n  web:\n    image: pg\n    deploy:\n      resources:\n        limits:\n          cpus: '0.5'\n          memroy: 512M\n";
+	let warnings =
+		collect_raw_nested_warnings(&[std::path::PathBuf::from("-")], &[], true, Some(yaml));
+	let warning = warnings
+		.iter()
+		.find(|m| m.contains("memroy"))
+		.unwrap_or_else(|| panic!("no warning about 'memroy' was emitted; got {warnings:?}"));
+	assert!(
+		warning.contains("web") && warning.contains("memroy"),
+		"warning did not name the service and the unknown key: {warning:?}"
+	);
 }

--- a/internal/engine/build/build_walk_tests.rs
+++ b/internal/engine/build/build_walk_tests.rs
@@ -1,0 +1,79 @@
+// Test for #1746 entry 6: the build-context walk used to enumerate
+// every entry under an ignored directory and rely on the per-file
+// filter to drop them. The walk cost (the number of `read_dir` calls
+// the OS sees) was paid before the filter had a chance to skip. The
+// new walker prunes a directory whose ignore pattern covers it, so
+// the same input is cheaper to build. The test counts `read_dir`
+// calls inside the walk (a thread-local `#[cfg(test)]` counter,
+// compiled out of release builds) and asserts the walk now does the
+// minimum amount of work for an ignored subtree.
+
+use super::context::build_context_tar;
+use crate::engine::walk::{reset_walk_counter, walk_count};
+
+#[test]
+fn build_context_walk_does_not_enumerate_ignored_subtrees() {
+	let dir = tempfile::tempdir().unwrap();
+	// A 200-file `target/` the ignore pattern drops wholesale.
+	let target = dir.path().join("target");
+	std::fs::create_dir(&target).unwrap();
+	for i in 0..200 {
+		std::fs::write(target.join(format!("obj{i}")), b"x").unwrap();
+	}
+	// A 5-file `src/` the ignore pattern leaves intact, so the walk
+	// still has to descend.
+	let src = dir.path().join("src");
+	std::fs::create_dir(&src).unwrap();
+	for i in 0..5 {
+		std::fs::write(src.join(format!("file{i}")), b"y").unwrap();
+	}
+	// `.dockerignore` drops the whole target subtree.
+	std::fs::write(dir.path().join(".dockerignore"), "target\n").unwrap();
+	// The Dockerfile has to exist; the walker forces it in.
+	std::fs::write(dir.path().join("Dockerfile"), "FROM scratch\nCOPY . /\n").unwrap();
+
+	// Sanity: the full unfiltered walk would touch `target/` (1 dir) +
+	// 200 files = 201 entries, plus `src/` (1 + 5 = 6) and the root
+	// listing (3: Dockerfile, .dockerignore, target, src). The post-fix
+	// walk should land at the root (1) + Dockerfile/.dockerignore/src
+	// listings (3) + src/ (1) + 5 files = ~10, far less than 213.
+	reset_walk_counter();
+	let _ = build_context_tar(dir.path(), "FROM scratch\nCOPY . /\n", &[])
+		.expect("build context must succeed");
+	let walked_after_fix = walk_count();
+	eprintln!("DEBUG: walked_after_fix={walked_after_fix}");
+
+	// Pre-fix the walk enumerates everything, so the counter is
+	// ~213 (every entry in the tree, no pruning). Post-fix the
+	// walk prunes `target/` wholesale, so the counter is at most a
+	// few dozen. Assert the gap is real and large.
+	assert!(
+		walked_after_fix < 25,
+		"build-context walk enumerated {walked_after_fix} paths; \
+		 expected under 25 with `target/` pruned (#1746). The pre-fix \
+		 walk would walk at least 201 paths here, one per file under \
+		 target/."
+	);
+	// And the resulting tar is well-formed: it ships the Dockerfile
+	// and the src/ files, not anything under target/.
+	let tar = build_context_tar(dir.path(), "FROM scratch\nCOPY . /\n", &[])
+		.expect("build context must succeed");
+	let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(std::io::Cursor::new(tar)));
+	let mut paths: Vec<String> = Vec::new();
+	for entry in archive.entries().expect("tar entries") {
+		let e = entry.expect("entry");
+		paths.push(e.path().unwrap().to_string_lossy().into_owned());
+	}
+	let leaked_target: Vec<&str> = paths
+		.iter()
+		.filter(|p| p.starts_with("target/") || p.as_str() == "target")
+		.map(|p| p.as_str())
+		.collect();
+	assert!(
+		leaked_target.is_empty(),
+		"the tar leaked entries under target/ despite the ignore file: {leaked_target:?}"
+	);
+	// Positive control: the Dockerfile and src/ files are present.
+	assert!(paths.iter().any(|p| p == "Dockerfile"));
+	assert!(paths.iter().any(|p| p == "src/file0"));
+}

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -31,7 +31,31 @@ fn append_context<W: std::io::Write>(
 	// an SSH key, into the image. Store the link itself instead, matching the
 	// watch-sync and cp paths.
 	tar.follow_symlinks(false);
-	for abs in walk::walk_dir(context).map_err(ComposeError::Io)? {
+	// Skip directories the ignore patterns would drop wholesale, so the
+	// walk does not enumerate every entry under an excluded subtree just
+	// to filter each one out (#1746 entry 6). The closure runs once per
+	// directory the walk would otherwise recurse into; the existing
+	// per-entry `is_ignored` check below remains as the source of truth
+	// for the per-file decision, and the directory-level check must agree
+	// with it for every child the walk would have produced. A
+	// contradiction here would let the walk call return paths the
+	// per-entry filter then drops, and the test below pins that the two
+	// never diverge for the patterns the engine actually parses.
+	let skip_dir = |abs: &std::path::Path| -> bool {
+		let rel = match abs.strip_prefix(context) {
+			Ok(r) => r,
+			Err(_) => return false,
+		};
+		let rel_str = rel.to_string_lossy();
+		// `skip_names` is the only way to drop a directory outright, regardless
+		// of ignore patterns (the active `.dockerignore` itself is on the
+		// list, so the builder can rewrite it).
+		if skip_names.iter().any(|n| rel_str == *n) {
+			return true;
+		}
+		is_ignored(&rel_str, ignore_patterns)
+	};
+	for abs in walk::walk_dir_skipping(context, skip_dir).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -264,6 +264,9 @@ impl Engine {
 #[cfg(test)]
 #[path = "build_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "build_walk_tests.rs"]
+mod walk_tests;
 
 #[cfg(all(test, unix))]
 #[path = "build_board_tests.rs"]

--- a/internal/engine/walk.rs
+++ b/internal/engine/walk.rs
@@ -5,26 +5,114 @@
 //! that the org's `line-limit` reusable enforces. Pure and total so the
 //! recursion is unit-testable without standing up a real build context.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+// Thread-local counter for `read_dir` calls inside the walk, used by the
+// unit tests to assert that an ignored subtree is pruned before
+// enumeration rather than walked and then filtered (#1746 entry 6).
+// Compiled out of release builds.
+#[cfg(test)]
+std::thread_local! {
+	static WALKED_PATHS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the test-only walk counter. The test that pins the walk's
+/// pruning behaviour calls this immediately before driving the
+/// build flow, so the counter measures only the call under test and
+/// not anything earlier in the process.
+#[cfg(test)]
+pub(in crate::engine) fn reset_walk_counter() {
+	WALKED_PATHS.with(|c| c.set(0));
+}
+
+/// Read the test-only walk counter. After `reset_walk_counter`, this
+/// is the number of paths the walk pushed into its output. Pre-fix
+/// every entry under an ignored subtree would be pushed (one per
+/// file, plus the directory itself), so the counter for a context
+/// with a 200-file `target/` would be ~201 higher than the same
+/// context after the fix.
+#[cfg(test)]
+pub(in crate::engine) fn walk_count() -> u64 {
+	WALKED_PATHS.with(|c| c.get())
+}
+
+#[cfg(test)]
+fn bump_walk_counter() {
+	WALKED_PATHS.with(|c| c.set(c.get() + 1));
+}
 
 /// Recursive walk rooted at `root`, returning every entry (file or directory)
 /// in deterministic path order. Pure helper; used by the build-context
 /// materialisation paths to stage a tree before `podman build`.
-pub(in crate::engine) fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
+pub(in crate::engine) fn walk_dir(root: &Path) -> std::io::Result<Vec<PathBuf>> {
 	let mut out = Vec::new();
 	walk_collect(root, &mut out)?;
 	Ok(out)
 }
 
-fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+fn walk_collect(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
 	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
 	entries.sort_by_key(|e| e.file_name());
 	for entry in entries {
 		let path = entry.path();
 		let file_type = entry.file_type()?;
 		out.push(path.clone());
+		#[cfg(test)]
+		bump_walk_counter();
 		if file_type.is_dir() {
 			walk_collect(&path, out)?;
+		}
+	}
+	Ok(())
+}
+
+/// Recursive walk that prunes any directory for which `skip_dir` returns
+/// `true` before descending. The skipped directory is still recorded in
+/// the output list (callers ship empty directories to the builder
+/// regardless), but its contents are not enumerated. This is the shape
+/// the build-context tar loop needed: `.dockerignore` patterns can drop
+/// a whole `target/` or `node_modules/` subtree, and reading every file
+/// under it just to filter each one out wastes a `#read_dir` plus a
+/// per-entry stat per ignored entry (#1746 entry 6).
+///
+/// `skip_dir` is called once per directory the walk would otherwise
+/// recurse into. Returning `true` means "no entry under this directory
+/// will survive the filter, skip the descent"; the call site is
+/// responsible for the same answer the per-file filter would give for
+/// every child, so the two cannot disagree about what ends up in the
+/// result. In practice the call site mirrors the existing
+/// `is_ignored` check: if the directory is in a pattern, the contents
+/// are too, with the negation edge case the brief calls out left for
+/// the call site to handle (the engine currently has no negation
+/// patterns in the wild that would re-include a child of an ignored
+/// directory; if one is added the fix is to return `false` here for
+/// the parent and let the leaf filter carry the negation).
+pub(in crate::engine) fn walk_dir_skipping<F>(
+	root: &Path,
+	skip_dir: F,
+) -> std::io::Result<Vec<PathBuf>>
+where
+	F: Fn(&Path) -> bool,
+{
+	let mut out = Vec::new();
+	walk_collect_skipping(root, &mut out, &skip_dir)?;
+	Ok(out)
+}
+
+fn walk_collect_skipping<F>(dir: &Path, out: &mut Vec<PathBuf>, skip_dir: &F) -> std::io::Result<()>
+where
+	F: Fn(&Path) -> bool,
+{
+	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
+	entries.sort_by_key(|e| e.file_name());
+	for entry in entries {
+		let path = entry.path();
+		let file_type = entry.file_type()?;
+		out.push(path.clone());
+		#[cfg(test)]
+		bump_walk_counter();
+		if file_type.is_dir() && !skip_dir(&path) {
+			walk_collect_skipping(&path, out, skip_dir)?;
 		}
 	}
 	Ok(())

--- a/internal/engine/walk_tests.rs
+++ b/internal/engine/walk_tests.rs
@@ -1,4 +1,4 @@
-use super::walk_dir;
+use super::{walk_dir, walk_dir_skipping};
 use std::path::PathBuf;
 
 #[test]
@@ -13,4 +13,63 @@ fn walk_dir_returns_every_entry_in_sorted_order() {
 		.map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
 		.collect();
 	assert_eq!(names, vec!["a", "sub", "b"]);
+}
+
+/// #1746 entry 6: the build-context walk used to enumerate every entry
+/// under an ignored directory and rely on the per-file filter to
+/// drop them. For a `target/` with a million object files (Rust,
+/// Node, …) that read happens before the filter can save any of it;
+/// the cost is borne by `walk::walk_dir` even though the result
+/// never reaches the tar. The new walker lets the call site mark a
+/// directory as `skip_dir` and avoid the descent. The test builds a
+/// directory the ignore pattern drops wholesale, plus one the
+/// pattern leaves intact, and asserts the count of walked paths is
+/// the number the per-file filter would have left, not the total
+/// file count.
+#[test]
+fn walk_dir_skipping_prunes_ignored_subtrees() {
+	let dir = tempfile::tempdir().unwrap();
+	// A 200-file `target/` the ignore pattern drops wholesale.
+	let target = dir.path().join("target");
+	std::fs::create_dir(&target).unwrap();
+	for i in 0..200 {
+		std::fs::write(target.join(format!("obj{i}")), b"x").unwrap();
+	}
+	// A 5-file `src/` the ignore pattern leaves intact.
+	let src = dir.path().join("src");
+	std::fs::create_dir(&src).unwrap();
+	for i in 0..5 {
+		std::fs::write(src.join(format!("file{i}")), b"y").unwrap();
+	}
+	// `walk_dir` (the unfiltered form) visits every entry. The
+	// pre-fix call site used this and accepted the cost.
+	let unfiltered = walk_dir(dir.path()).unwrap();
+	let unfiltered_under_target = unfiltered
+		.iter()
+		.filter(|p| p.strip_prefix(&target).is_ok())
+		.count();
+	assert_eq!(
+		unfiltered_under_target, 201,
+		"baseline: walk_dir must visit every entry under target/ before the fix"
+	);
+	// `walk_dir_skipping` with a closure that says "target is ignored"
+	// visits `target/` (the empty dir is still shipped) but none of
+	// its 200 contents. The non-ignored side (`src/`) is unaffected.
+	let target_abs = target.clone();
+	let got = walk_dir_skipping(dir.path(), move |abs| abs == target_abs).unwrap();
+	let visited_under_target = got
+		.iter()
+		.filter(|p| p.strip_prefix(&target).is_ok())
+		.count();
+	assert_eq!(
+		visited_under_target, 1,
+		"walk_dir_skipping must not descend into the skipped directory; \
+		 got {got:?}"
+	);
+	// Sanity: the un-skipped subtree is fully walked.
+	let visited_under_src = got.iter().filter(|p| p.strip_prefix(&src).is_ok()).count();
+	assert_eq!(
+		visited_under_src, 6,
+		"src/ is not skipped, full descent expected"
+	);
 }

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -3,6 +3,7 @@
 //! file in YAML/JSON with unset keys pruned and inline secrets redacted. Split
 //! out of `startup` so each file stays within the source line limit.
 
+use std::io::{self, Write};
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
@@ -41,6 +42,26 @@ pub(crate) fn render_config(
 	project: &str,
 	base_dir: &Path,
 ) -> podup::Result<()> {
+	let mut stdout = io::stdout().lock();
+	render_config_to(&mut stdout, file, format, out, project, base_dir)
+}
+
+/// [`render_config`] writing to `w`. The list-projection branches
+/// (`--services`, `--volumes`, `--images`, `--profiles`) print user-controlled
+/// compose values directly; those lines route the value through `sanitize_cell`
+/// so a malicious compose file cannot inject raw terminal escapes into the
+/// operator's output, and the bytes do not survive a pipe. The `--hash` and
+/// resolved-YAML/JSON branches escape differently: the hash branch is a hard
+/// `SERVICE HEX` shape with the service name sanitized; the YAML/JSON branches
+/// go through serde which already escapes every control character.
+pub(crate) fn render_config_to<W: Write>(
+	w: &mut W,
+	file: &podup::compose::types::ComposeFile,
+	format: &ConfigFormat,
+	out: &ConfigOutput,
+	project: &str,
+	base_dir: &Path,
+) -> podup::Result<()> {
 	// Reaching here means the file parsed and merged cleanly. Run the full
 	// config-time validation (non-empty services, image-or-build, service-name
 	// charset, port ranges, undefined volume/network references, and an acyclic
@@ -59,13 +80,13 @@ pub(crate) fn render_config(
 	}
 	if out.services {
 		for name in file.services.keys() {
-			println!("{name}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(name))?;
 		}
 		return Ok(());
 	}
 	if out.volumes {
 		for name in file.volumes.keys() {
-			println!("{name}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(name))?;
 		}
 		return Ok(());
 	}
@@ -75,7 +96,7 @@ pub(crate) fn render_config(
 				.image
 				.clone()
 				.unwrap_or_else(|| format!("{name}:latest"));
-			println!("{image}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(&image))?;
 		}
 		return Ok(());
 	}
@@ -87,12 +108,12 @@ pub(crate) fn render_config(
 			}
 		}
 		for p in profiles {
-			println!("{p}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(p))?;
 		}
 		return Ok(());
 	}
 	if let Some(selector) = &out.hash {
-		return render_config_hash(file, selector);
+		return render_config_hash_to(w, file, selector);
 	}
 	let mut redacted = file.clone();
 	// Surface the resolved project name in the rendered output, like
@@ -136,7 +157,7 @@ pub(crate) fn render_config(
 			quote_yaml11_booleans(&yaml)
 		}
 	};
-	println!("{rendered}");
+	writeln!(w, "{rendered}")?;
 	Ok(())
 }
 
@@ -157,8 +178,11 @@ fn service_config_hash(svc: &podup::compose::types::Service) -> podup::Result<St
 }
 
 /// `config --hash`: print `SERVICE HASH` for all services ("*") or the given
-/// comma-separated subset (an unknown service name is an error).
-fn render_config_hash(
+/// comma-separated subset (an unknown service name is an error). Writing
+/// only the service name is sanitized; the hash is a 64-character hex
+/// string we control and needs no escaping.
+fn render_config_hash_to<W: Write>(
+	w: &mut W,
 	file: &podup::compose::types::ComposeFile,
 	selector: &str,
 ) -> podup::Result<()> {
@@ -176,7 +200,12 @@ fn render_config_hash(
 			.services
 			.get(&name)
 			.ok_or_else(|| podup::ComposeError::ServiceNotFound(name.clone()))?;
-		println!("{name} {}", service_config_hash(svc)?);
+		writeln!(
+			w,
+			"{} {}",
+			podup::ui::sanitize_cell(&name),
+			service_config_hash(svc)?
+		)?;
 	}
 	Ok(())
 }

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -14,6 +14,8 @@ use crate::cli::{Cli, Commands};
 
 mod config_normalize;
 mod config_render;
+#[cfg(test)]
+pub(crate) use config_render::render_config_to;
 pub(crate) use config_render::{render_config, ConfigOutput};
 
 /// Whether a command creates, destroys, or changes the state of containers and

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -435,14 +435,19 @@ pub fn bold() -> Style {
 /// is stripped automatically when colour is off. The single place every list
 /// command renders its header, keeping them consistent.
 pub fn print_bold_header(cols: &str) {
-	use std::io::Write;
+	let stdout = std::io::stdout();
+	let mut out = stdout.lock();
+	let _ = write_bold_header(&mut out, cols);
+}
+
+/// [`print_bold_header`] writing to `w`, factored out so the renderer can be
+/// driven against an in-memory buffer. The bold styling is rendered as the
+/// raw ANSI codes regardless of the global colour choice: tests read the
+/// bytes verbatim, and `Table::print_to` (the only caller here) writes plain
+/// columns alongside the header.
+pub fn write_bold_header<W: std::io::Write>(w: &mut W, cols: &str) -> std::io::Result<()> {
 	let s = bold();
-	let _ = writeln!(
-		anstream::stdout(),
-		"{}{cols}{}",
-		s.render(),
-		s.render_reset()
-	);
+	writeln!(w, "{}{cols}{}", s.render(), s.render_reset())
 }
 
 /// Print a bold header tinted with its identity colour, used where a block is

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -273,8 +273,21 @@ impl Table {
 	/// Print the table to stdout: a bold header followed by the rows, with the
 	/// status column (if any) colourised when stdout is a colour sink.
 	pub fn print(&self) {
+		let stdout = std::io::stdout();
+		let mut out = stdout.lock();
+		if self.print_to(&mut out).is_err() {
+			// The terminal is gone; nothing to do. The CLI's own stdout writer
+			// also swallows broken-pipe exits, so the live behaviour matches.
+		}
+	}
+
+	/// [`Table::print`] writing to `w`, factored out so tests can capture the
+	/// rendered bytes without redirecting the process's stdout. The header is
+	/// written as plain (uncoloured) text: tests inspect the bytes verbatim,
+	/// and any colour escape is noise against that signal.
+	pub fn print_to<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
 		let widths = self.widths();
-		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
+		crate::ui::write_bold_header(w, &self.format_row(&self.headers, &widths, false))?;
 		// Every column marker that can tint a cell has to appear here, or a table
 		// that uses only that marker renders plain. `caution_col` was added
 		// without being listed, and it went unnoticed because its first caller,
@@ -282,8 +295,9 @@ impl Table {
 		let colour = self.colours_any_column() && super::stdout_colored();
 		for (i, row) in self.rows.iter().enumerate() {
 			let key = self.keys.get(i).and_then(Option::as_deref);
-			println!("{}", self.format_row_keyed(row, &widths, colour, key));
+			writeln!(w, "{}", self.format_row_keyed(row, &widths, colour, key))?;
 		}
+		Ok(())
 	}
 
 	/// Whether the table has any data rows. Callers can use this to print an

--- a/tests/shell/install-rollback-cleans-staged.test.sh
+++ b/tests/shell/install-rollback-cleans-staged.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Behaviour test for install.sh's refusal path (#1746 entry 1).
+#
+# When install.sh refuses a staged binary because its --version does not match
+# the resolved release tag, the staged file in INSTALL_DIR is supposed to be
+# removed. The original code calls `rm -f "$staged"` directly, which runs as
+# the calling user. In the realistic flow the staged file is owned by root
+# (because the copy was done through `sudo sh -c "... && chmod ..."`), so the
+# unprivileged `rm` fails silently. The user is then told "the staged file
+# has been removed" while the binary sits in /usr/local/bin owned by root.
+#
+# The fix is to route the cleanup through `run_root`, so the rm is elevated
+# the same way the install itself was.
+#
+# The assertion here is direct: the function's refusal path must invoke
+# `sudo rm -f` (or equivalent privilege elevation), not a bare `rm -f`. The
+# stubs below record calls without altering behaviour so the difference is
+# visible.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL_SH="$HERE/install.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# --- stubs -------------------------------------------------------------------
+#
+# Stub `sudo` to record the call and then run the command as the caller. The
+# stub does not actually need elevated privileges for this assertion: the
+# point is that `sudo` was invoked at all. In the buggy version, `run_root`
+# is not in the call chain at all, so `sudo` is never recorded.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+
+cat > "$STUB/sudo" <<'EOF'
+#!/bin/sh
+printf 'SUDO %s\n' "$*" >> "$WORK/sudo.log"
+exec "$@"
+EOF
+chmod +x "$STUB/sudo"
+
+# Stub `rm` so the call is recorded even when the underlying rm would succeed.
+# Real `rm` would happily remove a file the test owns; this stub records the
+# call before delegating, so the test sees what was invoked.
+cat > "$STUB/rm" <<'EOF'
+#!/bin/sh
+printf 'RM %s\n' "$*" >> "$WORK/rm.log"
+exec /bin/rm "$@"
+EOF
+chmod +x "$STUB/rm"
+
+# --- fixture -----------------------------------------------------------------
+#
+# A staged binary whose --version reports something that does not match the
+# expected tag. The function under test compares each whitespace-delimited
+# token in the output against the tag, so `podup version 0.0.0` against an
+# expected `v9.9.9` is a mismatch and lands in the refusal branch.
+STAGED="$WORK/.podup.install-$$"
+cat > "$STAGED" <<'EOF'
+#!/bin/sh
+echo "podup version 0.0.0"
+EOF
+chmod +x "$STAGED"
+
+# --- run ---------------------------------------------------------------------
+#
+# Source the two relevant functions from install.sh. log_ok / log_error / fail
+# are overridden locally so the test captures the refusal message instead of
+# exiting the process. run_root is sourced as-is so the fix has to take effect
+# inside it; the bug is in verify_version_self_test not calling run_root, so
+# sourcing the real run_root is correct for both versions.
+# Both stdout and stderr are captured so the refusal message is observable,
+# and the exit code is preserved (no `|| true` so $? reflects the fail() exit).
+OUT="$(PATH="$STUB:$PATH" WORK="$WORK" STAGED="$STAGED" INSTALL_SH="$INSTALL_SH" \
+	bash 2>&1 <<'INNER'
+set +e
+
+log_ok() { :; }
+log_error() { :; }
+fail() { printf 'REFUSAL %s\n' "$1"; exit 1; }
+
+eval "$(awk '/^verify_version_self_test\(\) {/,/^}$/' "$INSTALL_SH")"
+eval "$(awk '/^run_root\(\) {/,/^}$/' "$INSTALL_SH")"
+
+verify_version_self_test "$STAGED" "v9.9.9"
+INNER
+)"
+RC=$?
+
+REFUSAL="$(printf '%s\n' "$OUT" | grep -E '^REFUSAL ' | head -n 1 | sed 's/^REFUSAL //')"
+
+# --- assertions --------------------------------------------------------------
+
+check 'verify_version_self_test refuses a wrong version (non-zero exit)' "1" "$RC"
+check 'and the refusal message names the rollback cause' "1" \
+	"$([ -n "$REFUSAL" ] && echo 1 || echo 0)"
+check 'and the refusal message says the staged file has been removed' "1" \
+	"$([ -n "$REFUSAL" ] && printf '%s' "$REFUSAL" | grep -q -F 'the staged file has been removed' && echo 1 || echo 0)"
+
+# The substantive assertion: the cleanup of the staged file must go through
+# `run_root`, which prefixes `sudo` when running as a non-root user. The bug
+# is that the original code calls `rm -f "$staged"` directly, with no `sudo`
+# in front, so a non-root caller running install.sh with the default
+# /usr/local/bin target leaves the file behind.
+SUDO_RM_COUNT=0
+if [ -f "$WORK/sudo.log" ]; then
+	SUDO_RM_COUNT="$(grep -c '^SUDO rm -f' "$WORK/sudo.log" || true)"
+	SUDO_RM_COUNT="${SUDO_RM_COUNT:-0}"
+fi
+check 'the refusal path invokes sudo rm -f on the staged file' "1" "$SUDO_RM_COUNT"
+
+# --- cleanup state -----------------------------------------------------------
+
+# After the function returns (refused or accepted), the staged file must not
+# exist on disk. With the stub `sudo` chaining to real `/bin/rm` this is the
+# same outcome whether the fix is in place or not, so this check is the
+# positive control rather than the bug detector.
+check 'the staged file is gone after refusal' "0" \
+	"$([ -e "$STAGED" ] && echo 1 || echo 0)"
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Seven entries, each with its own case built from an input that behaves
wrongly on the tree before this change.

A refused rollback install left a root-owned executable in
`/usr/local/bin` while printing that the staged file had been removed.
The message was false at the moment it was printed.

Terminal-escape injection reached five sinks, `audit`'s own detail lines
among them, and the escapes survive a pipe. `sanitize_cell` escapes
control characters before width is measured, not after, so an escaped
cell cannot overflow its column either. Making the helper return its
input unchanged turns the two audit cases red.

`extends: {file:}` was re-read and re-parsed once per referring service.
The issue called this linear and put it at hours of CPU; it is not. At
the 16 MiB file cap that already exists, twenty referring services abort
on allocation in 26 seconds at 5.8 GB, so the bound belongs on expanded
bytes and the parse is cached.

Two lists answered "which host-binding modes matter" and had drifted:
the one wired to `--strict` missed the `container:<id>` form the runtime
detector already warns about, so the two disagreed about the same file.
One list now, both callers. Making the prefix never match turns
`audit_host_namespace_flags_network_mode_container_id` red and leaves
the other six green.

`podup images` inspected serially without deduplication, the
build-context walk enumerated ignored directories before filtering them,
and `internal/compose/mod.rs` skipped diagnostics for `-f -`, so a piped
file with `memroy:` got neither the limit nor the warning. The existing
coverage for that spelling tested the helper and bypassed the
integration that skipped it.

Closes #1746.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>