### PR TITLE
fix(quadlet): quote the volume driver option too

### DIFF
--- a/internal/quadlet/tests/fields_resources.rs
+++ b/internal/quadlet/tests/fields_resources.rs
@@ -226,6 +226,78 @@ services:
 }
 
 #[test]
+fn volume_driver_opt_cannot_smuggle_extra_flags() {
+	// The `.volume` unit routes unrecognised driver options through
+	// `PodmanArgs=` too, and that site was missed when the container ones
+	// were fixed for #1734: the sweep stopped at the `.container` unit.
+	// These are `podman volume create` flags rather than `podman run`
+	// flags, so the blast radius differs, but the mechanism is identical.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    volumes:
+      - data:/data
+volumes:
+  data:
+    driver_opts:
+      arbitrary: "value --label injected=yes"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let v = &unit_named(&out, "p-data.volume").contents;
+	assert_argv_has_no_token(v, "--label");
+	assert_argv_has_no_token(v, "injected=yes");
+}
+
+#[test]
+fn volume_driver_opt_key_cannot_smuggle_extra_flags() {
+	// Quoting only the value leaves the same hole on the other side of the
+	// `=`. The key is attacker-controlled too: it is a YAML mapping key the
+	// compose file chooses.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    volumes:
+      - data:/data
+volumes:
+  data:
+    driver_opts:
+      "k --label injected=yes": v
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let v = &unit_named(&out, "p-data.volume").contents;
+	assert_argv_has_no_token(v, "--label");
+}
+
+#[test]
+fn volume_driver_opt_doubles_the_systemd_specifier() {
+	// `PodmanArgs=` skips `escape_unit_value`, which is what doubles `%`.
+	// An undoubled `%h` is expanded by systemd into the operator's home,
+	// so the quoting helper has to do it on this path too, on both halves.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    volumes:
+      - data:/data
+volumes:
+  data:
+    driver_opts:
+      "pcent%h": "%h/evil"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let v = &unit_named(&out, "p-data.volume").contents;
+	assert!(
+		v.contains("%%h") && !v.contains("=\"%h"),
+		"the specifier must be doubled on both halves, in:\n{v}"
+	);
+}
+
+#[test]
 fn apparmor_profile_cannot_smuggle_extra_flags() {
 	// The apparmor arm routes through PodmanArgs too (`AppArmor=` would be
 	// dropped by Quadlet). A hostile profile like

--- a/internal/quadlet/tests/network_volume.rs
+++ b/internal/quadlet/tests/network_volume.rs
@@ -153,8 +153,17 @@ volumes:
 	assert!(vol.contains("Type=nfs"), "in:\n{vol}");
 	assert!(vol.contains("Device=:/exports"), "in:\n{vol}");
 	assert!(vol.contains("Options=addr=10.0.0.1,rw"), "in:\n{vol}");
-	// An option with no dedicated key falls back to PodmanArgs=--opt.
-	assert!(vol.contains("PodmanArgs=--opt custom=extra"), "in:\n{vol}");
+	// An option with no dedicated key falls back to PodmanArgs=--opt. The
+	// value is quoted (#1734): systemd consumes the quotes, so Podman's own
+	// generator still builds `--opt custom=extra`, and a value carrying
+	// whitespace stays one argv element instead of becoming extra flags.
+	// The assertion is on the argv rather than the unit text for that
+	// reason: the unit text is what looked correct while the bug was live.
+	assert_eq!(
+		crate::quadlet::tests::podman_argv::podman_argv_from_unit(vol),
+		vec!["--opt", "custom=extra"],
+		"in:\n{vol}"
+	);
 }
 
 #[test]

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -2,7 +2,9 @@
 
 use crate::compose::types::VolumeConfig;
 
-use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{
+	owner_marker, quote_podman_arg_value, sorted_label_pairs, unit_stem, QuadletUnit, Section,
+};
 
 /// Build the `.volume` unit for one declared named volume. Emits a single
 /// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
@@ -30,7 +32,23 @@ pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfi
 				"type" => vol.add("Type", val),
 				"device" => vol.add("Device", val),
 				"o" => vol.add("Options", val),
-				_ => vol.add("PodmanArgs", format!("--opt {key}={val}")),
+				// Quoted for the same reason the container sites are (#1734):
+				// `PodmanArgs=` is exempt from `escape_unit_value`, so an
+				// unquoted value here smuggles extra `podman volume create`
+				// flags. This site was missed when the container sites were
+				// fixed, because the search stopped at the `.container` unit.
+				// Both halves. Quoting only the value leaves the same hole on
+				// the other side of the `=`: a key carrying whitespace splits
+				// into extra flags, and a key carrying `%` is expanded by
+				// systemd. `--opt "k"="v"` is one argv element either way.
+				_ => vol.add(
+					"PodmanArgs",
+					format!(
+						"--opt {}={}",
+						quote_podman_arg_value(&key),
+						quote_podman_arg_value(&val)
+					),
+				),
 			}
 		}
 		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {


### PR DESCRIPTION
#1734 quoted the seven `PodmanArgs=` interpolations in the container and
build units and claimed the sweep was complete. It was not: the `.volume`
unit routes an unrecognised `driver_opts` key through `PodmanArgs=` as
well, and that site kept interpolating raw. An independent verification
pass of the landed fixes found it, and I reproduced it:

    volumes:
      data:
        driver_opts:
          arbitrary: "value --label injected=yes"

    PodmanArgs=--opt arbitrary=value --label injected=yes

These are `podman volume create` flags rather than `podman run` flags, so
the blast radius is smaller than the original finding, but the mechanism
is identical and the claim that every interpolated value was covered was
false. The sweep stopped at the `.container` unit because that is where
the reported input landed.

The remaining three interpolations are `cpu_shares`, `cpu_quota` and
`cpu_period`, typed `u64`/`i64`, so no string reaches them. That is now
the whole set.

An existing case asserted the unit text, `PodmanArgs=--opt custom=extra`,
which the quoting changes. Measured against Podman 5.7.0's own generator,
the quotes are consumed by systemd and it still builds
`--opt custom=extra`, so the behaviour is unchanged and only the text
moved. That assertion now reads the argv instead, for the reason #1734
gave for its own tests: the unit text is what looked correct for the
whole life of the bug.

Reverting the quoting turns the new case red on its own.