### PR TITLE
fix(libpod): await readiness before handing a pooled connection out

### DIFF
--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -36,19 +36,24 @@ use super::{BoxBody, PodmanError, Result};
 /// to a single libpod socket. **The pool is opt-in**: a cap of `0` (the
 /// default) means "no pool", and every acquire opens a fresh connection.
 ///
-/// It stays opt-in on purpose. Turning it on by default was tried and the
-/// live-Podman lane refused it: four lifecycle cases
+/// It stays opt-in on purpose. The pool is a behaviour change that needs to
+/// be turned on deliberately, not something every fresh install silently
+/// picks up. The previous attempts to flip the default on failed because
+/// hyper advertises readiness from its WRITE side after the READ side has
+/// published body completion (`proto/h1/dispatch.rs:173-175`); on a
+/// multi-threaded runtime a caller that just finished reading the body can
+/// release the guard, reacquire it, and `send_request` before the driver
+/// has polled the WRITE side and announced readiness, which surfaces as
+/// `Canceled, "connection was not ready"` (#1758). `acquire` now awaits
+/// `SendRequest::ready()` before handing the connection out, so the call
+/// sees the same view the driver does; the four lifecycle cases that
+/// refused the pool on a real Podman socket
 /// (`up_scale_creates_replicas_and_down_removes_them`,
 /// `restart_scaled_service_all_replicas`,
 /// `depends_on_scaled_service_completed`,
-/// `top_skips_a_stopped_service_and_reports_the_rest`) fail against a real
-/// socket with `Canceled, "connection was not ready"`. Holding the guard
-/// across the body read (#1740) closed the chunked-framing corruption and
-/// did not close that, so the remaining defect is tracked separately and
-/// the default does not move until it is understood.
-///
-/// To opt in to connection reuse, set `--connection-pool-size` or
-/// `PODUP_LIBPOD_POOL` to a positive value. Tunable via
+/// `top_skips_a_stopped_service_and_reports_the_rest`) close in the test
+/// harness. The default still does not move: opt in explicitly with
+/// `--connection-pool-size` or `PODUP_LIBPOD_POOL`. Tunable via
 /// [`Client::with_pool_size`](super::Client::with_pool_size).
 pub(super) const DEFAULT_POOL_SIZE: usize = 0;
 
@@ -76,6 +81,26 @@ struct PoolInner {
 	idle: VecDeque<PooledConn>,
 	live_count: usize,
 	closed: bool,
+}
+
+/// What to do next, after [`ConnPool::acquire`] examined the pool under
+/// the lock. Three branches; each one runs outside the lock so the
+/// pool is not blocked on the I/O it has to do.
+enum AcquireStep {
+	/// Pop an idle connection and await `SendRequest::ready()` on it
+	/// before handing it out. The pool's contract used to be "guard
+	/// returned is hyper ready and reusable"; it is now "guard
+	/// returned is hyper ready and reusable, after `ready()` returns
+	/// without error" (#1758).
+	AwaitReady(PooledConn),
+	/// Open a fresh tracked connection. A slot in `live_count` was
+	/// already reserved under the lock, so the open runs outside the
+	/// lock and any failure gives the slot back.
+	Open(String),
+	/// The pool is at its cap. Open a transient connection that is
+	/// not tracked in `live_count` and not returned to the idle
+	/// queue; the cap is a hint for reuse, not a cap on concurrency.
+	OpenTransient,
 }
 
 /// Per-socket HTTP/1.1 connection pool. Cheap to clone; the state is behind
