### PR TITLE
fix: the two regressions the medium batch introduced

### DIFF
--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -105,17 +105,28 @@ impl ExtendsCache {
 			.parent()
 			.map(|p| p.to_path_buf())
 			.unwrap_or_else(|| base_dir.to_path_buf());
-		let mut other = parse_file_inner(abs, &dir)?;
+		let other = parse_file_inner(abs, &dir)?;
 		// Resolve the external file's own `extends:` chains before
 		// caching, so a later `swap_remove` of the requested base
 		// service gives a fully-merged value. The cached entry is the
 		// resolved file; per-service callers still do their own merges
 		// of the base into the child.
-		// The caller's depth travels with the recursion. Passing 0 here
-		// would restart the count in every external file, so a chain of
-		// more than MAX_EXTENDS_DEPTH files never reached the limit and
-		// overflowed the stack instead.
-		resolve_all_extends_with_cache(&mut other, &dir, self, depth)?;
+		// The cache holds the PARSED file, not a fully resolved one. It used
+		// to resolve every service here before caching, which made a
+		// reference to one valid service fail when an unrelated service in
+		// the same file extended something missing: a file you do not
+		// control could break your build over a service you never asked
+		// for. The caller resolves the chain it actually needs, immediately
+		// after this returns, so nothing is lost by not doing it here.
+		//
+		// The parse is what the cache exists to save (#1746): twenty
+		// services pointing at one file parsed it twenty times and peaked
+		// at 5.8 GB. That saving is unaffected.
+		//
+		// `in_progress` and the depth counter still work, because the
+		// caller's `resolve_one_extends` recurses back through this
+		// function for any nested `extends.file`.
+		let _ = depth;
 		if self.entries.len() >= MAX_EXTENDS_CACHE_ENTRIES && !self.entries.contains_key(abs) {
 			self.in_progress.remove(abs);
 			return Err(ComposeError::Extends(format!(

--- a/internal/compose/extends/parse_count_tests.rs
+++ b/internal/compose/extends/parse_count_tests.rs
@@ -115,3 +115,40 @@ fn extends_file_caches_per_path() {
 	assert_eq!(parsed.services["a"].image.as_deref(), Some("postgres:16"));
 	assert_eq!(parsed.services["b"].image.as_deref(), Some("redis:7"));
 }
+
+#[test]
+fn an_unrelated_broken_service_does_not_fail_the_reference() {
+	// The cache used to resolve every service in a referenced file before
+	// caching it, so a project referencing one valid service failed when an
+	// unrelated service in that file extended something missing. A file you
+	// do not control could break your build over a service you never asked
+	// for.
+	let dir = tempdir().expect("tempdir");
+	let base = dir.path().join("base.yml");
+	fs::write(
+		&base,
+		"services:\n  base:\n    image: alpine:3.20\n  broken:\n    extends:\n      service: does-not-exist\n",
+	)
+	.expect("write base.yml");
+
+	let good = dir.path().join("good.yml");
+	fs::write(
+		&good,
+		"services:\n  app:\n    extends:\n      service: base\n      file: base.yml\n",
+	)
+	.expect("write good.yml");
+	parse_file(&good).expect("referencing a valid service must not fail over an unrelated one");
+
+	// And the broken service is still an error when it is the one asked for,
+	// so this does not simply stop reporting the failure.
+	let bad = dir.path().join("bad.yml");
+	fs::write(
+		&bad,
+		"services:\n  app:\n    extends:\n      service: broken\n      file: base.yml\n",
+	)
+	.expect("write bad.yml");
+	assert!(
+		parse_file(&bad).is_err(),
+		"asking for the broken service must still fail"
+	);
+}

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -53,7 +53,27 @@ fn append_context<W: std::io::Write>(
 		if skip_names.iter().any(|n| rel_str == *n) {
 			return true;
 		}
-		is_ignored(&rel_str, ignore_patterns)
+		// Pruning is only sound when nothing under this directory can be
+		// re-included. `.dockerignore` negation does exactly that:
+		//
+		//     vendor/
+		//     !vendor/keep.txt
+		//
+		// The directory is ignored and one file under it is not, so pruning
+		// `vendor` loses `keep.txt` from the context and a `COPY` naming it
+		// fails. The walk's own comment said the engine had no negation
+		// patterns "in the wild" that re-include a child; that was an
+		// assertion about what users write, and `.dockerignore` supports
+		// negation precisely so they can.
+		//
+		// The cheap, correct condition: descend whenever any negation
+		// pattern could name something beneath this directory. The
+		// optimisation still applies to the ordinary case, an ignored
+		// subtree with nothing re-included, which is what it was for.
+		if !is_ignored(&rel_str, ignore_patterns) {
+			return false;
+		}
+		!negation_could_reach(&rel_str, ignore_patterns)
 	};
 	for abs in walk::walk_dir_skipping(context, skip_dir).map_err(ComposeError::Io)? {
 		let rel = abs
@@ -320,6 +340,22 @@ fn ignore_file(context: &Path) -> (&'static str, Vec<String>) {
 /// `.dockerignore` semantics: a leading `!` re-includes a path that an earlier
 /// pattern excluded. So `*.log` then `!keep.log` ignores every log except
 /// `keep.log`.
+/// Could any negation pattern re-include something under `dir`?
+///
+/// Conservative on purpose: a `true` costs a descent that the leaf filter
+/// then throws away, while a wrong `false` silently drops a file the user
+/// asked to keep. A negation whose path starts at `dir`, or that begins
+/// with a wildcard and so could match at any depth, counts as reaching it.
+fn negation_could_reach(dir: &str, patterns: &[String]) -> bool {
+	patterns
+		.iter()
+		.filter_map(|p| p.strip_prefix('!'))
+		.any(|p| {
+			let p = p.trim_start_matches("./");
+			p.starts_with('*') || p.starts_with(dir) || dir.is_empty()
+		})
+}
+
 fn is_ignored(path: &str, patterns: &[String]) -> bool {
 	let mut ignored = false;
 	for pattern in patterns {

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -46,7 +46,7 @@ fn append_context<W: std::io::Write>(
 			Ok(r) => r,
 			Err(_) => return false,
 		};
-		let rel_str = rel.to_string_lossy();
+		let rel_str = to_ignore_path(rel);
 		// `skip_names` is the only way to drop a directory outright, regardless
 		// of ignore patterns (the active `.dockerignore` itself is on the
 		// list, so the builder can rewrite it).
@@ -79,7 +79,7 @@ fn append_context<W: std::io::Write>(
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-		let rel_str = rel.to_string_lossy();
+		let rel_str = to_ignore_path(rel);
 		if skip_names.iter().any(|n| rel_str == *n) {
 			continue;
 		}
@@ -340,6 +340,22 @@ fn ignore_file(context: &Path) -> (&'static str, Vec<String>) {
 /// `.dockerignore` semantics: a leading `!` re-includes a path that an earlier
 /// pattern excluded. So `*.log` then `!keep.log` ignores every log except
 /// `keep.log`.
+/// A relative path in the form `.dockerignore` patterns are written in.
+///
+/// Patterns always use `/`, and `Path` on Windows yields `\`, so matching the
+/// raw string meant no pattern below the top level ever matched there:
+/// `vendor/` silently ignored nothing. The tar writer already normalises, so
+/// the entry names and the ignore check disagreed about the same file. Found
+/// by a negation test failing on the Windows runner only.
+fn to_ignore_path(rel: &std::path::Path) -> String {
+	let s = rel.to_string_lossy();
+	if std::path::MAIN_SEPARATOR == '/' {
+		s.into_owned()
+	} else {
+		s.replace(std::path::MAIN_SEPARATOR, "/")
+	}
+}
+
 /// Could any negation pattern re-include something under `dir`?
 ///
 /// Conservative on purpose: a `true` costs a descent that the leaf filter

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -462,4 +462,7 @@ fn glob_rec(pat: &[u8], s: &[u8]) -> bool {
 }
 
 #[cfg(test)]
+#[path = "context/pattern_tests.rs"]
+mod pattern_tests;
+#[cfg(test)]
 mod tests;

--- a/internal/engine/build/context/pattern_tests.rs
+++ b/internal/engine/build/context/pattern_tests.rs
@@ -1,0 +1,132 @@
+//! Pattern-matching cases split out of `tests.rs`, which reached the
+//! 500-line hard limit. These exercise `is_ignored`, `glob_match` and
+//! `to_ignore_path` against strings only; what stays in `tests.rs` builds
+//! a real context tar and asserts on its entries. The split follows that
+//! seam rather than a line count.
+
+use super::*;
+
+#[test]
+fn build_ignored_exact() {
+	let patterns = vec!["secret.txt".to_string()];
+	assert!(is_ignored("secret.txt", &patterns));
+	assert!(!is_ignored("secret.txt.bak", &patterns));
+}
+#[test]
+fn build_ignored_dir() {
+	let patterns = vec!["node_modules/".to_string()];
+	assert!(is_ignored("node_modules/foo.js", &patterns));
+	assert!(!is_ignored("other/foo.js", &patterns));
+}
+#[test]
+fn build_ignored_path_separator() {
+	let patterns = vec!["vendor".to_string()];
+	assert!(is_ignored("vendor/lib.rs", &patterns));
+	assert!(!is_ignored("notvendor/lib.rs", &patterns));
+}
+#[test]
+fn build_ignored_glob_extension() {
+	let patterns = vec!["*.key".to_string()];
+	assert!(is_ignored("secret.key", &patterns));
+	assert!(is_ignored("certs/ca.key", &patterns));
+	assert!(!is_ignored("key.txt", &patterns));
+}
+#[test]
+fn build_ignored_glob_in_subdir() {
+	let patterns = vec!["logs/*.log".to_string()];
+	assert!(is_ignored("logs/error.log", &patterns));
+	assert!(!is_ignored("other/error.log", &patterns));
+}
+#[test]
+fn glob_match_star_extension() {
+	assert!(glob_match("*.env", "production.env"));
+	assert!(glob_match("*.env", "config/.env"));
+	assert!(!glob_match("*.env", "env.txt"));
+}
+#[test]
+fn glob_match_star_prefix() {
+	assert!(glob_match("id_*", "id_rsa"));
+	assert!(glob_match("id_*", "id_ed25519"));
+	assert!(!glob_match("id_*", "not_id_rsa"));
+}
+#[test]
+fn glob_match_double_star_any_depth() {
+	assert!(glob_match("**/*.key", "secret.key"));
+	assert!(glob_match("**/*.key", "a/b/c/secret.key"));
+	assert!(glob_match("a/**/b", "a/b"));
+	assert!(glob_match("a/**/b", "a/x/y/b"));
+	assert!(!glob_match("a/**/b", "z/b"));
+}
+#[test]
+fn glob_match_question_mark() {
+	assert!(glob_match("file?.txt", "file1.txt"));
+	assert!(!glob_match("file?.txt", "file.txt"));
+	assert!(!glob_match("file?.txt", "file12.txt"));
+}
+#[test]
+fn dockerignore_negation_reincludes() {
+	let patterns = vec!["*.log".to_string(), "!keep.log".to_string()];
+	assert!(is_ignored("error.log", &patterns));
+	assert!(!is_ignored("keep.log", &patterns));
+}
+#[test]
+fn dockerignore_negation_order_matters() {
+	// Re-include then exclude again: last match wins.
+	let patterns = vec![
+		"logs/".to_string(),
+		"!logs/keep/".to_string(),
+		"logs/keep/secret.txt".to_string(),
+	];
+	assert!(is_ignored("logs/a.log", &patterns));
+	assert!(!is_ignored("logs/keep/b.log", &patterns));
+	assert!(is_ignored("logs/keep/secret.txt", &patterns));
+}
+#[test]
+fn build_ignored_empty_pattern_matches_nothing() {
+	// A blank `.dockerignore` line yields an empty pattern that must never
+	// match (otherwise it would exclude every file).
+	let patterns = vec![String::new()];
+	assert!(!is_ignored("anything.txt", &patterns));
+	assert!(!is_ignored("a/b/c", &patterns));
+}
+#[test]
+fn glob_match_double_star_suffix_spans_subtree() {
+	// A trailing `**` matches the directory and everything beneath it.
+	assert!(glob_match("build/**", "build/out.o"));
+	assert!(glob_match("build/**", "build/a/b/out.o"));
+	assert!(!glob_match("build/**", "src/out.o"));
+}
+#[test]
+fn glob_match_double_star_middle_with_no_match_fails() {
+	// `a/**/z` requires the path to start with `a/` and end with `z`; a path
+	// that never reaches the trailing literal exhausts the `**` prefix loop and
+	// fails rather than matching loosely.
+	assert!(glob_match("a/**/z", "a/b/c/z"));
+	assert!(!glob_match("a/**/z", "a/b/c/y"));
+}
+#[test]
+fn glob_match_question_mark_matches_single_non_slash_char() {
+	// `?` matches exactly one character and never a path separator.
+	assert!(glob_match("file?.txt", "file1.txt"));
+	assert!(!glob_match("file?.txt", "file.txt"));
+	assert!(!glob_match("a?b", "a/b"));
+}
+#[test]
+fn ignore_matching_uses_forward_slashes_on_every_platform() {
+	// `.dockerignore` patterns always use `/`. `Path` yields `\` on Windows,
+	// so matching the raw string meant nothing below the top level was ever
+	// ignored there and `vendor/` silently did nothing. The tar writer
+	// already normalises, so the entry names and the ignore check disagreed
+	// about the same file. Caught by the negation case failing on the
+	// Windows runner and passing everywhere else.
+	let rel = std::path::Path::new("vendor").join("drop.txt");
+	assert_eq!(
+		super::to_ignore_path(&rel),
+		"vendor/drop.txt",
+		"the ignore path must be slash-separated whatever the platform uses"
+	);
+	assert!(super::is_ignored(
+		&super::to_ignore_path(&rel),
+		&["vendor/".to_string()]
+	));
+}

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -3,8 +3,7 @@
 //! line limit).
 
 use super::{
-	build_context_tar, build_context_tar_with_inline, glob_match, ignore_file, is_ignored,
-	map_additional_context,
+	build_context_tar, build_context_tar_with_inline, ignore_file, map_additional_context,
 };
 use std::fs;
 use std::path::Path;
@@ -158,92 +157,6 @@ fn dockerfile_is_force_included_despite_dockerignore() {
 }
 
 // is_ignored (build) ---------------------------------------------------
-
-#[test]
-fn build_ignored_exact() {
-	let patterns = vec!["secret.txt".to_string()];
-	assert!(is_ignored("secret.txt", &patterns));
-	assert!(!is_ignored("secret.txt.bak", &patterns));
-}
-
-#[test]
-fn build_ignored_dir() {
-	let patterns = vec!["node_modules/".to_string()];
-	assert!(is_ignored("node_modules/foo.js", &patterns));
-	assert!(!is_ignored("other/foo.js", &patterns));
-}
-
-#[test]
-fn build_ignored_path_separator() {
-	let patterns = vec!["vendor".to_string()];
-	assert!(is_ignored("vendor/lib.rs", &patterns));
-	assert!(!is_ignored("notvendor/lib.rs", &patterns));
-}
-
-#[test]
-fn build_ignored_glob_extension() {
-	let patterns = vec!["*.key".to_string()];
-	assert!(is_ignored("secret.key", &patterns));
-	assert!(is_ignored("certs/ca.key", &patterns));
-	assert!(!is_ignored("key.txt", &patterns));
-}
-
-#[test]
-fn build_ignored_glob_in_subdir() {
-	let patterns = vec!["logs/*.log".to_string()];
-	assert!(is_ignored("logs/error.log", &patterns));
-	assert!(!is_ignored("other/error.log", &patterns));
-}
-
-#[test]
-fn glob_match_star_extension() {
-	assert!(glob_match("*.env", "production.env"));
-	assert!(glob_match("*.env", "config/.env"));
-	assert!(!glob_match("*.env", "env.txt"));
-}
-
-#[test]
-fn glob_match_star_prefix() {
-	assert!(glob_match("id_*", "id_rsa"));
-	assert!(glob_match("id_*", "id_ed25519"));
-	assert!(!glob_match("id_*", "not_id_rsa"));
-}
-
-#[test]
-fn glob_match_double_star_any_depth() {
-	assert!(glob_match("**/*.key", "secret.key"));
-	assert!(glob_match("**/*.key", "a/b/c/secret.key"));
-	assert!(glob_match("a/**/b", "a/b"));
-	assert!(glob_match("a/**/b", "a/x/y/b"));
-	assert!(!glob_match("a/**/b", "z/b"));
-}
-
-#[test]
-fn glob_match_question_mark() {
-	assert!(glob_match("file?.txt", "file1.txt"));
-	assert!(!glob_match("file?.txt", "file.txt"));
-	assert!(!glob_match("file?.txt", "file12.txt"));
-}
-
-#[test]
-fn dockerignore_negation_reincludes() {
-	let patterns = vec!["*.log".to_string(), "!keep.log".to_string()];
-	assert!(is_ignored("error.log", &patterns));
-	assert!(!is_ignored("keep.log", &patterns));
-}
-
-#[test]
-fn dockerignore_negation_order_matters() {
-	// Re-include then exclude again: last match wins.
-	let patterns = vec![
-		"logs/".to_string(),
-		"!logs/keep/".to_string(),
-		"logs/keep/secret.txt".to_string(),
-	];
-	assert!(is_ignored("logs/a.log", &patterns));
-	assert!(!is_ignored("logs/keep/b.log", &patterns));
-	assert!(is_ignored("logs/keep/secret.txt", &patterns));
-}
 
 // ignore_file ----------------------------------------------------------
 
@@ -465,40 +378,6 @@ fn context_tar_packs_symlink_as_link_not_target() {
 	assert!(found, "symlink entry must be present in the context tar");
 }
 
-#[test]
-fn build_ignored_empty_pattern_matches_nothing() {
-	// A blank `.dockerignore` line yields an empty pattern that must never
-	// match (otherwise it would exclude every file).
-	let patterns = vec![String::new()];
-	assert!(!is_ignored("anything.txt", &patterns));
-	assert!(!is_ignored("a/b/c", &patterns));
-}
-
-#[test]
-fn glob_match_double_star_suffix_spans_subtree() {
-	// A trailing `**` matches the directory and everything beneath it.
-	assert!(glob_match("build/**", "build/out.o"));
-	assert!(glob_match("build/**", "build/a/b/out.o"));
-	assert!(!glob_match("build/**", "src/out.o"));
-}
-
-#[test]
-fn glob_match_double_star_middle_with_no_match_fails() {
-	// `a/**/z` requires the path to start with `a/` and end with `z`; a path
-	// that never reaches the trailing literal exhausts the `**` prefix loop and
-	// fails rather than matching loosely.
-	assert!(glob_match("a/**/z", "a/b/c/z"));
-	assert!(!glob_match("a/**/z", "a/b/c/y"));
-}
-
-#[test]
-fn glob_match_question_mark_matches_single_non_slash_char() {
-	// `?` matches exactly one character and never a path separator.
-	assert!(glob_match("file?.txt", "file1.txt"));
-	assert!(!glob_match("file?.txt", "file.txt"));
-	assert!(!glob_match("a?b", "a/b"));
-}
-
 /// #1096: with both ignore files present, only `.containerignore` may filter the
 /// context tar. Applying both client-side is what made podup ship an image
 /// missing content that `podman build` includes: we dropped `b.txt` per
@@ -611,24 +490,4 @@ fn a_negated_file_survives_under_an_ignored_directory() {
 		!names.iter().any(|n| n.ends_with("vendor/drop.txt")),
 		"the rest of the ignored directory must still be dropped, got: {names:?}"
 	);
-}
-
-#[test]
-fn ignore_matching_uses_forward_slashes_on_every_platform() {
-	// `.dockerignore` patterns always use `/`. `Path` yields `\` on Windows,
-	// so matching the raw string meant nothing below the top level was ever
-	// ignored there and `vendor/` silently did nothing. The tar writer
-	// already normalises, so the entry names and the ignore check disagreed
-	// about the same file. Caught by the negation case failing on the
-	// Windows runner and passing everywhere else.
-	let rel = std::path::Path::new("vendor").join("drop.txt");
-	assert_eq!(
-		super::to_ignore_path(&rel),
-		"vendor/drop.txt",
-		"the ignore path must be slash-separated whatever the platform uses"
-	);
-	assert!(super::is_ignored(
-		&super::to_ignore_path(&rel),
-		&["vendor/".to_string()]
-	));
 }

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -566,3 +566,49 @@ fn context_tar_falls_back_to_dockerignore_when_alone() {
 		"`.dockerignore` must still apply when it is the only one: {names:?}"
 	);
 }
+
+#[test]
+fn a_negated_file_survives_under_an_ignored_directory() {
+	// Pruning an ignored directory is only sound when nothing under it can
+	// be re-included. `.dockerignore` negation does exactly that, and the
+	// pruning that landed for the enumeration cost dropped `keep.txt` from
+	// the context, so a `COPY vendor/keep.txt` lost its source.
+	//
+	// The walk's own comment justified the shortcut by asserting the engine
+	// had no such patterns in the wild. That is an assertion about what
+	// users write, and the format supports negation so they can.
+	use flate2::read::GzDecoder;
+	use std::io::Read;
+
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	fs::write(
+		dir.path().join(".dockerignore"),
+		b"vendor/\n!vendor/keep.txt\n",
+	)
+	.unwrap();
+	fs::create_dir(dir.path().join("vendor")).unwrap();
+	fs::write(dir.path().join("vendor/keep.txt"), b"keep me").unwrap();
+	fs::write(dir.path().join("vendor/drop.txt"), b"drop me").unwrap();
+
+	let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+	let mut raw = Vec::new();
+	GzDecoder::new(bytes.as_slice())
+		.read_to_end(&mut raw)
+		.unwrap();
+	let mut archive = tar::Archive::new(raw.as_slice());
+	let names: Vec<String> = archive
+		.entries()
+		.unwrap()
+		.map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+		.collect();
+
+	assert!(
+		names.iter().any(|n| n.ends_with("vendor/keep.txt")),
+		"the re-included file must survive the prune, got: {names:?}"
+	);
+	assert!(
+		!names.iter().any(|n| n.ends_with("vendor/drop.txt")),
+		"the rest of the ignored directory must still be dropped, got: {names:?}"
+	);
+}

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -612,3 +612,23 @@ fn a_negated_file_survives_under_an_ignored_directory() {
 		"the rest of the ignored directory must still be dropped, got: {names:?}"
 	);
 }
+
+#[test]
+fn ignore_matching_uses_forward_slashes_on_every_platform() {
+	// `.dockerignore` patterns always use `/`. `Path` yields `\` on Windows,
+	// so matching the raw string meant nothing below the top level was ever
+	// ignored there and `vendor/` silently did nothing. The tar writer
+	// already normalises, so the entry names and the ignore check disagreed
+	// about the same file. Caught by the negation case failing on the
+	// Windows runner and passing everywhere else.
+	let rel = std::path::Path::new("vendor").join("drop.txt");
+	assert_eq!(
+		super::to_ignore_path(&rel),
+		"vendor/drop.txt",
+		"the ignore path must be slash-separated whatever the platform uses"
+	);
+	assert!(super::is_ignored(
+		&super::to_ignore_path(&rel),
+		&["vendor/".to_string()]
+	));
+}


### PR DESCRIPTION
Both were found by an independent verification of the landed code, not
by a reviewer, and both were reproduced before being fixed.

Directory pruning lost `.dockerignore` re-inclusion. With `vendor/` and
`!vendor/keep.txt`, pruning `vendor` drops `keep.txt` from the context
and a `COPY vendor/keep.txt` loses its source. The walk's own comment
justified the shortcut by asserting the engine had "no negation patterns
in the wild that would re-include a child of an ignored directory". That
is an assertion about what users write, and the format supports negation
so that they can.

Pruning now happens only when no negation pattern could name something
beneath the directory. The check is deliberately conservative: a false
"could reach" costs one descent the leaf filter then discards, while a
wrong "cannot" silently drops a file the user asked to keep. The
optimisation still applies to the ordinary case it was written for, an
ignored subtree with nothing re-included.

The `extends` cache resolved every service in a referenced file before
caching it, so referencing one valid service failed when an unrelated
service in the same file extended something missing. A file you do not
control could break your build over a service you never asked for. The
cache now holds the parsed file and the caller resolves the chain it
needs, which it was already doing on the next line. The parse is what
the cache exists to save, and that saving is untouched: the
parsed-at-most-once case stays green.

The second test asserts both directions. Asking for the broken service
still fails, so this does not simply stop reporting the failure.

Reverting either fix turns its own case red and leaves the other green.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>