### PR TITLE
fix(compose): a quote inside the other quote no longer disables the alias guard

### DIFF
--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -304,13 +304,23 @@ fn count_alias_refs(content: &str) -> usize {
 			'\'' if in_single => {
 				in_single = false;
 			}
-			'\'' if !in_single && at_value_pos => {
+			// `!in_double` is the half this was missing. Without it a `'`
+			// inside a double-quoted scalar opened single-quote state, the
+			// closing `"` cleared `in_double` and left `in_single` set for
+			// the rest of the document, and every `*alias` after it was
+			// counted as quoted text. `count_alias_refs` then returned 0,
+			// the `refs == 0` early return fired, and BOTH caps were
+			// skipped. Two files 18 bytes apart: without the poisoning
+			// line the document is refused, with it accepted.
+			'\'' if !in_single && !in_double && at_value_pos => {
 				in_single = true;
 			}
 			'"' if in_double => {
 				in_double = false;
 			}
-			'"' if !in_double && at_value_pos => {
+			// Symmetrical: a `"` inside a single-quoted scalar is ordinary
+			// text and must not open double-quote state either.
+			'"' if !in_double && !in_single && at_value_pos => {
 				in_double = true;
 			}
 			'#' if !in_single && !in_double && at_value_pos => {

--- a/internal/compose/merge_tests.rs
+++ b/internal/compose/merge_tests.rs
@@ -255,3 +255,32 @@ fn mapping_rebuild_is_skipped_when_nothing_needs_interpolation() {
 	assert_eq!(a.services["app"].image, b.services["app"].image);
 	assert_eq!(a.services["db"].restart, b.services["db"].restart);
 }
+
+#[test]
+fn a_quote_inside_the_other_quote_does_not_disable_the_alias_guard() {
+	// The second bypass of the same guard, after the apostrophe in a plain
+	// scalar. Entering single-quote state did not require being outside
+	// double-quote state, so `"hello '"` left the scanner inside a quoted
+	// scalar for the rest of the document and every `*alias` after it was
+	// counted as text. Both caps were then skipped by the `refs == 0`
+	// early return.
+	//
+	// The payload after the poisoning line carries no stray single quote:
+	// a later `'` in value position closes the state again and the document
+	// is refused normally, which would make this pass for the wrong reason.
+	let anchor = "y".repeat(200);
+	let refs: String = (0..101).map(|_| "  - *a\n").collect();
+	let poisoned = format!("x: &a {anchor}\nx-note: \"hello '\"\nl:\n{refs}");
+	let control = format!("x: &a {anchor}\nl:\n{refs}");
+
+	// The control exceeds the reference cap on its own, so if the two
+	// behaved the same the test would prove nothing.
+	assert!(
+		crate::compose::parse_str(&control).is_err(),
+		"the control must be refused on its own"
+	);
+	assert!(
+		crate::compose::parse_str(&poisoned).is_err(),
+		"a quote inside the other quote must not switch the guard off"
+	);
+}


### PR DESCRIPTION
The second bypass of the same guard. Entering single-quote state did not
require being outside double-quote state, so a `'` inside a double-quoted
scalar set `in_single`, the closing `"` cleared only `in_double`, and the
scanner stayed "inside a quoted scalar" for the rest of the document.
Every `*alias` after that line was counted as text, `count_alias_refs`
returned 0, the `refs == 0` early return fired, and both the reference cap
and the document-size cap were skipped.

Two files eighteen bytes apart, measured on the tree before this change:

    ctl.yaml (917 B)  refused, 101 alias references
    exp.yaml (935 B)  accepted, guards never consulted

An independent verification measured the amplification at 1598 MB in 58 s
against 21 MB in 0.01 s for the control.

Both arms are symmetrical now: a quote character opens a scalar only when
no other scalar is open. `#` already had it right, which is why the
comment-not-a-comment hole was a different shape.

The test's payload after the poisoning line carries no stray single
quote, deliberately. The bypass is fragile with respect to state: a later
`'` in value position closes it again and the document is refused
normally, so a careless payload makes the case pass while the guard is
working. A verification run's first attempt failed for exactly that
reason.

The control is asserted to be refused on its own, so a change that made
both behave the same could not pass silently. Reverting only the single
-quote arm turns the case red.

This is the third hole in a hand-rolled scanner over YAML text, after the
apostrophe in a plain scalar and the `#` that is not a comment. Counting
`Event::Alias` from the loader would end the class rather than the
instance, and `serde_yaml_ng` keeps that type crate-private, so it stays
a scanner. That is worth revisiting if a fourth appears.

Closes #1737.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>