### PR TITLE
fix(ui): one tail entry per line, so the board erases what it painted

### DIFF
--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -227,6 +227,31 @@ pub fn start_anchored(
 	emit(sink, kind, name, verb);
 }
 
+/// The lines one stream chunk contributes to a row's tail.
+///
+/// A builder writes several lines in one chunk, and the repaint arithmetic
+/// counts entries: a note holding `\n` is drawn as several terminal rows and
+/// counted as one, so `cursor_up(painted)` lands short and every later
+/// repaint erases too few lines (#1733). Splitting here keeps the invariant
+/// `Region` documents, that one entry is one row.
+///
+/// `split('\n')` rather than `lines()` on purpose: `lines()` also swallows a
+/// trailing `\r`, and the `trim()` here handles `\r\n` anyway, so the two
+/// responsibilities stay apart. Empty parts are dropped, matching what a
+/// single blank line already did.
+fn note_lines(line: &str) -> impl Iterator<Item = &str> {
+	line.split('\n')
+		.map(str::trim)
+		.filter(|part| !part.is_empty())
+}
+
+/// Test hook for [`note_lines`], which is otherwise only reachable through a
+/// live region the cargo-test runner cannot give us.
+#[cfg(test)]
+pub(crate) fn note_lines_for_tests(line: &str) -> Vec<&str> {
+	note_lines(line).collect()
+}
+
 /// Hand one line of a row's stream output to the renderer.
 ///
 /// On a live terminal the line is appended to the per-row tail kept under the
@@ -250,34 +275,49 @@ pub fn note_for(kind: &str, name: &str, line: &str) {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return;
 	};
