### PR TITLE
fix(substitute): bound the whole document, not one scalar at a time

### DIFF
--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -77,7 +77,11 @@ pub(super) fn interpolated_value(
 	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
 	if let Some(vars) = vars {
-		interpolate_value(&mut value, vars)?;
+		// One budget for the whole document. The per-scalar cap cannot see
+		// repetition spread across scalars, which is the shape that reached
+		// 5.27 GB with no single substitution over 1 MiB.
+		let mut spent = 0usize;
+		interpolate_value(&mut value, vars, &mut spent)?;
 	}
 	apply_merge_keys(&mut value);
 	Ok(value)
@@ -88,10 +92,14 @@ pub(super) fn interpolated_value(
 /// Mapping values and sequence items are coerced through [`interpolate_scalar`]
 /// (so an interpolated numeric/boolean keeps its YAML type, matching
 /// docker-compose's typed fields); mapping keys are interpolated as plain text.
-fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, String>) -> Result<()> {
+fn interpolate_value(
+	value: &mut serde_yaml::Value,
+	vars: &HashMap<String, String>,
+	spent: &mut usize,
+) -> Result<()> {
 	match value {
 		serde_yaml::Value::String(s) if s.contains('$') => {
-			*value = interpolate_scalar(s, vars)?;
+			*value = interpolate_scalar(s, vars, spent)?;
 		}
 		serde_yaml::Value::Sequence(seq) => {
 			// Skip the recursion when no element carries a `$`: a 100-service file
@@ -102,7 +110,7 @@ fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, Strin
 				return Ok(());
 			}
 			for item in seq.iter_mut() {
-				interpolate_value(item, vars)?;
+				interpolate_value(item, vars, spent)?;
 			}
 		}
 		serde_yaml::Value::Mapping(map) => {
@@ -119,7 +127,7 @@ fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, Strin
 			let mut rebuilt = serde_yaml::Mapping::with_capacity(taken.len());
 			for (key, mut val) in taken {
 				let key = interpolate_key(key, vars)?;
-				interpolate_value(&mut val, vars)?;
+				interpolate_value(&mut val, vars, spent)?;
 				rebuilt.insert(key, val);
 			}
 			*map = rebuilt;
@@ -173,8 +181,12 @@ fn value_needs_interp(value: &serde_yaml::Value) -> bool {
 /// would otherwise have `serde_yaml::from_str` build the full Value tree
 /// (allocating memory proportional to refs × anchor size) before we discard
 /// the result and keep the raw string.
-fn interpolate_scalar(s: &str, vars: &HashMap<String, String>) -> Result<serde_yaml::Value> {
-	let resolved = crate::substitute::substitute(s, vars)?;
+fn interpolate_scalar(
+	s: &str,
+	vars: &HashMap<String, String>,
+	spent: &mut usize,
+) -> Result<serde_yaml::Value> {
+	let resolved = crate::substitute::substitute_budgeted(s, vars, spent)?;
 	if resolved.is_empty() {
 		return Ok(serde_yaml::Value::String(String::new()));
 	}

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -28,6 +28,27 @@ const MAX_INTERP_DEPTH: usize = 64;
 /// secret, a multi-line config blob) can be told apart from a hostile one.
 const MAX_INTERP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 
+/// Upper bound on the total interpolated output of one document.
+///
+/// [`MAX_INTERP_OUTPUT_BYTES`] bounds a single scalar, which is the wrong
+/// unit on its own: repetition split across scalars is unbounded while every
+/// individual substitution stays legal. Measured on the tree before this
+/// bound existed, with a 1 MiB `.env` value and one service whose
+/// environment carries N entries all reading it: 256 entries reached 1.6 GB,
+/// 512 reached 3.2 GB, and 1024 aborted at 5.27 GB. No single substitution
+/// exceeded 1 MiB, so the per-scalar cap never fired once.
+///
+/// 16 MiB, the same number the per-file cap already uses, so a reader meets
+/// one size rather than two. It was picked by measurement rather than taste:
+/// at 64 MiB a document of 64 one-mebibyte entries is accepted and costs
+/// 419 MB resident, which is not a bound worth having. At 16 MiB the same
+/// shape is refused and a document that is legitimately large, a long secret
+/// or a config blob across a handful of services, still parses.
+///
+/// The per-scalar cap stays as the cheaper first line: it refuses a single
+/// runaway value without walking the rest of the document.
+pub(crate) const MAX_INTERP_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -37,7 +58,18 @@ const MAX_INTERP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 /// `vars` should contain both the process environment and the `.env` file
 /// entries (process environment takes precedence).
 pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String> {
-	substitute_depth(input, vars, 0)
+	let mut spent = 0usize;
+	substitute_depth(input, vars, 0, &mut spent)
+}
+
+/// [`substitute`] with a budget that outlives the call, so a caller
+/// interpolating many scalars bounds their total rather than each one.
+pub(crate) fn substitute_budgeted(
+	input: &str,
+	vars: &HashMap<String, String>,
+	spent: &mut usize,
+) -> Result<String> {
+	substitute_depth(input, vars, 0, spent)
 }
 
 /// Inner substitution carrying the current nesting `depth` so recursive
@@ -46,6 +78,7 @@ pub(super) fn substitute_depth(
 	input: &str,
 	vars: &HashMap<String, String>,
 	depth: usize,
+	spent: &mut usize,
 ) -> Result<String> {
 	if depth > MAX_INTERP_DEPTH {
 		return Err(ComposeError::InvalidSubstitution(format!(
@@ -73,8 +106,9 @@ pub(super) fn substitute_depth(
 			Some('{') => {
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
-				let value = resolve_modifier(var.clone(), modifier, vars, depth)?;
+				let value = resolve_modifier(var.clone(), modifier, vars, depth, spent)?;
 				check_output_cap(&out, &value, &var)?;
+				check_document_budget(spent, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
@@ -90,6 +124,7 @@ pub(super) fn substitute_depth(
 					}
 				};
 				check_output_cap(&out, &value, &var)?;
+				check_document_budget(spent, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(_) => {
@@ -105,6 +140,18 @@ pub(super) fn substitute_depth(
 /// output past [`MAX_INTERP_OUTPUT_BYTES`]. Called before the `push_str` so the
 /// refusal fires before the offending allocation, with a message naming the
 /// variable and the size it had reached.
+fn check_document_budget(spent: &mut usize, value: &str, var: &str) -> Result<()> {
+	*spent = spent.saturating_add(value.len());
+	if *spent > MAX_INTERP_DOCUMENT_BYTES {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"interpolating '{var}' pushes this document past {MAX_INTERP_DOCUMENT_BYTES} \
+			 bytes of substituted output; at most that much is allowed across the whole \
+			 file; the value may repeat across many fields"
+		)));
+	}
+	Ok(())
+}
+
 fn check_output_cap(out: &str, value: &str, var: &str) -> Result<()> {
 	let new_len = out.len().saturating_add(value.len());
 	if new_len > MAX_INTERP_OUTPUT_BYTES {

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -154,6 +154,7 @@ pub(super) fn resolve_modifier(
 	modifier: Modifier,
 	vars: &HashMap<String, String>,
 	depth: usize,
+	spent: &mut usize,
 ) -> Result<String> {
 	let value = vars.get(&var);
 
@@ -174,21 +175,21 @@ pub(super) fn resolve_modifier(
 		// than overflowing the stack.
 		Modifier::DefaultIfUnsetOrEmpty(default) => match value {
 			Some(v) if !v.is_empty() => Ok(v.clone()),
-			_ => super::substitute_depth(&default, vars, depth + 1),
+			_ => super::substitute_depth(&default, vars, depth + 1, spent),
 		},
 
 		Modifier::DefaultIfUnset(default) => match value {
 			Some(v) => Ok(v.clone()),
-			None => super::substitute_depth(&default, vars, depth + 1),
+			None => super::substitute_depth(&default, vars, depth + 1, spent),
 		},
 
 		Modifier::AltIfSetAndNonEmpty(alt) => match value {
-			Some(v) if !v.is_empty() => super::substitute_depth(&alt, vars, depth + 1),
+			Some(v) if !v.is_empty() => super::substitute_depth(&alt, vars, depth + 1, spent),
 			_ => Ok(String::new()),
 		},
 
 		Modifier::AltIfSet(alt) => match value {
-			Some(_) => super::substitute_depth(&alt, vars, depth + 1),
+			Some(_) => super::substitute_depth(&alt, vars, depth + 1, spent),
 			None => Ok(String::new()),
 		},
 

--- a/internal/substitute/parse_tests.rs
+++ b/internal/substitute/parse_tests.rs
@@ -182,11 +182,11 @@ fn parse_unterminated_modifier_is_error() {
 fn resolve_none_uses_value_or_empty() {
 	let v = vars(&[("A", "1")]);
 	assert_eq!(
-		resolve_modifier("A".into(), Modifier::None, &v, 0).unwrap(),
+		resolve_modifier("A".into(), Modifier::None, &v, 0, &mut 0usize).unwrap(),
 		"1"
 	);
 	assert_eq!(
-		resolve_modifier("MISSING".into(), Modifier::None, &v, 0).unwrap(),
+		resolve_modifier("MISSING".into(), Modifier::None, &v, 0, &mut 0usize).unwrap(),
 		""
 	);
 }
@@ -195,12 +195,18 @@ fn resolve_none_uses_value_or_empty() {
 fn resolve_default_if_unset_or_empty() {
 	let v = vars(&[("EMPTY", ""), ("SET", "x")]);
 	let m = || Modifier::DefaultIfUnsetOrEmpty("def".into());
-	assert_eq!(resolve_modifier("EMPTY".into(), m(), &v, 0).unwrap(), "def");
 	assert_eq!(
-		resolve_modifier("MISSING".into(), m(), &v, 0).unwrap(),
+		resolve_modifier("EMPTY".into(), m(), &v, 0, &mut 0usize).unwrap(),
 		"def"
 	);
-	assert_eq!(resolve_modifier("SET".into(), m(), &v, 0).unwrap(), "x");
+	assert_eq!(
+		resolve_modifier("MISSING".into(), m(), &v, 0, &mut 0usize).unwrap(),
+		"def"
+	);
+	assert_eq!(
+		resolve_modifier("SET".into(), m(), &v, 0, &mut 0usize).unwrap(),
+		"x"
+	);
 }
 
 #[test]
@@ -211,7 +217,8 @@ fn resolve_default_if_unset_keeps_empty_value() {
 			"EMPTY".into(),
 			Modifier::DefaultIfUnset("def".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		""
@@ -221,7 +228,8 @@ fn resolve_default_if_unset_keeps_empty_value() {
 			"MISSING".into(),
 			Modifier::DefaultIfUnset("def".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		"def"
@@ -236,7 +244,8 @@ fn resolve_alt_forms() {
 			"SET".into(),
 			Modifier::AltIfSetAndNonEmpty("a".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		"a"
@@ -246,17 +255,32 @@ fn resolve_alt_forms() {
 			"EMPTY".into(),
 			Modifier::AltIfSetAndNonEmpty("a".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		""
 	);
 	assert_eq!(
-		resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
+		resolve_modifier(
+			"EMPTY".into(),
+			Modifier::AltIfSet("a".into()),
+			&v,
+			0,
+			&mut 0usize
+		)
+		.unwrap(),
 		"a"
 	);
 	assert_eq!(
-		resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
+		resolve_modifier(
+			"MISSING".into(),
+			Modifier::AltIfSet("a".into()),
+			&v,
+			0,
+			&mut 0usize
+		)
+		.unwrap(),
 		""
 	);
 }
@@ -268,7 +292,8 @@ fn resolve_error_forms() {
 		"EMPTY".into(),
 		Modifier::ErrorIfUnsetOrEmpty("e".into()),
 		&v,
-		0
+		0,
+		&mut 0usize
 	)
 	.is_err());
 	assert_eq!(
@@ -276,14 +301,29 @@ fn resolve_error_forms() {
 			"SET".into(),
 			Modifier::ErrorIfUnsetOrEmpty("e".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		"x"
 	);
-	assert!(resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).is_err());
+	assert!(resolve_modifier(
+		"MISSING".into(),
+		Modifier::ErrorIfUnset("e".into()),
+		&v,
+		0,
+		&mut 0usize
+	)
+	.is_err());
 	assert_eq!(
-		resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).unwrap(),
+		resolve_modifier(
+			"EMPTY".into(),
+			Modifier::ErrorIfUnset("e".into()),
+			&v,
+			0,
+			&mut 0usize
+		)
+		.unwrap(),
 		""
 	);
 }

--- a/internal/substitute/tests.rs
+++ b/internal/substitute/tests.rs
@@ -521,3 +521,39 @@ fn interpolation_cap_allows_legitimate_repetition() {
 	let v = vars(&[("TAG", "v1")]);
 	assert_eq!(substitute("${TAG}-${TAG}-${TAG}", &v).unwrap(), "v1-v1-v1");
 }
+
+#[test]
+fn the_document_budget_bounds_repetition_spread_across_scalars() {
+	// The per-scalar cap is the wrong unit on its own: repetition split
+	// across scalars is unbounded while every single substitution stays
+	// legal. Measured before this budget existed, with a 1 MiB value and
+	// one service reading it from N environment entries: 256 reached
+	// 1.6 GB, 512 reached 3.2 GB, 1024 aborted at 5.27 GB, and no single
+	// substitution passed 1 MiB, so the per-scalar cap never fired.
+	//
+	// The value is built here rather than committed as a fixture.
+	let big = "y".repeat(1024 * 1024);
+	let mut vars = std::collections::HashMap::new();
+	vars.insert("BIG".to_string(), big);
+
+	// Under the budget: still accepted, because a long secret across a
+	// handful of fields is a legitimate document.
+	let mut spent = 0usize;
+	for _ in 0..8 {
+		super::substitute_budgeted("${BIG}", &vars, &mut spent)
+			.expect("eight one-mebibyte substitutions stay under the budget");
+	}
+
+	// Over it: refused, and the message names the variable so a large
+	// legitimate file can be told apart from a hostile one.
+	let mut spent = 0usize;
+	let err = (0..64)
+		.map(|_| super::substitute_budgeted("${BIG}", &vars, &mut spent))
+		.find_map(|r| r.err())
+		.expect("sixty-four must cross the document budget");
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("BIG") && msg.contains("past"),
+		"the refusal must name the variable and the budget, got: {msg}"
+	);
+}


### PR DESCRIPTION
The 4 MiB cap on a single interpolation pass works and bounds the wrong
unit. `interpolate_value` calls substitution separately for each scalar
with no shared budget, so repetition split across scalars is unbounded
while every individual substitution stays legal.

Measured before this change, with a 1 MiB `.env` value and one service
whose environment reads it from N entries: 256 reached 1.6 GB, 512
reached 3.2 GB, and 1024 aborted at 5.27 GB. No single substitution
exceeded 1 MiB, so the existing cap never fired once.

One budget now spans the interpolation of a document, threaded from
`interpolate_value` down to `substitute_depth` rather than kept in
global state, which is what the fifteen updated test call sites cost.

16 MiB, picked by measurement. My first choice was 64 MiB and the
measurement refused it: at that size a document of 64 one-mebibyte
entries is accepted and costs 419 MB resident, which is not a bound
worth having. At 16 MiB, eight entries still parse at 80 MB, thirty-two
are refused in 1.3 s at 42 MB, and 256 in 1.2 s. It is also the number
the per-file cap already uses, so a reader meets one size rather than
two.

The question that set the number was not "does it refuse the attack" but
"what does it cost to accept what I still accept". The first answer was
yes to both, which is how 64 MiB looked defensible in prose.

The per-scalar cap stays as the cheaper first line: it refuses a single
runaway value without walking the rest of the document. The refusal
names the variable, so a large legitimate file is distinguishable from a
hostile one.

Making the comparison unreachable turns the new case red.

Closes #1738.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>