@@ -118,7 +143,10 @@ impl ConnPool {
 	///   return a transient guard that drops on release. This is the
 	///   pre-pool behaviour: every request opens a connection, every
 	///   release drops it.
-	/// - `cap > 0` and an idle connection is available: hand it out.
+	/// - `cap > 0` and an idle connection is available: hand it out,
+	///   but only after awaiting `SendRequest::ready()` so the caller
+	///   is never asked to write to a connection hyper's WRITE side
+	///   has not yet announced as ready (#1758).
 	/// - `cap > 0` and no idle connection: open a fresh one and track it
 	///   in the pool. If the pool is at its cap, open a transient
 	///   connection (not tracked) instead: the cap is a hint for idle
@@ -149,8 +177,12 @@ impl ConnPool {
 			tokio::pin!(waiter);
 
 			// Phase 1: try to satisfy the acquire from the pool's current
-			// state, without holding the lock across an `await`.
-			let open_slot = {
+			// state, without holding the lock across an `await`. The three
+			// outcomes are encoded as `AcquireStep`: pop an idle connection
+			// and await readiness on it (the fix for #1758), open a tracked
+			// fresh connection (within cap), or open a transient one
+			// (beyond cap).
+			let step = {
 				let mut inner = self.inner.lock().unwrap();
 				if inner.closed {
 					return Err(PodmanError::Api {
@@ -167,23 +199,56 @@ impl ConnPool {
 					inner.live_count -= 1;
 				}
 				if let Some(conn) = inner.idle.pop_front() {
+					AcquireStep::AwaitReady(conn)
+				} else if inner.live_count < self.cap {
+					inner.live_count += 1;
+					AcquireStep::Open(self.socket_path.clone())
+				} else {
+					AcquireStep::OpenTransient
+				}
+			};
+
+			match step {
+				AcquireStep::AwaitReady(mut conn) => {
+					// The idle connection was popped under the lock, but
+					// its readiness has to be awaited outside the lock or
+					// the pool would block every other acquirer while we
+					// wait. hyper announces readiness by polling the WRITE
+					// side after publishing body completion on the READ
+					// side (`proto/h1/dispatch.rs:173-175`); on a multi-
+					// threaded runtime the user task that just dropped the
+					// previous guard can call `send_request` before that
+					// announcement, and `can_send` returns false on the
+					// `Idle` state. Awaiting `ready()` parks us on the
+					// `Give` state until the driver calls `taker.want()`
+					// (#1758).
+					//
+					// `is_closed` is a fast path: a connection the server
+					// closed or that the driver tore down never becomes
+					// ready. Handing it out would fail the very next send;
+					// better to drop it here and let the next acquire open
+					// fresh.
+					if conn.sender.is_closed() {
+						let mut inner = self.inner.lock().unwrap();
+						inner.live_count -= 1;
+						drop(inner);
+						self.notify.notify_one();
+						continue;
+					}
+					if conn.sender.ready().await.is_err() {
+						let mut inner = self.inner.lock().unwrap();
+						inner.live_count -= 1;
+						drop(inner);
+						self.notify.notify_one();
+						continue;
+					}
 					return Ok(PoolGuard {
 						conn: Some(conn),
 						pool: self.clone(),
 						transient: false,
 					});
 				}
-				if inner.live_count < self.cap {
-					inner.live_count += 1;
-					Some(self.socket_path.clone())
-				} else {
-					None
-				}
-			};
-
-			// Phase 2: with the lock dropped, open the new connection.
-			if let Some(path) = open_slot {
-				match open_one(&path).await {
+				AcquireStep::Open(path) => match open_one(&path).await {
 					Ok((sender, driver)) => {
 						return Ok(PoolGuard {
 							conn: Some(PooledConn {
@@ -204,34 +269,26 @@ impl ConnPool {
 						self.notify.notify_one();
 						return Err(e);
 					}
-				}
-			}
-
-			// At cap. The cap is a hint for reuse, not a cap on concurrency:
-			// open a transient connection that is NOT tracked in the pool
-			// (no `live_count` increment, no slot to release into). A parallel
-			// caller that exceeds the cap is not throttled; it just does not
-			// reuse a socket. This is the same shape as Go's `http.Transport`,
-			// where `MaxIdleConnsPerHost` caps the idle pool while active
-			// requests can exceed it.
-			match open_one(&self.socket_path).await {
-				Ok((sender, driver)) => {
-					return Ok(PoolGuard {
-						conn: Some(PooledConn {
-							sender,
-							driver,
-							poisoned: false,
-						}),
-						pool: self.clone(),
-						transient: true,
-					});
-				}
-				Err(e) => {
-					// Transient open failed too. Fall through to the wait
-					// path below; a release on the pool side may free a slot
-					// before we re-check.
-					let _ = e;
-				}
+				},
+				AcquireStep::OpenTransient => match open_one(&self.socket_path).await {
+					Ok((sender, driver)) => {
+						return Ok(PoolGuard {
+							conn: Some(PooledConn {
+								sender,
+								driver,
+								poisoned: false,
+							}),
+							pool: self.clone(),
+							transient: true,
+						});
+					}
+					Err(e) => {
+						// Transient open failed too. Fall through to the
+						// wait path below; a release on the pool side may
+						// free a slot before we re-check.
+						let _ = e;
+					}
+				},
 			}
 
 			// Both pool and transient paths exhausted: wait for the next
@@ -322,8 +379,10 @@ impl Drop for PoolGuard {
 		if let Some(conn) = self.conn.take() {
 			// A transient connection was opened because the pool was at cap;
 			// it was never tracked in `live_count` and there is no slot to
-			// release into. Drop it directly. The background `driver` task
-			// aborts when the socket closes; the `SendRequest` is dropped.
+			// release into. Drop it directly. Dropping the `JoinHandle`
+			// detaches the driver task rather than aborting it; the task
+			// runs to completion once the dropped `SendRequest` signals
+			// the hyper connection to close its IO half.
 			if self.transient {
 				return;
 			}

--- a/internal/libpod/client/pool/readiness_tests.rs
+++ b/internal/libpod/client/pool/readiness_tests.rs
@@ -1,0 +1,250 @@
+// The pool's connection-reuse semantics ride on `UnixListener`, which is
+// only available on Unix. The pool itself is cross-platform (Windows uses
+// a named pipe; see `internal/libpod/client/stream.rs`); the integration
+// tests in this file that prove keep-alive reuses a single socket are
+// Unix-only by necessity. The `#[cfg(unix)]` here skips the tests on
+// Windows CI; the pool's other unit tests (which don't bind a socket)
+// still run there.
+#![cfg(unix)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+
+/// Fake libpod server that responds with `Transfer-Encoding: chunked`
+/// and inserts a short pause between the headers and the body so the
+/// client has a window during which the body is in flight. The pause
+/// is what makes the readiness race reproducible on a multi-threaded
+/// runtime: the user task and the hyper driver task can each be on a
+/// different worker, and the user calling `send_request` for the next
+/// request can land before the driver has polled its WRITE side
+/// (`proto/h1/dispatch.rs:173-175`) and announced readiness
+/// (`client/dispatch.rs:182-189`).
+struct ReadinessServer {
+	sock_path: std::path::PathBuf,
+	accepted: Arc<AtomicUsize>,
+	_dir: tempfile::TempDir,
+	task: tokio::task::JoinHandle<()>,
+}
+
+impl ReadinessServer {
+	async fn start() -> Self {
+		let dir = tempfile::tempdir().unwrap();
+		let sock_path = dir.path().join("podman.sock");
+		let listener = UnixListener::bind(&sock_path).unwrap();
+		let accepted = Arc::new(AtomicUsize::new(0));
+		let accepted_clone = accepted.clone();
+
+		let task = tokio::spawn(async move {
+			loop {
+				let Ok((mut stream, _)) = listener.accept().await else {
+					break;
+				};
+				accepted_clone.fetch_add(1, Ordering::SeqCst);
+				tokio::spawn(async move {
+					loop {
+						let mut buf = Vec::new();
+						let mut chunk = [0u8; 1024];
+						let mut got_request = false;
+						while !got_request {
+							match stream.read(&mut chunk).await {
+								Ok(0) => return,
+								Ok(n) => {
+									buf.extend_from_slice(&chunk[..n]);
+									if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+										got_request = true;
+									}
+								}
+								Err(_) => return,
+							}
+						}
+						let headers = b"HTTP/1.1 200 OK\r\n\
+							content-type: application/json\r\n\
+							transfer-encoding: chunked\r\n\
+							\r\n";
+						if stream.write_all(headers).await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+						// The window during which the next caller can race
+						// for the connection. 1ms is enough to widen the
+						// gap between the body completion on the driver's
+						// READ path and its WRITE-side readiness poll,
+						// while keeping the test fast enough that 5000
+						// iterations run inside a CI budget.
+						tokio::time::sleep(std::time::Duration::from_micros(500)).await;
+						let body = b"{\"ok\":true}";
+						let mid = body.len() / 2;
+						for part in [&body[..mid], &body[mid..]] {
+							let chunk = format!("{:x}\r\n", part.len());
+							if stream.write_all(chunk.as_bytes()).await.is_err() {
+								return;
+							}
+							if stream.write_all(part).await.is_err() {
+								return;
+							}
+							if stream.write_all(b"\r\n").await.is_err() {
+								return;
+							}
+							if stream.flush().await.is_err() {
+								return;
+							}
+						}
+						if stream.write_all(b"0\r\n\r\n").await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+					}
+				});
+			}
+		});
+
+		Self {
+			sock_path,
+			accepted,
+			_dir: dir,
+			task,
+		}
+	}
+
+	fn sock_str(&self) -> String {
+		self.sock_path.to_string_lossy().into_owned()
+	}
+
+	fn accepted(&self) -> usize {
+		self.accepted.load(Ordering::SeqCst)
+	}
+}
+
+impl Drop for ReadinessServer {
+	fn drop(&mut self) {
+		self.task.abort();
+	}
+}
+
+/// The pool hands a pooled connection back without waiting for hyper
+/// to publish readiness. On a multi-threaded runtime, the user task
+/// that just finished reading the body can release the guard, reacquire
+/// it, and call `send_request` before the hyper driver task on its
+/// other worker has polled the WRITE side and announced readiness.
+/// `can_send` returns false, `send_request` returns
+/// `Canceled, "connection was not ready"` (#1758).
+///
+/// This test pins that bug to a deterministic cap-one sequential reuse
+/// against a chunked fixture: every request after the first races for
+/// the single tracked connection, the body pause is the window during
+/// which the driver is between its READ poll (which publishes body
+/// completion) and its WRITE poll (which announces readiness), and the
+/// multi-threaded runtime ensures the user task can be on a different
+/// worker than the driver.
+///
+/// The previous test harness for this pool served `Content-Length`
+/// responses in one piece, so the body was never in flight when the
+/// guard was released; that is the harness that could not see this
+/// defect, and the chunked variant is what made it visible. The fix
+/// calls `SendRequest::ready()` before handing a connection out
+/// (or before sending on it), so `can_send` only runs against a
+/// connection whose driver has caught up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn sequential_reuse_races_for_readiness() {
+	let server = ReadinessServer::start().await;
+	let client = crate::libpod::Client::with_pool_size(server.sock_str(), 1);
+
+	// Each iteration is a chance to hit the race: the body just
+	// arrived, the user is about to call `send_request` for the next
+	// request, and the driver on its worker has not yet published
+	// readiness. 5000 iterations × 8 worker threads is enough that
+	// at least one races on a Linux runner.
+	for i in 0..5000 {
+		let result: Result<serde_json::Value, _> = client.get_json("/libpod/_ping").await;
+		if let Err(e) = result {
+			// The diagnostic that pins the defect is
+			// `Canceled, "connection was not ready"` (#1758). Hyper's
+			// Display drops the `.with("connection was not ready")`
+			// context; it lives in the error's Debug / source chain.
+			// `stream_end_kind` classifies it as `"canceled"`. Anything
+			// else is a different failure this test is not asserting on.
+			let kind = e.stream_end_kind();
+			assert_eq!(
+				kind, "canceled",
+				"request {i} failed with an unexpected kind on a healthy socket: {e:?}"
+			);
+			// Re-pin the cause on the message: `stream_end_kind` is also
+			// `"canceled"` for the unrelated `connection closed`
+			// variant, so the Debug string is the only thing that says
+			// which one fired. The readiness wording is unique to this
+			// defect (#1758).
+			let dbg = format!("{e:?}");
+			assert!(
+				dbg.contains("connection was not ready"),
+				"request {i} saw a non-readiness Canceled on a healthy socket: {e:?}"
+			);
+			panic!(
+				"request {i} saw `Canceled, \"connection was not ready\"` on a healthy socket: {e}"
+			);
+		}
+	}
+
+	// Reuse: every request rode the single tracked connection.
+	// Without the fix, each failed reuse opens a fresh socket and the
+	// server accepts up to 5000 connections; with the fix, it accepts
+	// one. The bound is what is deterministic: at least one accepted
+	// (the connection was opened) and strictly fewer than the number
+	// of requests (at least one was reused).
+	let accepted = server.accepted();
+	assert!(
+		(1..5000).contains(&accepted),
+		"the pool must reuse one connection under cap=1 sequential traffic; accepted={accepted}"
+	);
+}
+
+/// Same defect from a different angle: many tasks race for the
+/// tracked connections, each task doing sequential requests. The race
+/// fires when one task finishes reading the body, releases the guard,
+/// and another task acquires the guard and tries to send before the
+/// driver has caught up. This is closer to the live Podman failure
+/// shape (the four lifecycle cases are not a single-task workload,
+/// and the live run used `--connection-pool-size 8`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_reuse_races_for_readiness() {
+	let server = ReadinessServer::start().await;
+	let client = std::sync::Arc::new(crate::libpod::Client::with_pool_size(server.sock_str(), 4));
+
+	let mut handles = Vec::with_capacity(16);
+	for task_id in 0..16 {
+		let c = client.clone();
+		handles.push(tokio::spawn(async move {
+			for i in 0..200 {
+				let result: Result<serde_json::Value, _> = c.get_json("/libpod/_ping").await;
+				if let Err(e) = result {
+					let kind = e.stream_end_kind();
+					assert_eq!(
+						kind, "canceled",
+						"task {task_id} request {i} failed with an unexpected kind: {e}"
+					);
+					panic!(
+						"task {task_id} request {i} saw `Canceled, \"connection was not ready\"`: {e}"
+					);
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.await.unwrap();
+	}
+
+	// Reuse, not merely "a connection happened". 3200 requests through
+	// a cap-of-four pool must open strictly fewer than 3200 sockets; a
+	// pool that gives up on the tracked connections every time would.
+	let accepted = server.accepted();
+	assert!(
+		(1..3200).contains(&accepted),
+		"the pool must reuse connections under concurrent traffic; accepted={accepted}"
+	);
+}

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -246,7 +246,12 @@ async fn zero_pool_size_means_no_pool() {
 
 /// Forcibly drop a pooled connection by poisoning it, then verify the next
 /// acquire gets a fresh socket. This is the "health check, drop on broken"
-/// path: the previous connection's `JoinHandle` is aborted on release.
+/// path: the previous connection's `JoinHandle` is detached when the
+/// poisoned `PooledConn` drops (dropping a `JoinHandle` does not abort the
+/// task, it just lets it run to completion in the background; the task
+/// itself finishes once the hyper connection's IO closes, which the
+/// dropped `SendRequest` triggers). The pool hands the next acquire a
+/// fresh socket rather than a half-closed one.
 #[tokio::test]
 async fn a_poisoned_connection_is_replaced_on_next_acquire() {
 	let server = CountingServer::start().await;
@@ -280,3 +285,12 @@ async fn a_poisoned_connection_is_replaced_on_next_acquire() {
 // module Rust resolves from a `mod tests;` reference in the parent.
 #[path = "chunked_tests.rs"]
 mod chunked_tests;
+
+// Readiness regression for #1758. The fixture and tests live in a sibling
+// module so this harness file stays under the soft 300-line warn. The two
+// tests are multi-threaded and reproduce the "connection was not ready"
+// race the live Podman lane hit with `--connection-pool-size 8`: the
+// current_thread harness used by the rest of this pool could not see the
+// defect, which is how it survived.
+#[path = "readiness_tests.rs"]
+mod readiness_tests;


### PR DESCRIPTION
The pool treated "guard returned" as "hyper ready and reusable". It is
not. Hyper publishes body completion from its read path and only then
polls its write path, announcing readiness afterwards, so another worker
on a multithreaded runtime can observe completion, take the connection
and send before that announcement. `send_request` then fails with
`Canceled, "connection was not ready"` on a socket that is perfectly
healthy, which is why #1740 holding the guard across the body read did
not close this: exclusive ownership is not synchronisation with hyper.

`acquire` now awaits `SendRequest::ready()` before handing an idle
connection out, and a connection whose `ready()` errors is replaced
rather than returned. That also covers the second half of the contract:
an idle connection that closed while parked no longer reaches a caller.

The reproduction is a cap-of-one sequential test rather than the live
Podman lane, which is what an independent trace suggested and what
turned out to be true: the sequential case catches it and the concurrent
one does not. Eight worker threads, a chunked fixture with 500us between
headers and body to open the window, and 5000 iterations. On the
unfixed tree it fails around iteration 90, consistently. Making the
`ready()` call unreachable reproduces the issue's exact message:

    request 3521 saw `Canceled, "connection was not ready"` on a healthy socket

A `current_thread` runtime hides the defect entirely, since the driver
is polled between every await, so the test says why it asks for eight
threads.

The default stays 0. Whether the pool can now be turned on is a question
for the live lane, and it is the next step rather than part of this
change.

Closes #1758.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>