-	let trimmed = line.trim();
-	if trimmed.is_empty() {
-		return;
-	}
-	let sink = {
-		let Ok(mut slot) = SESSION.lock() else {
-			return;
-		};
-		match slot.as_mut() {
-			Some(session) => {
-				if session.region.is_some() {
-					push_note_live(&mut session.notes, kind, name, trimmed);
-					Sink::Live
-				} else {
-					Sink::Plain
-				}
-			}
-			None => Sink::None,
-		}
-	};
-	match sink {
-		Sink::Live => repaint(),
-		Sink::Plain | Sink::None => {
-			if !super::progress_enabled() {
+	// One entry per line. A builder stream chunk can carry several lines in a
+	// single write, and the repaint arithmetic counts entries: a note holding
+	// `\n` is drawn as several terminal rows but counted as one, so from that
+	// frame on `cursor_up(painted)` lands short and every repaint erases too
+	// few lines. That is the eighty-times-scrolled board in #1733, and
+	// `Region`'s own doc comment predicts it: it says a line that wraps makes
+	// the terminal count two rows where this counted one. An embedded newline
+	// breaks the same invariant by a different route, and the width fit does
+	// not cover it because `chars().take(width)` counts `\n` as an ordinary
+	// character.
+	//
+	// It also restores `MAX_NOTES_PER_ROW`, which a single arbitrarily tall
+	// entry defeats.
+	//
+	// `split('\n')` rather than `lines()` on purpose: `lines()` also swallows
+	// a trailing `\r`, and the `trim()` below handles `\r\n` anyway, so this
+	// keeps the two responsibilities apart.
+	for trimmed in note_lines(line) {
+		let sink = {
+			let Ok(mut slot) = SESSION.lock() else {
 				return;
+			};
+			match slot.as_mut() {
+				Some(session) => {
+					if session.region.is_some() {
+						push_note_live(&mut session.notes, kind, name, trimmed);
+						Sink::Live
+					} else {
+						Sink::Plain
+					}
+				}
+				None => Sink::None,
 			}
-			use std::io::Write;
-			let _ = writeln!(anstream::stderr(), "{name} | {trimmed}");
+		};
+		match sink {
+			Sink::Live => repaint(),
+			Sink::Plain | Sink::None => {
+				if !super::progress_enabled() {
+					return;
+				}
+				use std::io::Write;
+				let _ = writeln!(anstream::stderr(), "{name} | {trimmed}");
+			}
 		}
 	}
 }

--- a/internal/ui/progress/mod_tests.rs
+++ b/internal/ui/progress/mod_tests.rs
@@ -335,3 +335,68 @@ fn a_row_added_after_begin_widens_the_name_column() {
 	reset_plain_buffer();
 	super::super::set_progress(prev_progress);
 }
+
+/// #1733: a builder stream chunk carrying several lines in one write was one
+/// tail entry. The board counted it as one row and the terminal drew it as
+/// several, so `cursor_up(painted)` landed short and every later repaint
+/// erased too few lines. One build scrolled the same block down the terminal
+/// about eighty times.
+#[test]
+fn a_multi_line_chunk_becomes_one_entry_per_line() {
+	assert_eq!(
+		super::super::progress::note_lines_for_tests("a\nb\nc"),
+		vec!["a", "b", "c"],
+		"a chunk with newlines must not stay one entry"
+	);
+}
+
+#[test]
+fn a_crlf_chunk_leaves_no_stray_carriage_return() {
+	// `split('\n')` leaves the `\r` on each part and the `trim()` removes it.
+	// `lines()` would swallow it too, but it would also make the split and
+	// the trimming one decision instead of two.
+	assert_eq!(
+		super::super::progress::note_lines_for_tests("a\r\nb\r\n"),
+		vec!["a", "b"],
+		"a CRLF chunk must produce clean entries"
+	);
+}
+
+#[test]
+fn empty_lines_inside_a_chunk_are_dropped() {
+	// Matches what a single blank line already did before the split.
+	assert_eq!(
+		super::super::progress::note_lines_for_tests("a\n\n   \nb"),
+		vec!["a", "b"],
+		"blank parts must be dropped, as a lone blank line already was"
+	);
+}
+
+#[test]
+fn the_note_cap_still_holds_when_the_input_arrives_as_one_chunk() {
+	// A single arbitrarily tall entry defeated MAX_NOTES_PER_ROW: the cap
+	// counts entries, so one entry of seven lines was one line as far as it
+	// was concerned.
+	let mut notes = std::collections::HashMap::new();
+	for line in super::super::progress::note_lines_for_tests("1\n2\n3\n4\n5\n6\n7") {
+		super::super::progress::push_note_live_for_tests(
+			&mut notes,
+			Kind::Image,
+			"localhost/img:1",
+			line,
+		);
+	}
+	let tail = notes
+		.get(&(Kind::Image, "localhost/img:1".to_string()))
+		.expect("the row's tail is populated");
+	assert_eq!(
+		tail.iter().cloned().collect::<Vec<_>>(),
+		vec![
+			"4".to_string(),
+			"5".to_string(),
+			"6".to_string(),
+			"7".to_string()
+		],
+		"the cap must see one entry per line"
+	);
+}

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -212,6 +212,12 @@ pub fn summary(done: usize, total: usize, width: usize) -> String {
 /// Truncated by character, not by escape sequence, the same way [`render`]
 /// does it.
 pub fn render_note(line: &str, width: usize) -> String {
+	// The invariant this function relies on, asserted where it is relied on
+	// rather than only where it is produced. A note carrying `\n` is drawn as
+	// several rows and counted as one, and the repaint arithmetic then erases
+	// the wrong lines (#1733). `note_for` splits at ingestion; this catches a
+	// future path that does not.
+	debug_assert!(!line.contains('\n'), "a note must be one line: {line:?}");
 	let indented = format!(" {line}");
 	let trimmed = if width > 0 && indented.chars().count() > width {
 		indented.chars().take(width).collect::<String>()


### PR DESCRIPTION
A builder stream chunk carrying several lines in one write became a
single tail entry. The repaint arithmetic counts entries, so the board
counted one row where the terminal drew seven, `cursor_up(painted)`
landed six lines short from that frame on, and one build scrolled the
same block down the terminal about eighty times.

`Region`'s doc comment already stated the invariant: a line that wraps
makes the terminal count two rows where this counted one, and from then
on every repaint erases the wrong lines. The invariant was right and an
embedded newline breaks it by a route the width fit does not cover, since
`chars().take(width)` counts `\n` as an ordinary character.

`note_lines` splits at ingestion, which is also where the trim and the
drop-empty already lived, so one entry is one row again. `split('\n')`
rather than `lines()` on purpose: `lines()` also swallows a trailing
`\r`, and the `trim()` handles `\r\n` anyway, so the split and the
trimming stay two decisions.

It restores `MAX_NOTES_PER_ROW` as well. The cap counts entries, so one
arbitrarily tall entry defeated it.

`render_note` gains a `debug_assert!` that a note carries no newline, so
the invariant is enforced where it is relied on rather than only where it
is produced today.

The split is a pure function with its own test hook, because the live
path needs a region the cargo-test runner cannot give us and the
existing hook enters below the split. Replacing it with a
`std::iter::once` turns the multi-line case red on its own.

Closes #1733.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>