### PR TITLE
release: 5.9.2

### DIFF
--- a/.github/scripts/check-branch-conclusion.sh
+++ b/.github/scripts/check-branch-conclusion.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Decide whether the newest completed run of a workflow on a branch is a
+# pass. Extracted from the step in `reusable-branch-health.yml` so the
+# conclusion logic can be exercised against planted API answers without
+# `gh` or the network.
+#
+# Reads the GitHub API response on stdin (the JSON returned by
+# `repos/:owner/:repo/actions/workflows/:workflow/runs?branch=:branch&status=completed&per_page=1`),
+# prints a one-line summary on stdout, and exits 0 only when the
+# newest run's `conclusion` is `success`.
+#
+# Exits 1 otherwise. The line printed is the same one the workflow step
+# surfaces, so a planted test can match on it.
+
+set -euo pipefail
+
+workflow=${WORKFLOW:?WORKFLOW env var is required}
+branch=${BRANCH:?BRANCH env var is required}
+
+# Pull both fields out of the response in a single `jq` call. `jq` reads
+# stdin exactly once, so two separate calls would race for the input and
+# the second would see nothing. `gh api ... --jq` gives exactly the same
+# shape on a runner; here `jq` is the same dependency the workflow
+# already requires for the JSON parsing elsewhere, so this script does
+# not introduce a new tool.
+#
+# Each filter emits one line, in order, so two reads pick them up cleanly.
+# Joining them on a single tab-separated line and slicing with shell
+# parameter expansion would also work; two reads is the shape the rest of
+# the test suite uses (`grep | sed | while read`) and reads the same way.
+fields="$(jq -r '.workflow_runs[0].conclusion // empty, .workflow_runs[0].html_url // empty')"
+conclusion="$(printf '%s\n' "$fields" | sed -n '1p')"
+run_url="$(printf '%s\n' "$fields" | sed -n '2p')"
+
+if [ -z "$conclusion" ]; then
+	echo "::error::No completed run of ${workflow} on record for branch ${branch}."
+	echo "A protected branch with no completed run is not a branch to release from." >&2
+	exit 1
+fi
+
+echo "Newest completed run of ${workflow} on ${branch}: conclusion=${conclusion}, url=${run_url}"
+
+case "$conclusion" in
+	success)
+		echo "Within the success threshold."
+		exit 0
+		;;
+	failure)
+		echo "::error::Newest completed run of ${workflow} on ${branch} failed: ${run_url}"
+		exit 1
+		;;
+	cancelled)
+		# A cancelled run is a suite that was interrupted, not one that
+		# passed. Reporting it as success would let a published branch
+		# carry a "we never finished" verdict; reporting it as a generic
+		# failure loses the reason. So name it.
+		echo "::error::Newest completed run of ${workflow} on ${branch} was cancelled: ${run_url}"
+		echo "A cancelled run on a protected branch is a published state whose suite was interrupted." >&2
+		exit 1
+		;;
+	skipped)
+		# Skipped is the workflow's own gate deciding not to run for the
+		# branch. On a branch whose `on:` is supposed to cover it, that is
+		# the gate not exercising the protection the comment claims.
+		echo "::error::Newest completed run of ${workflow} on ${branch} was skipped: ${run_url}"
+		echo "A skipped run on a protected branch is the workflow deciding not to exercise the gate." >&2
+		exit 1
+		;;
+	*)
+		# Any other conclusion (timed_out, action_required, neutral,
+		# startup_failure, stale) is also not success. The workflow does
+		# not enumerate them, and this script is the single place that
+		# decides which ones to enumerate.
+		echo "::error::Newest completed run of ${workflow} on ${branch} has unexpected conclusion ${conclusion}: ${run_url}"
+		exit 1
+		;;
+esac

--- a/.github/scripts/check-caller-with-defaults.py
+++ b/.github/scripts/check-caller-with-defaults.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Refuse a caller's `with:` value that differs from the reusable's declared
+default for any input the reusable emits as a required check.
+
+A pull request can edit the caller's `with:` to alter what a required job does
+the same way an `if:` line can switch off a required job: the ruleset matches
+on the CHECK NAME GitHub reports, not on the inputs the job received. Setting
+`coverage-threshold: 76` -> 0 keeps `rust / Coverage` as the name while
+lowering the gate below any failing build, and the same shape holds for
+`msrv: 1.85` -> '', `extra-test-os: '["macos-latest", ...]'` -> '[]',
+`doc-warnings: true` -> false, `extensions: 'rs go ... yml yaml'` -> a subset,
+`working-directory: '.'` -> 'src', and any other input the ruleset depends on.
+
+The fix is to compare each caller's `with:` value to the reusable's declared
+`inputs.X.default`. A value that matches the default is invisible to the
+runner (it would have been applied as the default anyway), so the ruleset
+sees the same job either way. A value that DIFFERS from the default is a
+pull request changing what a required job does; the step refuses it with
+a message that names the file, the job, the input key, the supplied value,
+and the declared default.
+
+The reusable is the place where the value the ruleset assumes is canonicalised.
+A pull request that changes a default is reviewed on the reusable's diff,
+where the ruleset's check name is fixed by definition (the reusable emits
+the same `name:` either way), so the change has to be deliberate and visible.
+
+Same shape as caller-if in reusable-workflow-lint.yml: same static map of
+required reusables, same direct-emitter list (which has no `with:` to
+compare, so it never trips), same `reusable-*` filename filter that exempts
+the reusable's own input declarations. An unknown `with:` key (the reusable
+does not declare it) is silently allowed: GitHub itself ignores it, and
+the ruleset does not gate on it.
+
+Output: writes one `::error` line per violation to stdout, exits 0 on
+clean and 1 on any violation. The step body in
+.github/workflows/reusable-workflow-lint.yml is a thin shell-out to this
+script; the extracted step body the shell test suites run is this script.
+
+Reads: .github/workflows/*.yml, .github/workflows/*.yaml under the working
+directory. Symlinks are not followed: a caller escaping the filter through
+a symlinked workflow file is out of scope.
+"""
+import glob
+import os
+import sys
+
+import yaml
+
+# Same map of required-emitting reusables as the caller-if step in
+# .github/workflows/reusable-workflow-lint.yml. A change here must move
+# together with caller-if: a reusable removed from the ruleset is removed
+# from both lists or the two steps drift in what they consider required.
+REQUIRED_REUSABLES = {
+    "reusable-rust-ci.yml": [
+        "Format & lint", "Test", "Coverage", "Doc warnings",
+        "MSRV", "Extra platforms",
+    ],
+    "reusable-dco.yml": [
+        "Signed-off-by present on every commit",
+    ],
+    "reusable-line-limit.yml": [
+        "line limit",
+    ],
+    "reusable-main-guard.yml": [
+        "develop-only",
+    ],
+    "reusable-workflow-lint.yml": [
+        "workflow-lint",
+    ],
+}
+
+
+def yaml_scalar(value):
+    # The reusable's `inputs.X.default` and the caller's `with.X` value
+    # are both reachable as a Python value after yaml.safe_load.
+    # Comparing them as `==` works for the scalars that matter here
+    # (strings, numbers, booleans, and the JSON-array strings
+    # cargo-cyclonedx and similar tools accept). Lists and dicts do not
+    # appear as declared defaults in the required-emitting reusables
+    # the lint walks; if they ever do, they hit a separate problem
+    # (the default is opaque) and the assertion treats that as "literal
+    # scalar expected".
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list):
+        return value
+    return repr(value)
+
+
+def main():
+    files = sorted(set(
+        glob.glob(".github/workflows/*.yml")
+        + glob.glob(".github/workflows/*.yaml")
+    ))
+
+    # First pass: read each reusable's declared `inputs.X.default`.
+    # The map is `reusable-name -> {key: default}`. An unknown reusable
+    # is not in scope; a caller wrapping it has no `with:` to compare.
+    reusable_defaults = {}
+    for path in files:
+        name = os.path.basename(path)
+        if not name.startswith("reusable-"):
+            continue
+        if name not in REQUIRED_REUSABLES:
+            continue
+        try:
+            with open(path) as fh:
+                spec = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            # Warn and skip; same shape as the other lint steps in this
+            # file. A misconfigured workflow is not this step's reason
+            # to fail the run.
+            print(f"::warning file={path}::skipped: YAML parse error: {e}")
+            continue
+        if not isinstance(spec, dict):
+            continue
+        on = spec.get("on", spec.get(True))
+        if not isinstance(on, dict):
+            continue
+        wc = on.get("workflow_call")
+        if not isinstance(wc, dict):
+            continue
+        inputs = wc.get("inputs")
+        if not isinstance(inputs, dict):
+            continue
+        defaults = {}
+        for key, decl in inputs.items():
+            if not isinstance(decl, dict):
+                continue
+            defaults[key] = yaml_scalar(decl.get("default"))
+        reusable_defaults[name] = defaults
+
+    violations = []
+
+    for path in files:
+        name = os.path.basename(path)
+        # A reusable's own `with:`-shaped block is its `inputs.X.default`
+        # declaration, not a caller override. The reusables are filtered
+        # out for the same reason as caller-if: the `if:` seam carries
+        # the same shape and the same exemption.
+        if name.startswith("reusable-"):
+            continue
+        try:
+            with open(path) as fh:
+                spec = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            print(f"::warning file={path}::skipped: YAML parse error: {e}")
+            continue
+        if not isinstance(spec, dict):
+            continue
+        jobs = spec.get("jobs") or {}
+        if not isinstance(jobs, dict):
+            continue
+        for job_id, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            uses = job.get("uses")
+            if not (isinstance(uses, str) and uses.startswith("./")):
+                # Direct emitters (jobs whose `name:` is the required
+                # check itself) do not pass a `with:` block.
+                continue
+            ref = uses[2:]
+            reusable_name = None
+            for entry in reusable_defaults:
+                if ref.endswith(entry):
+                    reusable_name = entry
+                    break
+            if reusable_name is None:
+                # Caller of a reusable that is not in the required list.
+                # Out of scope; the ruleset matches the reusable's
+                # emitted check name, and a non-required reusable's
+                # gates are advisory, not load-bearing.
+                continue
+            with_inputs = job.get("with")
+            if not isinstance(with_inputs, dict):
+                # No `with:` block at all is the cleanest case: every
+                # input takes its declared default, which is what the
+                # ruleset sees.
+                continue
+            defaults = reusable_defaults[reusable_name]
+            for input_key, supplied in with_inputs.items():
+                if input_key not in defaults:
+                    # The reusable declares no such input. GitHub
+                    # itself ignores an undeclared `with:` key, so the
+                    # lint does too.
+                    continue
+                if yaml_scalar(supplied) != defaults[input_key]:
+                    violations.append((
+                        path, job_id, reusable_name, input_key,
+                        supplied, defaults[input_key],
+                    ))
+
+    if violations:
+        for path, job_id, reusable_name, input_key, supplied, default in violations:
+            print(
+                f"::error file={path}::job `{job_id}` in {path} "
+                f"calls `./{reusable_name}` with `with: "
+                f"{input_key}: {supplied!r}`, which differs from "
+                f"the reusable's declared default "
+                f"`{default!r}`. A pull request can edit this "
+                "value to alter what a required check does "
+                "while the ruleset still matches the same check "
+                "name. Either drop the `with:` entry to let the "
+                "default apply, or update the reusable's "
+                f"`inputs.{input_key}.default` so the value the "
+                "ruleset assumes is the one the caller passes."
+            )
+        sys.exit(1)
+    print(
+        "caller-with-defaults: every caller of a required check "
+        "carries `with:` values equal to the reusable's declared "
+        "defaults."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -191,7 +191,7 @@ jobs:
     # would otherwise cost.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5ac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Run the proto-redir shell fixture

--- a/.github/workflows/asset-contract.yml
+++ b/.github/workflows/asset-contract.yml
@@ -170,6 +170,32 @@ jobs:
           persist-credentials: false
       - name: Run the version-self-test shell fixture
         run: bash tests/fixtures/releases/version-self-test.sh
+  # --proto-redir pin in the shell installer (issue #1722). The flag
+  # restricts the protocol across redirects, so a CDN 302 to http://
+  # is refused at the download rather than fetched from. Nothing
+  # exercised it: the only mentions of proto-redir in the tree were
+  # the comment in install.sh and the curl flag itself. The fixture
+  # stands up a local https listener that 302s to an http listener
+  # serving a valid fixture artifact, sources install.sh's helpers,
+  # and runs the download function against the redirect. The case
+  # asserts the install refused, attributed to the download step
+  # rather than to some later check (so removing --proto-redir
+  # cannot make it pass for the wrong reason).
+  shell-proto-redir:
+    runs-on: ubuntu-latest
+    # Bound: the case starts a python http.server on 127.0.0.1 plus
+    # an openssl one-shot cert. Both are local; no I/O bound on the
+    # network. Worst case observed locally on this hardware was under
+    # 5 s including interpreter start. Ten times that, rounded up,
+    # never under ten minutes; the six-hour default is what a hang
+    # would otherwise cost.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5ac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run the proto-redir shell fixture
+        run: bash tests/fixtures/releases/proto-redir-test.sh
   # Same fixture on Windows so install.ps1's Test-StagedVersion is
   # covered. The PowerShell script extracts the function via AST and
   # runs it against .cmd stubs, so a regression in the strict-equality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
   #
   # max-age-days allows about two periods, so one miss is tolerated:
   # 15 for weekly, 3 for daily, 65 for the monthly benchmark.
+  #
+  # These jobs are ADVISORY and must never be promoted to required status
+  # checks. Each one fails because a cron somewhere else stopped firing, which
+  # has nothing to do with the change under review, so requiring one would
+  # block every pull request for the length of an unrelated outage. The rule
+  # lives in the organisation standard, and it is repeated here because this
+  # file is what somebody wiring a ruleset has open.
   freshness-audit:
     permissions:
       contents: read
@@ -137,6 +144,25 @@ jobs:
   # successful scheduled run on record" until the workflow has reached `main`
   # and its cron has fired once. `pin-watch.yml` (#1526) is waiting for exactly
   # that and gets its entry afterwards.
+  #
+  # `podman-lane-develop-nightly.yml` has a cron and is deliberately NOT
+  # watched here, so that its absence reads as a decision rather than an
+  # oversight. Two reasons, and the second is the blocking one.
+  #
+  # Its output is an observation, not a gate: it reports the coverage of
+  # `develop` under Podman 6 against a floor that no pull request can move,
+  # since the gate a pull request answers to is the 76 per cent threshold on
+  # `rust / Coverage`. A watcher would then report the staleness of a number
+  # nobody is required to keep fresh.
+  #
+  # And a watcher added today would be born red. The guard reads the newest
+  # scheduled run with `status=success`, and measured on 2026-09-06 the last
+  # successful nightly was 2026-09-01: five consecutive nights failed on the
+  # 88 per cent floor (85.51, then 85.38, then 85.40 on the three that print
+  # the figure). A cron that fires nightly and fails nightly is, to this
+  # guard, indistinguishable from a cron that stopped. The entry belongs here
+  # once that lane is green again, not before, and #1380 is where the floor
+  # itself is argued.
 
   # Monthly (`0 4 1 * *`), so seventeen days without a run is normal and a
   # weekly threshold here would fail on ordinary work for most of the month.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,43 @@ jobs:
       workflow: benchmark.yml
       max-age-days: 65
 
+  # Fails when the newest COMPLETED run of `ci.yml` on a protected branch is
+  # not a success. The freshness watchers above cannot catch this: they read
+  # the newest SUCCESSFUL scheduled run, so a failing scheduled run is
+  # missing from their answer by construction. A protected branch whose
+  # gates are red is the published state failing rather than a broken
+  # integration branch, and that is the gap this closes.
+  #
+  # Two jobs, one per branch. They MUST stay separate. Each name carries
+  # the branch it watches, and a single job that watched both would emit
+  # one check name covering two branches - and a check name that does not
+  # move is the property required checks depend on (Glyndor/podup#1552).
+  #
+  # MUST NOT BECOME A REQUIRED STATUS CHECK. A red `main` would then block
+  # the pull request that repairs it, which is the exact failure mode this
+  # check exists to surface. The reason is repeated inside the reusable,
+  # where somebody wiring required checks would look first. Do not remove
+  # either copy.
+  health-main:
+    name: branch health (main)
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+
+  health-develop:
+    name: branch health (develop)
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: develop
+
   # Dependabot silently stops proposing updates when its config is not
   # re-registered, and like a dead cron it reports nothing at all. This fails
   # when no pull request has been opened recently enough.

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -16,6 +16,7 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
+      - "tests/shell/install-help.test.sh"
       - "tests/shell/install-rollback-cleans-staged.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
@@ -42,6 +43,7 @@ on:
       - "tests/shell/reusable-workflow-lint-pin-length.test.sh"
       - "tests/shell/reusable-workflow-lint-caller-with.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
+      - "tests/shell/install-help.test.sh"
       - "tests/shell/install-rollback-cleans-staged.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
@@ -80,7 +82,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh ./tests/shell/install-rollback-cleans-staged.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh ./tests/shell/install-rollback-cleans-staged.test.sh ./tests/shell/install-help.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -16,6 +16,7 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
+      - "tests/shell/install-rollback-cleans-staged.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
   pull_request:
@@ -41,6 +42,7 @@ on:
       - "tests/shell/reusable-workflow-lint-pin-length.test.sh"
       - "tests/shell/reusable-workflow-lint-caller-with.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
+      - "tests/shell/install-rollback-cleans-staged.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -78,7 +80,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh ./tests/shell/install-rollback-cleans-staged.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -57,7 +57,18 @@ jobs:
       # clang/otool (Linux, most non-macOS); the workflow only invokes it,
       # the script only runs the controls where the tools exist, and
       # ci-runs-every-test.test.sh still sees the file as wired.
-      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh
+      #
+      # branch-health-conclusion.test.sh exercises the conclusion script
+      # the branch-health reusable calls.
+      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh
+      # branch-health-conclusion.test.sh pipes API JSON into the
+      # conclusion script and asserts exit codes. jq is the tool that
+      # turns the response into shell-readable lines, and it is not in
+      # the runner's base image. Install it through the reusable's
+      # apt-packages input rather than a one-off step so the dependency
+      # travels with the test, and shellcheck keeps a single place to
+      # see what the suite needs.
+      apt-packages: jq
 
   # The macOS gate on a Mac. The fixture skips where clang/otool/nm are
   # absent, so on the Linux job above it never runs; the first release that

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -36,6 +36,7 @@ on:
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
+      - "tests/shell/reusable-workflow-lint-caller-if.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -73,7 +74,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -37,6 +37,7 @@ on:
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
       - "tests/shell/reusable-workflow-lint-caller-if.test.sh"
+      - "tests/shell/reusable-workflow-lint-pin-length.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -74,7 +75,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -35,9 +35,12 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
+      - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
       - "tests/shell/check-suite-completeness.test.sh"
       - "tests/shell/reusable-workflow-lint-caller-if.test.sh"
       - "tests/shell/reusable-workflow-lint-pin-length.test.sh"
+      - "tests/shell/reusable-workflow-lint-caller-with.test.sh"
+      - "tests/shell/reusable-workflow-lint-tooling-installers.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -75,7 +78,7 @@ jobs:
       # never produces the sentinel, and this check names the file that
       # did not. Without this check, a truncated test and a passing one
       # look the same to the chain: exit 0, no count line.
-      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh ./tests/shell/reusable-workflow-lint-tooling-installers.test.sh ./tests/shell/reusable-workflow-lint-caller-if.test.sh ./tests/shell/reusable-workflow-lint-caller-with.test.sh ./tests/shell/reusable-workflow-lint-pin-length.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -15,6 +15,7 @@ on:
       - ".github/workflows/reusable-shell-ci.yml"
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
+      - "tests/shell/check-suite-completeness.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
   pull_request:
@@ -34,6 +35,7 @@ on:
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
       - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
+      - "tests/shell/check-suite-completeness.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -62,7 +64,16 @@ jobs:
       #
       # branch-health-conclusion.test.sh exercises the conclusion script
       # the branch-health reusable calls.
-      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh && bash ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+      #
+      # check-suite-completeness.test.sh runs every other shell test and
+      # requires each one to print its sentinel (the DONE line is the last
+      # thing every test writes, after the last check and before the
+      # `[ "$fail" -eq 0 ]` gate). A test that exits early -- a planted
+      # `exit 0`, a `set -e` abort, anything that cuts the run short --
+      # never produces the sentinel, and this check names the file that
+      # did not. Without this check, a truncated test and a passing one
+      # look the same to the chain: exit 0, no count line.
+      test-command: bash ./tests/shell/check-suite-completeness.test.sh ./tests/shell/locale-pinned.test.sh ./tests/shell/ci-runs-every-test.test.sh ./tests/shell/check-hardening.test.sh ./tests/shell/check-hardening-macos.test.sh ./tests/shell/branch-health-conclusion.test.sh ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -30,8 +30,10 @@ on:
       # without this line a pull request that touches only the reusable
       # merges without ever running it.
       - ".github/workflows/reusable-shell-ci.yml"
+      - ".github/workflows/reusable-workflow-lint.yml"
       - ".github/scripts/check-hardening-macos.sh"
       - "tests/shell/check-hardening-macos.test.sh"
+      - "tests/shell/reusable-workflow-lint-tooling-isolation.test.sh"
       - ".cargo/**"
       - "Cargo.toml"
 
@@ -60,7 +62,7 @@ jobs:
       #
       # branch-health-conclusion.test.sh exercises the conclusion script
       # the branch-health reusable calls.
-      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh
+      test-command: bash ./tests/shell/locale-pinned.test.sh && bash ./tests/shell/ci-runs-every-test.test.sh && bash ./tests/shell/check-hardening.test.sh && bash ./tests/shell/check-hardening-macos.test.sh && bash ./tests/shell/branch-health-conclusion.test.sh && bash ./tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
       # branch-health-conclusion.test.sh pipes API JSON into the
       # conclusion script and asserts exit codes. jq is the tool that
       # turns the response into shell-readable lines, and it is not in

--- a/.github/workflows/reusable-branch-health.yml
+++ b/.github/workflows/reusable-branch-health.yml
@@ -1,0 +1,116 @@
+name: Branch health (reusable)
+
+# Fails when the newest COMPLETED run of a workflow on a branch is not a
+# success.
+#
+# The companion guard `reusable-schedule-freshness.yml` watches workflows
+# that fire on `event=schedule`; this one watches a workflow on a branch.
+# The two together are the same idea in two places: a thing that is
+# supposed to be true about a workflow is converted from "silence when
+# broken" into a red check on ordinary work, because nobody watches a
+# quiet log.
+#
+# The defect that prompted this file: the freshness watchers cannot catch
+# it. They read the newest SUCCESSFUL scheduled run, so a failing run is
+# missing from their answer by construction. On 2026-09-06 three
+# distribution channels sat with `main` red for twenty minutes after a
+# pull request merged while its suite was still reporting, and the only
+# reason anybody knew is that somebody went looking. The fix the other
+# three shipped was `scripts/check-suite-on-main.sh`; this file mirrors
+# its shape, not its spelling, because those repos are shell-only and
+# this one runs on GitHub Actions.
+#
+# Three states that are NOT failures and must not be reported as one:
+#
+# 1. A run still in progress. `status=completed` in the API query
+#    excludes it, and the comment on the `gh api` line says so. Do NOT
+#    widen the filter to "newest run of any status"; an in-progress run
+#    reported as a failure would defeat the purpose of this check.
+# 2. An empty history. A protected branch whose suite has never
+#    completed is not a branch anybody should be releasing from, so the
+#    empty case fails with a message that says "no completed run on
+#    record". Make that non-fatal only with a reason; the script does
+#    not.
+# 3. A conclusion of `cancelled` or `skipped`, which are neither success
+#    nor failure. Both are decided as failures: a cancelled run is a
+#    suite that was interrupted, and a skipped one is the workflow's own
+#    gate deciding not to exercise the branch it claims to protect.
+#    Reporting either as success would let a published branch carry a
+#    "we never finished" verdict.
+#
+# Permissions: same as the freshness reusable. A called workflow cannot
+# elevate beyond the permissions of the workflow that calls it, and
+# reading this repository's run history needs `actions: read`. Without
+# that grant the run does not start.
+#
+# NOT A REQUIRED STATUS CHECK. A red `main` would then block the pull
+# request that repairs it, which is exactly the situation this check
+# exists to surface. The reason lives beside the `uses:` line below; do
+# not remove it.
+
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        description: >-
+          File name of the workflow to check, e.g. "ci.yml".
+        type: string
+        required: true
+      branch:
+        description: >-
+          Branch to read the newest completed run for, e.g. "main".
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: branch-health-${{ github.workflow }}-${{ github.ref }}-${{ inputs.workflow }}-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  health:
+    name: branch health
+    runs-on: ubuntu-latest
+    # Bound: the request itself is small; ten seconds covers the fetch and the
+    # jq pass. Ten times that, rounded up; the six-hour default is what a hang
+    # would otherwise cost.
+    timeout-minutes: 10
+    permissions:
+      actions: read # reading this repository's workflow-run history
+    steps:
+      # The step below runs a script from this repository, so the tree has to be
+      # here. Without this the job dies with `No such file or directory` and exit
+      # 127, which reads like a broken script rather than a missing checkout.
+      #
+      # `persist-credentials: false` because nothing here writes: the API read
+      # uses GITHUB_TOKEN from the env below, and leaving a credential in the
+      # git config of a job that never pushes is reach it has no use for.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # This step runs as GITHUB_TOKEN, a job-scoped token on its own rate
+      # limit, and reads nothing beyond this repository's own run history. No
+      # personal credential is ever used here, and the `actions: read` grant
+      # above is the whole of what it can reach.
+      - name: Check the newest completed run on the branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW: ${{ inputs.workflow }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          # `status=completed` excludes runs that are queued or in progress;
+          # do NOT widen this to all statuses. A run that is still running
+          # would otherwise be reported as a failure, and the job that
+          # repairs the branch would block itself with a verdict nobody
+          # has finished reaching.
+          #
+          # `per_page=1` returns the newest match. The full set is not
+          # needed; the question is "is the most recent run a success".
+          gh api \
+            "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=${BRANCH}&status=completed&per_page=1" \
+            | bash .github/scripts/check-branch-conclusion.sh

--- a/.github/workflows/reusable-line-limit.yml
+++ b/.github/workflows/reusable-line-limit.yml
@@ -20,12 +20,26 @@ on:
         default: 300
       extensions:
         description: Space-separated source file extensions to check
+        # Pinned: a caller that passes a subset of the configured
+        # extension list narrows what the line-limit gate covers
+        # while the ruleset still requires `line limit`. Workflow
+        # YAML is maintained under the same constraint as the rest
+        # of the source; the gate must continue to read it.
         type: string
-        default: "rs go ts tsx js jsx mjs cjs py sh astro vue svelte"
+        default: "rs go ts tsx js jsx mjs cjs py sh astro vue svelte yml yaml"
       exclude-pattern:
         description: Optional extended regex; matching paths are skipped
+        # Pinned: a caller that passes a different regex narrows what
+        # the line-limit gate covers while the ruleset still
+        # requires `line limit`. The bench scenarios are deliberately
+        # oversized by the benchmark that runs on them, and a
+        # maintainability warning there is noise. The condition: this
+        # holds while bench/scenarios contains only generated or
+        # deliberately-oversized fixtures. The day something
+        # maintained by hand lands there, the exclusion is wrong and
+        # this sentence is where it says so.
         type: string
-        default: ""
+        default: "^bench/scenarios/"
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-rust-ci.yml
+++ b/.github/workflows/reusable-rust-ci.yml
@@ -25,7 +25,13 @@ on:
       coverage-threshold:
         description: Minimum line coverage percentage (0 disables the gate)
         type: number
-        default: 0
+        # Pinned: a caller that passes 0 drops the coverage gate while
+        # the ruleset still requires `rust / Coverage`. The reusable
+        # carries the configured threshold here so callers can use it
+        # by omission; a PR that wants to lower it must move this
+        # default on the reusable's own diff, where the ruleset's
+        # check name stays stable by definition.
+        default: 76
       coverage-ignore-regex:
         description: Regex of file paths to exclude from coverage (e.g. code covered only by a separate DB integration job)
         type: string
@@ -37,7 +43,11 @@ on:
       extra-test-os:
         description: JSON array of extra runner images to also run tests on (e.g. '["macos-latest"]')
         type: string
-        default: "[]"
+        # Pinned: an empty default disables the Extra platforms gate
+        # while the ruleset still requires it. The configured array
+        # lives here so callers omit `with:`; a PR that wants to
+        # drop platforms moves this default on the reusable's diff.
+        default: "[\"macos-latest\", \"windows-latest\"]"
       podman:
         description: Start rootless Podman socket before running the coverage job (ubuntu-latest only)
         type: boolean
@@ -45,7 +55,13 @@ on:
       msrv:
         description: Minimum supported Rust version to verify a --locked build against (empty disables the check)
         type: string
-        default: ""
+        # Pinned: an empty default disables the MSRV job while the
+        # ruleset still requires `rust / MSRV` and the gated name
+        # `rust / MSRV (<version>)`. The configured value lives here
+        # so callers omit `with:`; a PR that wants a different MSRV
+        # moves this default on the reusable's diff, where the gate
+        # name stays stable by definition.
+        default: "1.85"
       package-check:
         description: Run cargo publish --dry-run on PRs to catch packaging breakage before tagging
         type: boolean
@@ -61,7 +77,11 @@ on:
       doc-warnings:
         description: Build the docs with -D warnings so broken doc links fail the build
         type: boolean
-        default: false
+        # Pinned: a caller that passes `false` disables the Doc
+        # warnings gate while the ruleset still requires
+        # `rust / Doc warnings`. The configured value lives here so
+        # callers omit `with:`.
+        default: true
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -360,3 +360,256 @@ jobs:
           if __name__ == "__main__":
               sys.exit(main())
           PY
+
+      # A caller-level `if:` on a job that emits a required check name is a
+      # switch, not a filter. GitHub reports a SKIPPED required check as
+      # SUCCESS, so one `if:` line can switch off coverage, the MSRV floor,
+      # or the validation on both supported Podman majors while the ruleset
+      # reports the gate as satisfied.
+      #
+      # Measured against this repository on 2026-09-06: eleven status checks
+      # are required on `main` and ten on `develop`. Every one of them is
+      # emitted either directly by a job in this tree or by a reusable a job
+      # here calls. Nothing in this repository asserts that property; #1718.
+      #
+      # The interesting case is `if: always()`. It can never evaluate false,
+      # so the job always runs and the check is always reported. Allowed.
+      # That is the load-bearing pattern from #1552: a gate job summarises a
+      # matrix that may fail, so it has to run on `failure` too and reads
+      # `needs.*.result` to make the verdict. The reusable-rust-ci and
+      # podman-lane gates are full of it.
+      #
+      # `if:` lines INSIDE a reusable are not in scope here. They are how
+      # the reusable is configured (`if: inputs.msrv != ''`), and refusing
+      # them would take down the repository by deleting controls. The step
+      # below skips files whose basename starts with `reusable-` so the
+      # rejection cannot reach them.
+      #
+      # Why a list of names and not "any job in any reusable": a ruleset
+      # requires a stable name (Glyndor/podup#1552), so the named set is the
+      # actual contract. A reuse-side `name: foo (bar)` whose value moves
+      # is its own problem; this step refuses a switch in front of it, not
+      # the move.
+      #
+      # Lives here for the same reason tooling-isolation does: a workflow-lint
+      # job inside the shell suite would share the fate of the `if:` it tries
+      # to gate, and any other required job is the one whose `if:` is the
+      # defect being caught.
+      - name: A caller of a required check must not carry a switchable `if:`
+        run: |
+          python3 - <<'PY'
+          import glob
+          import os
+          import sys
+
+          import yaml
+
+          # Reusables whose jobs' `name:` becomes part of a required check
+          # name when a job here calls them. Each entry is the basename of
+          # the reusable; the matching caller is any job with
+          # `uses: ./.github/workflows/<name>`.
+          #
+          # The names below are the ones the rulesets on `main` and `develop`
+          # require, deduplicated and corrected against
+          # `gh pr checks <merged-PR> --required` on 2026-09-06. They move
+          # only when a required check is added or removed, and that is
+          # pulled by reading the live ruleset, not by guessing.
+          REQUIRED_REUSABLES = {
+              "reusable-rust-ci.yml": [
+                  "Format & lint", "Test", "Coverage", "Doc warnings",
+                  "MSRV", "Extra platforms",
+              ],
+              "reusable-dco.yml": [
+                  "Signed-off-by present on every commit",
+              ],
+              "reusable-line-limit.yml": [
+                  "line limit",
+              ],
+              "reusable-main-guard.yml": [
+                  "develop-only",
+              ],
+              "reusable-workflow-lint.yml": [
+                  "workflow-lint",
+              ],
+          }
+
+          # Required check names emitted directly by a job in this
+          # repository, not via a reusable call. The set is the value of
+          # the job's `name:` field that GitHub reports. A future addition
+          # lands here with its check name; the file it sits in is
+          # incidental.
+          DIRECT_EMITTER_NAMES = {
+              "Supported Podman majors",
+          }
+
+          # `if: always()` is the only `if:` value allowed on a caller of
+          # a required check. It evaluates true on every outcome, so the
+          # job runs and the check is reported. Anything else can evaluate
+          # false (`false`, `github.event_name == ...`, `inputs.x`,
+          # `success()`), and a skipped required check reports Success.
+          ALWAYS = "always()"
+
+
+          def is_switchable(value):
+              """True if an `if:` value can skip the job. Anything other
+              than `always()` can, including `true` (redundant but not
+              skip-causing on its own; refuse on principle so the rule is
+              easy to read and the tree does not grow decorative
+              conditionals). The point is that the assertion is precise:
+              the only blessed form is `always()`, and the reason is that
+              it cannot evaluate false."""
+              if isinstance(value, bool):
+                  return True
+              if not isinstance(value, str):
+                  return True
+              # A bare `if:` is evaluated as an expression whether or not
+              # the author wraps it in the dollar-brace form, so the wrapped
+              # spelling of `always()` means the same thing. Comparing the
+              # raw text would refuse it, which is valid and common, and
+              # push somebody to rewrite working code. The wrapper is
+              # stripped once, and only when it wraps the whole value:
+              # `always() && needs.x.result` keeps its tail, stays unequal
+              # and is refused, which is right because it can be false.
+              # The opening delimiter is built rather than written out:
+              # actionlint parses any literal one it finds inside this
+              # `run:` block as an expression of this workflow and fails on
+              # it, which is a real trap for anybody editing this scanner.
+              open_expr = "$" + "{{"
+              text = value.strip()
+              if text.startswith(open_expr) and text.endswith("}}"):
+                  text = text[len(open_expr):-2].strip()
+              return text != ALWAYS
+
+
+          def main():
+              files = sorted(set(
+                  glob.glob(".github/workflows/*.yml")
+                  + glob.glob(".github/workflows/*.yaml")
+              ))
+
+              # First pass: walk the reusables themselves to learn which
+              # required check names each one emits. The map is asserted
+              # against the static list above: a move in a reusable's
+              # `name:` is a defect this step refuses to silently follow.
+              # Skipping reusable-* in the caller scan below is the reason
+              # the static map is needed: those files are scanned for
+              # their own internals, not for how callers use them.
+              reusable_emits = {}
+              for path in files:
+                  name = os.path.basename(path)
+                  if not name.startswith("reusable-"):
+                      continue
+                  if name not in REQUIRED_REUSABLES:
+                      # An unknown reusable is not in scope; a caller
+                      # wrapping it is not gated. Leave it alone.
+                      continue
+                  try:
+                      with open(path) as fh:
+                          spec = yaml.safe_load(fh)
+                  except yaml.YAMLError as e:
+                      print(f"::warning file={path}::skipped: YAML parse error: {e}")
+                      continue
+                  if not isinstance(spec, dict):
+                      continue
+                  expected = set(REQUIRED_REUSABLES[name])
+                  found = set()
+                  jobs = spec.get("jobs") or {}
+                  for job_id, job in jobs.items():
+                      if not isinstance(job, dict):
+                          continue
+                      jname = job.get("name")
+                      if isinstance(jname, str) and jname in expected:
+                          found.add(jname)
+                  missing = expected - found
+                  if missing:
+                      print(
+                          f"::warning file={path}::reusable `{name}` no longer "
+                          f"emits expected required check name(s) {sorted(missing)}; "
+                          "the static map may be stale. Verify against "
+                          "`gh pr checks <merged-PR> --required`."
+                      )
+                  reusable_emits[name] = expected
+
+              violations = []
+
+              for path in files:
+                  name = os.path.basename(path)
+                  # A reusable's own `if:` lines are INSIDE the reusable
+                  # and configure it (`if: inputs.msrv != ''`). They are
+                  # not a caller switch and must stay allowed. The same
+                  # file is also scanned above for the emit assertion.
+                  if name.startswith("reusable-"):
+                      continue
+                  try:
+                      with open(path) as fh:
+                          spec = yaml.safe_load(fh)
+                  except yaml.YAMLError as e:
+                      print(f"::warning file={path}::skipped: YAML parse error: {e}")
+                      continue
+                  if not isinstance(spec, dict):
+                      continue
+                  jobs = spec.get("jobs") or {}
+                  if not isinstance(jobs, dict):
+                      continue
+                  for job_id, job in jobs.items():
+                      if not isinstance(job, dict):
+                          continue
+                      # Direct emitter: the job's `name:` is a required
+                      # check name. The file the job sits in is
+                      # incidental; what the ruleset matches is the
+                      # name GitHub reports.
+                      job_name = job.get("name")
+                      if isinstance(job_name, str) and job_name in DIRECT_EMITTER_NAMES:
+                          required_name = job_name
+                      else:
+                          required_name = None
+                      # Reusable caller: `uses:` references a known
+                      # required-emitting reusable.
+                      caller_required_names = []
+                      uses = job.get("uses")
+                      if isinstance(uses, str) and uses.startswith("./"):
+                          ref = uses[2:]
+                          for entry in reusable_emits:
+                              if ref.endswith(entry):
+                                  caller_required_names = sorted(reusable_emits[entry])
+                                  break
+                      if required_name is None and not caller_required_names:
+                          continue
+                      if "if" not in job:
+                          continue
+                      value = job["if"]
+                      if not is_switchable(value):
+                          # `if: always()` is the blessed form. Allowed.
+                          continue
+                      listed = (
+                          f"required check `{required_name}`"
+                          if required_name is not None
+                          else f"required checks {caller_required_names}"
+                      )
+                      violations.append((
+                          path, job_id, value, listed,
+                      ))
+
+              if violations:
+                  for path, job_id, value, listed in violations:
+                      print(
+                          f"::error file={path}::job `{job_id}` in {path} "
+                          f"emits {listed} and carries a job-level `if:` "
+                          f"of `{value!r}`. A caller-level conditional on a "
+                          "required check is a switch, not a filter: a "
+                          "skipped required check reports Success and does "
+                          "not block a merge. Only `if: always()` is allowed "
+                          "(it always evaluates true). Move the condition "
+                          "into the job's steps, or change it to "
+                          "`if: always()` if that is what you mean."
+                      )
+                  sys.exit(1)
+              print(
+                  "caller-if: every caller of a required check carries no "
+                  "switchable `if:` (only `if: always()` is allowed)."
+              )
+
+
+          if __name__ == "__main__":
+              main()
+          PY

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -111,11 +111,16 @@ jobs:
 
           import yaml
 
-          # `secrets.<id>` is how every GitHub Actions expression reaches a
-          # secret. `secrets: inherit` and `secrets:` declarations on
-          # reusable calls don't match, because those are declaration blocks, not
-          # references, and `secrets:` does not contain a `.`.
-          SECRET_RE = re.compile(r"(?<!\w)secrets\.[A-Za-z_]\w*")
+          # Three forms reach a secret at runtime: `secrets.<id>`,
+          # `secrets['<id>']` and `secrets["<id>"]` (with optional
+          # whitespace inside the brackets). `secrets: inherit` and the
+          # `secrets:` block on a reusable call don't match, because
+          # those are declaration blocks, not references, and `secrets:`
+          # is not followed by `.` or `[`.
+          SECRET_RE = re.compile(
+              r"(?<!\w)secrets(?:\.[A-Za-z_]\w*|\[\s*['\"]"
+              r"[A-Za-z_]\w*['\"]\s*])"
+          )
 
           # (`pattern`, `opt-out marker on the same line`). The marker, when
           # present on the line, exempts that install: the only case where
@@ -159,6 +164,19 @@ jobs:
                   return violations
               if not isinstance(spec, dict):
                   return violations
+
+              # A workflow-level `env:` propagates to every job in the
+              # workflow, so a secret referenced there reaches every step.
+              # `defaults:` only sets `shell` and `working-directory`, not
+              # `env`, so a secret under it does NOT reach a step and is
+              # not in scope here.
+              workflow_env = spec.get("env")
+              workflow_env_text = (
+                  yaml.safe_dump(workflow_env)
+                  if isinstance(workflow_env, dict) else ""
+              )
+              workflow_holds_secret = bool(SECRET_RE.search(workflow_env_text))
+
               jobs = spec.get("jobs") or {}
               for job_id, job in jobs.items():
                   if not isinstance(job, dict):
@@ -168,7 +186,11 @@ jobs:
                   # Comments are stripped by safe_load, so they cannot
                   # produce a false positive.
                   job_text = yaml.safe_dump(job)
-                  if not SECRET_RE.search(job_text):
+                  # The job holds a secret if its own text references one,
+                  # or if the workflow-level env does (every job inherits
+                  # it).
+                  job_holds_secret = bool(SECRET_RE.search(job_text))
+                  if not job_holds_secret and not workflow_holds_secret:
                       continue
                   for step in (job.get("steps") or []):
                       if not isinstance(step, dict):
@@ -184,7 +206,12 @@ jobs:
                               if pattern in line and not (
                                   except_marker and except_marker in line
                               ):
-                                  violations.append((spec_path, job_id, line))
+                                  violations.append((
+                                      spec_path, job_id, line,
+                                      "the workflow-level `env:`"
+                                      if not job_holds_secret
+                                      else "this job",
+                                  ))
                                   break
               return violations
 
@@ -198,9 +225,14 @@ jobs:
               for path in files:
                   violations.extend(find_violations(path))
               if violations:
-                  for path, job_id, line in violations:
+                  for path, job_id, line, source in violations:
+                      # Naming where the secret comes from matters when it is
+                      # not in the job: an author reading "job X holds a
+                      # secret" and seeing no secret in job X concludes the
+                      # check is wrong rather than looking further up the file.
                       msg = (
-                          f"job `{job_id}` installs third-party tooling while holding a secret: "
+                          f"job `{job_id}` installs third-party tooling while holding a secret "
+                          f"from {source}: "
                           f"`{line.strip()}`. See Glyndor/apt#121. Fix by moving the install "
                           f"into a job that holds no secrets, or pin it by hash "
                           f"(e.g. `pip install --require-hashes`)."

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -613,3 +613,120 @@ jobs:
           if __name__ == "__main__":
               main()
           PY
+
+      # A `uses:` pin shorter or longer than 40 hex characters makes the
+      # referenced job unreachable: GitHub answers 422 for any other length,
+      # the workflow's run never starts, and the only thing that notices is
+      # a release that was supposed to be exercised. This is the check
+      # #1741 missed on the way in, and it sits at this layer rather than
+      # in the shell suite for the same reason tooling-isolation does:
+      # the defect is a pin GitHub rejects, and any other required job is
+      # the one whose pinned action never ran.
+      #
+      # Local reusable calls (`uses: ./.github/workflows/x.yml`) carry no
+      # `@` and are naturally excluded: the form has no pin to measure.
+      # The third-party form (`uses: owner/repo@<hex> # vX.Y.Z`) is the
+      # only one with a pin and the only one this check reaches.
+      #
+      # A tag or branch reference (`uses: owner/repo@v7`) fails the same
+      # assertion, and deliberately so: nothing else in this repository
+      # refuses one, and no workflow here uses the form, so measuring it
+      # closes the gap rather than deferring it to a check that does not
+      # exist. `tests/shell/reusable-workflow-lint-pin-length.test.sh`
+      # covers every branch of this step, including that one.
+      - name: Every `uses:` pin must be 40 hex characters
+        run: |
+          python3 - <<'PY'
+          import glob
+          import re
+          import sys
+
+          # A SHA-1 pin is exactly 40 lowercase hex characters. Anything
+          # shorter is the defect #1741 caught: a 39-character copy-paste
+          # typo GitHub answers 422 for, leaving the workflow's job never
+          # to run. Anything longer is rejected for the same reason.
+          SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+
+          # `uses:` at the start of a YAML scalar value, optionally
+          # preceded by a list dash. Captures the value to end-of-line;
+          # the trailing `# vX.Y.Z` comment rides along and is stripped
+          # by the part-split below.
+          USES_LINE_RE = re.compile(
+              r"^\s*-\s+uses:\s*(\S.*?)\s*$|^\s*uses:\s*(\S.*?)\s*$"
+          )
+
+
+          def find_violations(spec_path):
+              out = []
+              try:
+                  with open(spec_path) as fh:
+                      lines = fh.readlines()
+              except OSError as exc:
+                  # Silent skip would hide a workflow the linter cannot
+                  # read; reporting as a warning keeps the silence
+                  # visible the way tooling-isolation does.
+                  print(
+                      f"::warning file={spec_path}::skipped: {exc}",
+                      file=sys.stderr,
+                  )
+                  return out
+              for n, raw in enumerate(lines, start=1):
+                  line = raw.rstrip("\n")
+                  if line.lstrip().startswith("#"):
+                      continue
+                  m = USES_LINE_RE.match(line)
+                  if m is None:
+                      continue
+                  value = m.group(1) or m.group(2)
+                  if value is None:
+                      continue
+                  # Local reusable form: `uses: ./.github/workflows/x.yml`.
+                  # No pin, no `@`, not in scope.
+                  if value.startswith("./"):
+                      continue
+                  if "@" not in value:
+                      # No `@` at all is a malformed reference GitHub
+                      # rejects before it gets as far as a pin, and it
+                      # carries nothing to measure.
+                      continue
+                  _owner_repo, _at, after = value.partition("@")
+                  # The pin is the leading whitespace-separated token of
+                  # everything after `@`; the trailing `# vX.Y.Z` rides
+                  # along but does not enter the pin.
+                  pin = after.split()[0] if after.split() else ""
+                  if not SHA1_RE.match(pin):
+                      out.append((spec_path, n, value, pin))
+              return out
+
+
+          def main():
+              files = sorted(set(
+                  glob.glob(".github/workflows/*.yml")
+                  + glob.glob(".github/workflows/*.yaml")
+              ))
+              violations = []
+              for path in files:
+                  violations.extend(find_violations(path))
+              if violations:
+                  for path, line_no, value, pin in violations:
+                      print(
+                          f"::error file={path}::line {line_no}: "
+                          f"`uses:` value `{value}` pins to `{pin}`, "
+                          f"which is {len(pin)} characters; a SHA-1 "
+                          f"pin must be exactly 40 hexadecimal "
+                          f"characters. GitHub answers 422 for any "
+                          f"other length and the job never runs. A tag "
+                          f"or branch name is refused for a second "
+                          f"reason: it moves, so it is not a pin."
+                      )
+                  sys.exit(1)
+              print(
+                  "checkout-pin-length: every `uses:` pin in "
+                  ".github/workflows/ is exactly 40 hexadecimal "
+                  "characters."
+              )
+
+
+          if __name__ == "__main__":
+              main()
+          PY

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -16,6 +16,119 @@ name: Workflow lint (reusable)
 # pinned version (shell-ci.yml). Installing the same pinned shellcheck here
 # and pointing actionlint at it with -shellcheck keeps that pass reproducible
 # too.
+#
+# ===========================================================================
+# Release-path workflows and the ruleset (#1745)
+# ===========================================================================
+#
+# The caller-if and caller-with-defaults steps in this file both reference a
+# static map of "required" reusables (REQUIRED_REUSABLES) and a static map
+# of "required" direct emitters (DIRECT_EMITTER_NAMES). Those maps name the
+# checks the ruleset requires on `main` and `develop`. Five reusables and
+# one direct emitter are wired. The release path -- the workflows that build,
+# sign, attest and verify the artifacts that publish as a GitHub release --
+# is not on that list. That is the deliberate state at the time of this
+# writing, and the rationale is what follows.
+#
+# The rule that says "do not promote a check that has never failed for the
+# right reason" is in `~/.claude/CLAUDE.md`:
+#
+#   A gate that never has failed is not tested. Before marking a check as
+#   required, provoke the failure on purpose and confirm it goes red for
+#   the right reason.
+#
+# The release-path workflows are not required today because none of them
+# has been demonstrated to fail at the gate they would defend. Promoting
+# any of them would replace "no failure observed" with "no failure
+# possible": a required check whose name matches a workflow that runs
+# green regardless of what the pull request changes is a green check
+# that blocks the merge. The cost is real, the value is zero, and a
+# future operator looking at this file is the right place to be told so.
+#
+# The release-path workflows that touch a PR, what each would have to
+# demonstrate to become a required check, and where it would sit:
+#
+#   asset-contract.yml:check
+#     Calls reusable-installer-contract.yml. Today this fires once per
+#     PR that touches install.sh, install.ps1, release.yml, or any of
+#     the release-script paths. To be promoted: provoke a deliberate
+#     drift between install.sh's ARTIFACT template and release.yml's
+#     asset: matrix (rename one, do not rename the other, push a PR
+#     that touches only install.sh and confirm this job exits red with
+#     a message that names the missing asset). The job's name would
+#     pin to its current `check` (`release / install.sh <-> release
+#     asset names` or similar; the reusable's emit map below would
+#     carry the value).
+#
+#   asset-contract.yml:shell-signing-fixture
+#     Runs the per-asset .sig loop fixture in Linux bash. To be
+#     promoted: delete one of the seed signature files in the fixture
+#     tree, push a PR, confirm the fixture's loop falls through to the
+#     missing-file branch and exits red with the L7 class of error
+#     pinned in tests/fixtures/releases/test.sh. Pin the job's name
+#     once the failure is reproducible.
+#
+#   asset-contract.yml:powershell-signing-fixture
+#     Same fixture in PowerShell, on windows-latest. The acceptance
+#     is the same (a missing .sig reaches the L7 branch and the job
+#     exits red under pwsh). Both fixtures are tested on
+#     windows-latest; either promotion would require a windows-latest
+#     failure to be reproducible there.
+#
+#   asset-contract.yml:shell-version-self-test
+#     Drives verify_version_self_test in install.sh against a set of
+#     .cmd stubs (matching, older, -dev suffix, garbage, non-zero
+#     exit, missing file). To be promoted: edit the fixture to skip
+#     one of the cases and confirm the job reads red. Same shape for
+#     powershell-version-self-test, on windows-latest.
+#
+#   asset-contract.yml:rust-self-test-reference
+#     `cargo test --locked -p podup install::tests::self_test` at the
+#     configured MSRV, mirroring the shell installer path. To be
+#     promoted: disable a branch of `self_test`, run the job, confirm
+#     the rust test goes red. The job's name is the cargo test's
+#     harness path; if it moves, the ruleset has to be rewritten.
+#
+#   asset-contract.yml:shell-proto-redir
+#     Stands up a local https listener that 302s to an http listener,
+#     sources install.sh's helpers, runs the download, and asserts
+#     the install refused. The case the fixture exercises today is
+#     `--proto-redir` catching the downgrade. To be promoted: remove
+#     the `--proto-redir` flag from the install helper, run the
+#     fixture, confirm it goes red on the install side rather than
+#     somewhere later.
+#
+# `release.yml`'s jobs (verify, build, build-deb, sbom, release) are
+# not on this list at all: the workflow triggers on tag push, not on
+# pull_request, so its jobs cannot be required status checks for PRs.
+# They cannot be promoted because promotion means "matched by name
+# against a ruleset that gates merges", and a merge gate is a PR gate.
+# If at some future point the release path needs defence the day a tag
+# is cut, the rule that would carry it is a tag-protection rule rather
+# than a branch-protection rule, and the candidate fixtures above
+# (asset-contract.yml's six jobs) are what would do that defence on
+# the PR that produced the tag.
+#
+# All six candidates live in asset-contract.yml, which is already in
+# the ruleset's pull-request filter, so the path filter does not need
+# to move for any promotion. What each promotion needs is the
+# demonstrate-the-failure step above, run against a deliberately-broken
+# fixture, with the resulting red PR carrying the message so a future
+# operator can see what the check catches. After the demonstration
+# the static map REQUIRED_REUSABLES (or DIRECT_EMITTER_NAMES) grows
+# by one entry, the ruleset on `main` (and `develop`, where the ruleset
+# duplicates the `main` rule) gains the new check, and the failures
+# that would have escaped before that PR appear in the ruleset's red
+# list from then on.
+#
+# The lint itself is the wrong place to verify the demonstration. A
+# step that says "every release-path candidate has been demonstrated"
+# is a step that requires the demonstration to have run, and the
+# demonstration is by construction a thing that happened once in the
+# past. A static check would be lying. The actual verification is the
+# PR that first landed the failure-mode fixture, the comparison of the
+# red log against the expected reason, and the follow-up that turns
+# the candidate into a required check.
 
 on:
   workflow_call:
@@ -126,13 +239,36 @@ jobs:
           # present on the line, exempts that install: the only case where
           # the resolved tree is fixed is pip with --require-hashes, which
           # reads the lockfile verbatim and installs exactly what it lists.
+          #
+          # Property-based list (every entry is a known way to pull code
+          # from outside this org and have it run on the runner; the
+          # literal-string list this replaced caught the obvious shapes
+          # and missed synonyms like `cargo binstall`, `pip3 install`,
+          # `python -m pip install`, `python3 -m pip install`, `pipx
+          # install`, and `dotnet tool install`). The release signing
+          # job holds `GLYNDOR_RELEASE_ED25519_KEY` and runs `pip install
+          # --quiet --require-hashes -r .github/scripts/sign-requirements
+          # .txt`, which executes the cryptography package's native build
+          # script; hashed, so it is exempt, and the build script runs.
+          # The release target's own build-script count is 14 (cargo
+          # metadata --filter-platform x86_64-unknown-linux-gnu),
+          # confirmed against 15 directories in target/release/build (one
+          # of which is podup's own build script); the whole lockfile
+          # graph with dev-deps is 33, and an acceptance built on 33 would
+          # exempt crates the release never builds.
           INSTALL_PATTERNS = (
               ("cargo install",   None),
+              ("cargo binstall",  None),
               ("go install",      None),
               ("gem install",     None),
               ("npm install -g",  None),
               ("npm i -g",        None),
+              ("dotnet tool install", None),
               ("pip install",     "--require-hashes"),
+              ("pip3 install",    "--require-hashes"),
+              ("python -m pip install",  "--require-hashes"),
+              ("python3 -m pip install", "--require-hashes"),
+              ("pipx install",    None),
           )
 
 
@@ -730,3 +866,43 @@ jobs:
           if __name__ == "__main__":
               main()
           PY
+
+      # The caller-if step above refuses a job-level `if:` that can
+      # skip a required job. The same defect repeats through a
+      # different lever: a `with:` value a pull request can change that
+      # alters what a required job does. The ruleset matches on the
+      # CHECK NAME GitHub reports, not on the inputs the job received;
+      # `coverage-threshold: 76` -> 0 keeps `rust / Coverage` as the
+      # name while lowering the gate below any failing build, and the
+      # same shape holds for `msrv: 1.85` -> '', `extra-test-os:
+      # '["macos-latest", ...]'` -> '[]', `doc-warnings: true` ->
+      # false, `extensions: 'rs go ... yml yaml'` -> a subset,
+      # `working-directory: '.'` -> 'src'. Each is a different lever
+      # for the same outcome the ruleset cannot see.
+      #
+      # The fix is to compare each caller's `with:` value to the
+      # reusable's declared `inputs.X.default`. A value that matches
+      # the default is invisible to the runner (it would have been
+      # applied as the default anyway), so the ruleset sees the same
+      # job either way. A value that DIFFERS from the default is a
+      # pull request changing what a required job does; the step
+      # refuses it with a message that names the file, the job, the
+      # input key, the supplied value, and the declared default.
+      #
+      # The reusable is the place where the value the ruleset
+      # assumes is canonicalised. A pull request that changes a
+      # default is reviewed on the reusable's diff, where the
+      # ruleset's check name is fixed by definition (the reusable
+      # emits the same `name:` either way), so the change has to be
+      # deliberate and visible.
+      #
+      # Lives in .github/scripts/check-caller-with-defaults.py because
+      # the inline heredoc would push this file over the line-limit
+      # gate's 500-line hard limit, and the same shape as caller-if
+      # above (static map, direct-emitter list, `reusable-*` filter)
+      # already lives next to it in this file. An unknown `with:` key
+      # (the reusable does not declare it) is silently allowed: GitHub
+      # itself ignores it, and the ruleset does not gate on it.
+      - name: A caller of a required check must carry `with:` equal to the reusable's declared default
+        run: |
+          python3 .github/scripts/check-caller-with-defaults.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.9.1"
+version = "5.9.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,10 @@ temp-env = "0.3"
 # dev-dependency features out of the shipped binary): the fake-Podman test
 # harness (`internal/engine/fake_podman.rs`) reads/writes a raw HTTP/1.1
 # request over a Unix socket by hand, needing `AsyncReadExt`/`AsyncWriteExt`.
-tokio = { version = "1", features = ["io-util"] }
+# `test-util` enables `#[tokio::test(start_paused = true)]` and
+# `tokio::time::pause()`, which the hijack-timeout tests need to verify
+# wall-clock ceilings without making the suite wait thirty real seconds.
+tokio = { version = "1", features = ["io-util", "test-util"] }
 
 [workspace]
 exclude = ["bench/timeit", "fuzz"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.9.1"
+version = "5.9.2"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,46 @@
 podup (5.9.2) unstable; urgency=medium
 
+  * SECURITY: a compose file could smuggle arbitrary `podman run` and
+    `podman volume create` flags through the generated Quadlet units. A
+    `security_opt` entry such as "apparmor=unconfined --privileged --net=host
+    -v /:/hostfs" reached podman as separate flags, so a hostile file could
+    run privileged on the host network with the host root bind-mounted, and
+    neither the `privileged` warning nor the `audit` finding said anything.
+    Every value podup interpolates into a unit is quoted now, on both halves
+    of a key=value, and `%` is doubled so systemd does not expand it.
+  * SECURITY: `autostart install --mode quadlet`, the command that writes and
+    starts the units, skipped the validator that `generate quadlet` runs. The
+    same file could be refused by one command and installed by the other.
+  * SECURITY: `cp` from a container followed a symlink planted in the archive
+    and moved the contents of the directory it pointed at, so a compromised
+    container could empty a directory outside the copy.
+  * SECURITY: two ways to switch off the YAML alias guards, an apostrophe in a
+    plain scalar and a quote inside the other quote, let a small file expand
+    to gigabytes. Interpolation is also bounded across the whole document now,
+    not one scalar at a time.
+  * SECURITY: on Windows, `.dockerignore` patterns never matched anything
+    below the top level, because the path was compared with the platform
+    separator against a pattern written with `/`. An ignored subdirectory was
+    sent to the builder anyway.
+  * `logs` no longer stops at about 1 MiB and exits 0. The cap counted every
+    byte ever received rather than what was still held, so a long stream of
+    small frames tripped it.
+  * `audit` reads the value the engine will use rather than the field as
+    written: `mem_limit: not-a-size` is no longer reported as a memory limit,
+    and a dangerous `cap_add` is named with the reason it is dangerous.
+  * `top` fetches the project's containers once instead of once per service,
+    and `images` inspects each image once instead of once per service.
+  * The build board no longer redraws itself down the terminal when a builder
+    writes several lines in one chunk.
+  * The libpod connection pool no longer hands out a connection before hyper
+    is ready for it. The pool stays off by default.
+  * `podup cp` and the build context walk keep `.dockerignore` re-inclusion
+    working: a `!vendor/keep.txt` under an ignored `vendor/` survives again.
   * `audit` stops reporting `unpinned_image` against a tag the service builds
-    itself: a `build:` section makes the tag a local output, not an unpinned
-    pull, so the finding was noise on every compose file that builds.
-  * `audit` matches `secret_in_environment` on name segments rather than
-    substrings, so a variable whose name merely contains a flagged word, for
-    example `PASSWORD_FILE_PATH` alongside `NOT_A_PASSWORD_HINT`, is no longer
-    reported on the substring alone.
+    itself, and matches `secret_in_environment` on name segments rather than
+    substrings.
 
- -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 07 Sep 2026 00:05:00 -0500
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 08 Sep 2026 20:25:00 -0500
 
 podup (5.9.1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+podup (5.9.2) unstable; urgency=medium
+
+  * `audit` stops reporting `unpinned_image` against a tag the service builds
+    itself: a `build:` section makes the tag a local output, not an unpinned
+    pull, so the finding was noise on every compose file that builds.
+  * `audit` matches `secret_in_environment` on name segments rather than
+    substrings, so a variable whose name merely contains a flagged word, for
+    example `PASSWORD_FILE_PATH` alongside `NOT_A_PASSWORD_HINT`, is no longer
+    reported on the substring alone.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Mon, 07 Sep 2026 00:05:00 -0500
+
 podup (5.9.1) unstable; urgency=medium
 
   * `up --build` draws one board: the image rows sit at the top and are

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,7 @@ These appear before the subcommand and may also come from the environment.
 | `-f, --file <PATH>` | `COMPOSE_FILE` | Compose file. Repeatable; later files merge over earlier ones. When unset, the compose-spec precedence list is probed: `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`. |
 | `-p, --project <NAME>` | `COMPOSE_PROJECT_NAME` | Project name, prefixing container/network/volume names. When unset: the top-level `name:`, then the sanitized project-directory basename. |
 | `--socket <PATH>` | `PODMAN_SOCKET` | Podman socket path; overrides auto-detection. |
-| `--connection-pool-size <N>` | `PODUP_LIBCOD_POOL` | Maximum HTTP/1.1 connections the libpod client keeps open to the Podman socket for reuse. Streaming calls each take a dedicated connection outside this cap. Default: 8. |
+| `--connection-pool-size <N>` | `PODUP_LIBPOD_POOL` | Maximum HTTP/1.1 connections the libpod client keeps open to the Podman socket for reuse. Streaming calls each take a dedicated connection outside this cap. Default: 0, which means no pool; connection reuse is opt-in. The earlier spelling `PODUP_LIBCOD_POOL` (a typo of `LIBPOD`) is read as a fallback when the new name is unset, so an existing script that exports the old name keeps working. |
 | `--profile <NAMES>` | `COMPOSE_PROFILES` | Active profiles, comma-separated. |
 
 | `--project-directory <PATH>` | | Base directory for relative paths (env_file, build context, bind mounts, config/secret sources). Defaults to the compose file's directory. |
@@ -865,7 +865,7 @@ when both are set.
 | `COMPOSE_PROJECT_NAME` | Default project name (`--project`). |
 | `COMPOSE_PROFILES` | Default active profiles (`--profile`). |
 | `PODMAN_SOCKET` | Podman socket path (`--socket`). |
-| `PODUP_LIBCOD_POOL` | HTTP/1.1 connection-pool size for the libpod client (`--connection-pool-size`). Default 8. |
+| `PODUP_LIBPOD_POOL` | HTTP/1.1 connection-pool size for the libpod client (`--connection-pool-size`). Default 0 (no pool); connection reuse is opt-in. `PODUP_LIBCOD_POOL` (the earlier typo'd name) is still read when the new name is unset. |
 | `DOCKER_HOST` | Docker-compatible fallback for the Podman socket, used only when `PODMAN_SOCKET` is unset. Must be a local `unix://` socket (or `npipe://` on Windows); a remote `tcp://`/`ssh://` value is rejected. |
 | `RUST_LOG` | Log verbosity filter. Unset shows warnings and errors; e.g. `RUST_LOG=podup=info` or `RUST_LOG=podup=debug` for more detail. |
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -233,9 +233,9 @@ data into a process or onto disk:
   a filesystem path from it.
 - **URL paths** go through `urlencoded` so container names, project names,
   and tags with arbitrary bytes reach libpod as a single encoded segment.
-- **Quadlet values** are filtered through `escape_unit_value` /
-  `safe_unit_stem`; the unit filename is checked again by `write_units` so
-  a poisoned value cannot break out of the output directory.
+- **Quadlet values** are filtered through `escape_unit_value` and the dedicated
+  `PodmanArgs=` interpolations use `quote_podman_arg_value`; the unit filename is
+  checked again by `write_units` so a poisoned value cannot break out of the output directory.
 - **Signal names** are resolved to numbers through `resolve_stop_signal`:
   the libpod endpoint is a number, a string returns HTTP 500.
 - **Pull policies** are normalised through `libpod_pull_policy`; an

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,40 @@ fail() {
 }
 
 usage() {
-	sed -n '3,21p' "$0" | sed 's/^# \{0,1\}//'
+	# The previous version read the help from this script's own header
+	# via `sed -n '3,21p' "$0"`. That works for `./install.sh --help`
+	# and `bash install.sh --help`, but fails the documented pipe
+	# `curl ... | bash -s -- --help` because $0 there is the program
+	# name "bash", not the script path: the helper tries to read a file
+	# literally named "bash" and exits with `sed: can't read bash`.
+	# The header is also unreachable from /dev/stdin in that mode;
+	# bash has already consumed the piped script bytes for parsing by
+	# the time the function runs, so /dev/stdin is empty.
+	#
+	# The heredoc duplicates the header deliberately. The script header
+	# is the source of truth by convention, so any drift between the two
+	# is detected by `install_help_matches_header` in the shell suite.
+	cat <<'USAGE'
+podup installer.
+
+Default: download a release binary, verify it and install it to a directory.
+Updates come from `podup update`.
+
+  curl -fsSL https://glyndor.net/podup/install/unix | bash
+
+--apt (Debian/Ubuntu, amd64/arm64): set up the Glyndor apt repository and install
+with apt. Updates - including signing-key renewals - come from `apt upgrade`.
+
+  curl -fsSL https://glyndor.net/podup/install/unix | bash -s -- --apt
+
+--skip-podman-check: bypass the local-Podman-version precheck. Use this when
+the engine podup will use is on a different host than the local podman
+binary (e.g. a `podman machine` VM, or a remote socket).
+
+Environment:
+  PODUP_VERSION      Release tag to install (e.g. v0.3.0). Default: latest.
+  PODUP_INSTALL_DIR  Installation directory (binary mode). Default: /usr/local/bin.
+USAGE
 	exit 0
 }
 

--- a/install.sh
+++ b/install.sh
@@ -243,6 +243,12 @@ PYEOF
 # past the `3.7.0` check, which is the rollback case this gate exists
 # to reject. Matches the Rust behaviour token-for-token.
 #
+# The cleanup of the staged file goes through `run_root`: when the install
+# ran via sudo the staged binary is owned by root, and a bare `rm -f` from
+# the caller would fail silently, leaving a root-owned executable in
+# /usr/local/bin while this function printed that the file had been
+# removed. `run_root rm` elevates the same way the install itself did.
+#
 #   verify_version_self_test <staged-path> <resolved-tag>
 verify_version_self_test() {
 	local staged="$1" expected_tag="$2"
@@ -253,7 +259,7 @@ verify_version_self_test() {
 	# hidden name; reading --version requires execute permission but no
 	# read/ownership on the parent.
 	if ! reported="$("$staged" --version 2>/dev/null)"; then
-		rm -f "$staged" 2>/dev/null || true
+		run_root rm -f "$staged" 2>/dev/null || true
 		fail "Could not run ${staged} --version to self-test the staged binary"
 	fi
 
@@ -265,7 +271,7 @@ verify_version_self_test() {
 			return 0
 		fi
 	done
-	rm -f "$staged" 2>/dev/null || true
+	run_root rm -f "$staged" 2>/dev/null || true
 	log_error "Staged binary reports '${reported}', expected ${expected_tag}"
 	fail "Refusing to install: staged binary's --version does not match the resolved release tag (possible rollback) - the staged file has been removed"
 }

--- a/install.sh
+++ b/install.sh
@@ -97,10 +97,13 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 download() {
 	# download <url> <dest>
 	#
-	# --proto '=https' only restricts the initial URL: GitHub release assets
-	# redirect to its CDN, and that redirect is governed by --proto-redir, not
-	# --proto, so it needs its own pin - this is the fix that actually closes
-	# the downgrade (an unpinned redirect could otherwise fall back to http).
+	# --proto '=https' denies http, and that denial carries over to redirects:
+	# curl's own manual says protocols denied by --proto are not overridden by
+	# --proto-redir. Measured on curl 8.18.0 and 7.81.0 against a local https
+	# origin answering 302 to an http URL: the redirect is refused with or
+	# without --proto-redir. The pin stays as a second lock, because the bare
+	# form --proto https adds rather than restricts, and under that spelling
+	# --proto-redir is the only thing holding the redirect to https.
 	# --max-filesize caps the response at 200 MB, but only on curl that honours
 	# it: it aborts mid-stream on curl >= 8.4.0, or on any curl version when the
 	# server sends Content-Length. It does NOT bound the size on an older curl

--- a/internal/audit/audit_tests.rs
+++ b/internal/audit/audit_tests.rs
@@ -1,16 +1,21 @@
+use std::path::Path;
+
 use podup::parse_str;
 
 use crate::audit;
+use crate::cli::ConfigFormat;
+use crate::startup::{render_config_to, ConfigOutput};
 
 // ---------------------------------------------------------------------------
 // Test scaffolding
 // ---------------------------------------------------------------------------
 
 // Pull the names this test file reaches for into scope so the body reads as
-// straight assertions rather than naming the path every line.
+// straight assertions rather than naming the path every time.
 #[allow(unused_imports)]
 use super::{
-	audit_file, ordered_services, render_json, render_table, AuditReport, Finding as _, Finding,
+	audit_file, ordered_services, render_json, render_json_to, render_table, render_table_to,
+	AuditReport, Finding as _, Finding,
 };
 
 // ---------------------------------------------------------------------------
@@ -222,4 +227,205 @@ fn audit_secret_in_environment_flags_a_value_that_only_ends_in_a_brace() {
 
 fn report_for_file(yaml: &str) -> AuditReport {
 	audit_file(&parse_str(yaml).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// #1746 entry 2: terminal-escape injection in five sinks.
+//
+// The detail lines emitted by `podup audit` and the four `podup config
+// --services/--volumes/--images/--profiles/--hash` projections print
+// user-controlled compose values verbatim. A compose file authored by a
+// third party can therefore inject raw terminal escapes; the cross-review
+// noted that the bytes survive a pipe, because the rendering path is just
+// `println!("{user_value}")`.
+//
+// The five sinks:
+//
+//   1. `audit` table detail lines (`render_table_to`)
+//   2. `config --services` (`render_config_to`)
+//   3. `config --volumes`  (`render_config_to`)
+//   4. `config --images`   (`render_config_to`)
+//   5. `config --profiles` (`render_config_to`)
+//
+// The audit table cells and the JSON renderer are intentionally out of
+// scope: the table goes through `Table::print` -> `fit_cell` ->
+// `sanitize_cell`, and `serde_json` escapes every control character. The
+// "16 raw ESC bytes" payload the issue names only reaches the operator
+// through the five unescaped sinks above, so this test pins those five
+// and ignores the rest.
+//
+// The fix routes every user-controlled value through
+// `podup::ui::sanitize_cell`, the same gate the table already uses. The
+// test asserts that the bytes never appear verbatim, regardless of which
+// user-controlled slot the attacker writes them into.
+//
+// The YAML parser itself rejects raw control characters in scalars, so
+// the attack reaches the parsed model through env-var interpolation:
+// the compose file says `image: $HOSTILE` and the operator's
+// environment sets `HOSTILE` to the byte sequence. The interpolated
+// scalar fallback in `merge::interpolate_scalar` stores the resolved
+// string verbatim when the bytes are not a valid YAML scalar. The test
+// constructs the `ComposeFile` directly with the interpolated values to
+// pin the renderer behaviour without coupling to the parser's own
+// rejection (which the issue does not ask to change).
+// ---------------------------------------------------------------------------
+
+/// The payload the issue names: a 16-byte sequence that, raw, asks the
+/// terminal to clear the screen and move the cursor home. The exact
+/// content does not matter; what matters is that the byte stream the
+/// renderer produces for a sink using the value does not contain any
+/// raw `\x1b` byte.
+const HOSTILE: &str = "\x1b[2J\x1b[HINJECTED";
+
+/// A `ComposeFile` whose every user-controlled slot the renderers
+/// consume carries the same hostile payload. The service name is left
+/// valid (compose validation rejects ESC chars in service names, so
+/// that vector is not reachable from a YAML file in production); the
+/// other slots are not validated against control characters and reach
+/// the renderers verbatim when the typed model is built with them.
+///
+/// Specifically, each field is the value a different sink prints:
+///
+///   - `services.web.image`: the audit reason (via
+///     `check_unpinned_image`) AND the `config --images` projection
+///   - `services.web.cap_add`: the audit reason (via
+///     `check_dangerous_capability`)
+///   - `services.web.profiles`: the `config --profiles` projection
+///   - `volumes[HOSTILE]`: the `config --volumes` projection
+///
+/// `Service` and `ComposeFile` are `#[non_exhaustive]`, so the test
+/// builds a clean file from a safe YAML first, then mutates the typed
+/// model in place to plant the hostile payload. This is the same shape
+/// a hostile env-var interpolation (`image: $HOSTILE` with
+/// `HOSTILE=\x1b[2J:latest`) would leave the model in: a string field
+/// carrying a sequence of bytes the YAML parser would have refused, but
+/// the typed model carries without question.
+fn hostile_compose() -> podup::compose::types::ComposeFile {
+	let yaml = "services:\n  web:\n    image: nginx:1.27\n    cap_add: [SYS_ADMIN]\n    \
+	            profiles: [safe]\nvolumes:\n  data: null\n";
+	let mut file = podup::parse_str(yaml).expect("safe compose parses");
+	let web = file.services.get_mut("web").expect("web present");
+	web.image = Some(format!("{HOSTILE}:latest"));
+	web.cap_add = vec![HOSTILE.to_string()];
+	web.profiles = vec![HOSTILE.to_string()];
+	// The named volume reaches the `config --volumes` projection
+	// directly. Volumes are not validated against control characters;
+	// a hostile env interpolation would land here.
+	let vol = file
+		.volumes
+		.shift_remove("data")
+		.expect("data volume present");
+	file.volumes.insert(HOSTILE.to_string(), vol);
+	file
+}
+
+fn assert_no_hostile(label: &str, bytes: &[u8]) {
+	// The hostile payload is a literal byte sequence, not a generic
+	// "any ESC byte" check. Podup's own styling always emits SGR
+	// sequences (`\x1b[1m`, `\x1b[0m`), so a raw byte count would
+	// alert on those too; the meaningful signal is whether the exact
+	// payload the attacker planted reaches the byte stream.
+	let haystack = String::from_utf8_lossy(bytes);
+	assert!(
+		!haystack.contains(HOSTILE),
+		"{label} carried the hostile payload verbatim; the attacker's compose file reached the \
+		 operator's terminal. Output was: {haystack}",
+	);
+}
+
+#[test]
+fn hostile_compose_does_not_inject_escapes_into_audit_table_detail_lines() {
+	// Sink 1: the audit table's per-finding detail lines. The service name
+	// and the reason both come from user-controlled compose data; both
+	// must be sanitized through `sanitize_cell` before they reach the byte
+	// stream the operator (or a pipe) sees.
+	let file = hostile_compose();
+	let report = audit_file(&file);
+	let services = ordered_services(&file);
+	let mut buf: Vec<u8> = Vec::new();
+	render_table_to(&mut buf, &services, &report).expect("render");
+	assert_no_hostile("audit detail lines", &buf);
+	// Positive control: the renderer did produce output, and the host's
+	// word (sanitized) is still in the byte stream somewhere. Without
+	// this assertion a test that simply returned no output would also
+	// pass `assert_no_hostile`.
+	let out = String::from_utf8_lossy(&buf);
+	assert!(
+		out.contains("INJECTED"),
+		"the host's word is gone entirely: {out}"
+	);
+}
+
+#[test]
+fn hostile_compose_does_not_inject_escapes_into_config_list_projections() {
+	// Sinks 2..5: the four `config` list-projection branches all print a
+	// value taken from the compose file. They share the `_to` writer so a
+	// single test covers all four.
+	let file = hostile_compose();
+	let mut buf: Vec<u8> = Vec::new();
+
+	let projections: [(&str, ConfigOutput); 4] = [
+		(
+			"--services",
+			ConfigOutput {
+				services: true,
+				..Default::default()
+			},
+		),
+		(
+			"--volumes",
+			ConfigOutput {
+				volumes: true,
+				..Default::default()
+			},
+		),
+		(
+			"--images",
+			ConfigOutput {
+				images: true,
+				..Default::default()
+			},
+		),
+		(
+			"--profiles",
+			ConfigOutput {
+				profiles: true,
+				..Default::default()
+			},
+		),
+	];
+	for (name, out) in projections {
+		buf.clear();
+		render_config_to(
+			&mut buf,
+			&file,
+			&ConfigFormat::Yaml,
+			&out,
+			"proj",
+			Path::new("/proj"),
+		)
+		.unwrap_or_else(|e| panic!("{name} render: {e}"));
+		assert_no_hostile(name, &buf);
+	}
+
+	// Sink 6: `config --hash` also prints the service name. The branch
+	// runs the same `sanitize_cell` gate as the other projections.
+	buf.clear();
+	render_config_to(
+		&mut buf,
+		&file,
+		&ConfigFormat::Yaml,
+		&ConfigOutput {
+			hash: Some("*".to_string()),
+			..Default::default()
+		},
+		"proj",
+		Path::new("/proj"),
+	)
+	.expect("--hash render");
+	assert_no_hostile("--hash", &buf);
+	// The 64-character hex hash is bytes we own, so the only sanitized
+	// thing in this line is the service name. The print still produces a
+	// line per service, so the line count is exactly one.
+	assert_eq!(buf.iter().filter(|&&b| b == b'\n').count(), 1);
 }

--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -7,6 +7,11 @@
 //! that turns the eleven named checks into a flat `Vec<Finding>`.
 
 use podup::compose::types::{ComposeFile, Service};
+use podup::size;
+// The audit must read the runtime value a `security_opt` entry resolves to,
+// not the raw compose-side text (#1743). `podup::effective_no_new_privileges`
+// calls the engine's own `parse_security_opts` so the two cannot drift again.
+use podup::effective_no_new_privileges;
 
 use super::Finding;
 
@@ -153,21 +158,52 @@ fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> V
 	out
 }
 
-/// `cap_add: [SYS_ADMIN]` or `cap_add: [ALL]`, Linux capabilities that
-/// effectively grant root inside the container.
+/// `cap_add: [SYS_ADMIN]`, `cap_add: [SYS_MODULE]`, or any other capability
+/// in the curated dangerous list. The runtime honours exactly what was
+/// asked for, so reading the resolved value cannot narrow the audit; this
+/// check exists because the spec has no opinion about which capabilities
+/// are dangerous, and the operator who ships `--strict` in CI needs one
+/// (`#1743`).
 fn check_dangerous_capability(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
 	let mut out = Vec::new();
 	for cap in &service.cap_add {
-		let cap = normalized_capability(cap);
-		if cap == "SYS_ADMIN" || cap == "ALL" {
+		if let Some(reason) = dangerous_capability_reason(&normalized_capability(cap)) {
 			out.push(finding(
 				name,
 				"dangerous_capability",
-				&format!("cap_add: {cap} grants root-equivalent capability"),
+				&format!("cap_add: {cap}: {reason}"),
 			));
 		}
 	}
 	out
+}
+
+/// Returns the reason a normalised capability (`CAP_` stripped,
+/// upper-cased) is on the dangerous list, or `None` when it is not. The
+/// list is curated against the CIS Docker Benchmark and the Podman
+/// hardening notes: each entry either grants a path to host-level
+/// compromise (kernel / syscall / audit), breaks the container's file
+/// or device isolation, or subverts networking in a way that lets one
+/// container attack another. `SYS_ADMIN` and `ALL` are the obvious
+/// root-equivalents; the rest are the narrower capabilities an attacker
+/// chains into the same outcome.
+fn dangerous_capability_reason(cap: &str) -> Option<&'static str> {
+	Some(match cap {
+		"ALL" => "every capability, equivalent to root",
+		"SYS_ADMIN" => "broad kernel administration, effectively root",
+		"SYS_MODULE" => "load or unload kernel modules (root-equivalent)",
+		"DAC_READ_SEARCH" => "bypass file read and directory search permission checks",
+		"SYS_RAWIO" => "raw I/O port access, can crash or compromise the host kernel",
+		"SYS_PTRACE" => "ptrace any process, including those in other containers",
+		"NET_ADMIN" => "arbitrary network interface and routing changes",
+		"SYS_BOOT" => "reboot or halt the host from inside the container",
+		"MKNOD" => "create device nodes that mimic host block devices",
+		"SYSLOG" => "read the kernel ring buffer (information disclosure)",
+		"AUDIT_CONTROL" => "configure the kernel audit subsystem",
+		"AUDIT_WRITE" => "tamper with the audit log",
+		"SETFCAP" => "set arbitrary file capabilities on host binaries",
+		_ => return None,
+	})
 }
 
 /// `read_only` not set to `true`, the container's rootfs is writable.
@@ -207,18 +243,13 @@ fn check_no_cap_drop_all(name: &str, service: &Service, _file: &ComposeFile) -> 
 
 /// `security_opt` without `no-new-privileges:true`. Podman spells it
 /// `no-new-privileges` (no `:true`); both spellings are accepted. The check
-/// iterates each entry and looks for a prefix match on either spelling; a
-/// bare `no-new-privileges` (no value) also passes.
+/// asks the engine's own `parse_security_opts` for the resolved value
+/// (`#1743`): the engine splits on `:` or `=` and last-wins, so an audit
+/// that splits on `:` only disagrees with the runtime on every docker-form
+/// `=true` and on contradictory multi-entry lists like
+/// `[no-new-privileges:true, no-new-privileges:false]`.
 fn check_no_new_privileges_off(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
-	// Podman spells it `no-new-privileges` alone or `no-new-privileges:true`;
-	// `no-new-privileges:false` is the option being switched off, not on.
-	let has = service.security_opt.iter().any(|opt| {
-		let mut parts = opt.splitn(2, ':');
-		let head = parts.next().unwrap_or(opt);
-		let value = parts.next().unwrap_or("true");
-		head == "no-new-privileges" && value == "true"
-	});
-	if has {
+	if effective_no_new_privileges(service) == Some(true) {
 		Vec::new()
 	} else {
 		vec![finding(
@@ -245,18 +276,25 @@ fn check_no_pids_limit(name: &str, service: &Service, _file: &ComposeFile) -> Ve
 
 /// Neither `mem_limit` nor `deploy.resources.limits.memory` set, no upper
 /// bound on memory. A misbehaving service can OOM the host.
+///
+/// Reads both fields through the same `parse_memory` the engine uses to
+/// build `LinuxResources` (`#1743`): a value like `mem_limit: not-a-size`
+/// keeps the compose field non-empty, so an `.is_none()` audit reads it
+/// as a limit, but `parse_memory` returns `None` and the runtime applies
+/// no limit at all. The audit must agree with what the engine will build.
 fn check_no_memory_limit(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
+	let mem_top = service.mem_limit.as_deref().and_then(size::parse_memory);
 	let deploy_limit = service
 		.deploy
 		.as_ref()
 		.and_then(|d| d.resources.as_ref())
 		.and_then(|r| r.limits.as_ref())
-		.and_then(|l| l.memory.as_ref());
-	if service.mem_limit.is_none() && deploy_limit.is_none() {
+		.and_then(|l| l.memory.as_deref().and_then(size::parse_memory));
+	if mem_top.is_none() && deploy_limit.is_none() {
 		vec![finding(
 			name,
 			"no_memory_limit",
-			"neither mem_limit nor deploy.resources.limits.memory is set: a leak can OOM the host",
+			"neither mem_limit nor deploy.resources.limits.memory is parseable: a leak can OOM the host",
 		)]
 	} else {
 		Vec::new()

--- a/internal/audit/checks.rs
+++ b/internal/audit/checks.rs
@@ -124,7 +124,12 @@ fn check_privileged(name: &str, service: &Service, _file: &ComposeFile) -> Vec<F
 }
 
 /// Host-binding namespacing modes: `pid`, `ipc`, `uts`, `cgroup`, `userns_mode`
-/// set to `host`, or `network_mode: host`. One finding per active mode.
+/// set to `host` or `container:<id>`, or `network_mode` carrying the same. One
+/// finding per active mode. The `container:<id>` form is the share-another-
+/// container mode the runtime detector in
+/// `internal/engine/container/host_mode.rs` already warns on; the audit
+/// detector must agree, otherwise `podup audit --strict` would pass a file
+/// the engine later refuses to run silently (#1746).
 fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> Vec<Finding> {
 	let mut out = Vec::new();
 	if let Some(mode) = service.network_mode.as_deref() {
@@ -133,6 +138,14 @@ fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> V
 				name,
 				"host_namespace",
 				"network_mode: host shares the host's network namespace",
+			));
+		} else if let Some(target) = mode.strip_prefix("container:") {
+			out.push(finding(
+				name,
+				"host_namespace",
+				&format!(
+					"network_mode: container:{target} shares another container's network namespace"
+				),
 			));
 		}
 	}
@@ -151,6 +164,14 @@ fn check_host_namespace(name: &str, service: &Service, _file: &ComposeFile) -> V
 					name,
 					"host_namespace",
 					&format!("{field}: host shares the host's {field} namespace"),
+				));
+			} else if let Some(target) = mode.strip_prefix("container:") {
+				out.push(finding(
+					name,
+					"host_namespace",
+					&format!(
+						"{field}: container:{target} shares another container's {field} namespace"
+					),
 				));
 			}
 		}

--- a/internal/audit/checks_more_tests.rs
+++ b/internal/audit/checks_more_tests.rs
@@ -181,3 +181,65 @@ fn audit_no_new_privileges_off_flags_an_explicit_false() {
 	);
 	assert!(report.iter().any(|f| f.check == "no_new_privileges_off"));
 }
+
+// ---------------------------------------------------------------------------
+// #1743: audit must read the resolved value the engine will use
+// ---------------------------------------------------------------------------
+//
+// Each of the three tests below targets one of the issue's findings and is
+// built from a compose file that `audit --strict` accepted on the unfixed
+// tree but must not afterwards. They are the issue's acceptance criterion,
+// and were failing when the brief was written. Keeping them in a single
+// section so the file's `grep "1743"` lands the reviewer on the lot.
+
+/// `mem_limit: not-a-size` keeps the compose field non-empty, so an
+/// `.is_none()` audit reads it as a limit, but `parse_memory` returns
+/// `None` and the runtime applies no limit. The audit must agree.
+#[test]
+fn audit_no_memory_limit_flags_an_unparseable_limit() {
+	let report =
+		report_for("services:\n  web:\n    image: alpine:3.20\n    mem_limit: not-a-size\n");
+	assert!(
+		report.iter().any(|f| f.check == "no_memory_limit"),
+		"a mem_limit the runtime cannot parse must still fire: {report:#?}"
+	);
+}
+
+/// `security_opt: [no-new-privileges:true, no-new-privileges:false]`: the
+/// engine last-wins (resolves to disabled), the unfixed audit iterates and
+/// finds the first entry matches (resolves to enabled). The two must agree.
+#[test]
+fn audit_no_new_privileges_off_flags_contradictory_entries() {
+	let report = report_for(
+		"services:\n  web:\n    image: alpine:3.20\n    security_opt:\n      - no-new-privileges:true\n      - no-new-privileges:false\n",
+	);
+	assert!(
+		report.iter().any(|f| f.check == "no_new_privileges_off"),
+		"contradictory security_opt entries where the engine disables the \
+		 protection must fire: {report:#?}"
+	);
+}
+
+/// The runtime honours exactly what was asked for in `cap_add:`. The audit
+/// must reject the curated dangerous list (`SYS_MODULE` and friends)
+/// regardless of what the engine does with them.
+#[test]
+fn audit_dangerous_capability_flags_the_curated_list() {
+	let report = report_for(
+		"services:\n  web:\n    image: alpine:3.20\n    cap_add: [SYS_MODULE, DAC_READ_SEARCH, SYS_RAWIO]\n",
+	);
+	assert!(
+		report.iter().any(|f| f.check == "dangerous_capability"),
+		"SYS_MODULE / DAC_READ_SEARCH / SYS_RAWIO must fire: {report:#?}"
+	);
+	// Every entry in the curated list is its own finding, so the count
+	// pins the list rather than just any-of.
+	assert_eq!(
+		report
+			.iter()
+			.filter(|f| f.check == "dangerous_capability")
+			.count(),
+		3,
+		"three distinct dangerous_capability findings expected: {report:#?}"
+	);
+}

--- a/internal/audit/checks_tests.rs
+++ b/internal/audit/checks_tests.rs
@@ -151,12 +151,12 @@ fn audit_dangerous_capability_flags_sys_admin_and_all() {
 }
 
 #[test]
-fn audit_dangerous_capability_passes_when_empty() {
+fn audit_dangerous_capability_passes_when_safe() {
 	let yaml = r#"
 services:
   web:
     image: alpine:3.20
-    cap_add: [NET_ADMIN]
+    cap_add: [CHOWN]
 "#;
 	let findings = report_for(yaml);
 	assert!(

--- a/internal/audit/checks_tests.rs
+++ b/internal/audit/checks_tests.rs
@@ -107,6 +107,55 @@ fn audit_host_namespace_flags_pid_ipc_uts_cgroup_userns_host() {
 	}
 }
 
+/// `container:<id>` is the share-another-container mode the runtime
+/// detector in `internal/engine/container/host_mode.rs` already warns
+/// on; the audit detector must agree, otherwise `podup audit --strict`
+/// would pass a file the engine later refuses silently (#1746 entry 4).
+/// The two lists are now one: every mode the runtime flags, the audit
+/// flags, so a finding on the same file is consistent across the two
+/// commands.
+#[test]
+fn audit_host_namespace_flags_container_id_on_every_namespace_field() {
+	for (yaml_field, expected_field) in [
+		("pid: container:sidecar", "pid"),
+		("ipc: container:sidecar", "ipc"),
+		("uts: container:sidecar", "uts"),
+		("cgroup: container:sidecar", "cgroup"),
+		("userns_mode: container:sidecar", "userns_mode"),
+	] {
+		let yaml = format!("services:\n  web:\n    image: alpine:3.20\n    {yaml_field}\n");
+		let findings = report_for(&yaml);
+		assert!(
+			findings.iter().any(|f| f.check == "host_namespace"
+				&& f.reason.contains(expected_field)
+				&& f.reason.contains("container:sidecar")),
+			"expected host_namespace finding for `{yaml_field}` mentioning the \
+			 target id; got {findings:#?}"
+		);
+	}
+}
+
+/// `network_mode: container:<id>` is its own branch (the field is a
+/// sibling of the per-namespace keys, not one of them). Cover it
+/// separately so a regression that fixes the `pid`/`ipc`/... loop but
+/// leaves `network_mode` behind gets caught.
+#[test]
+fn audit_host_namespace_flags_network_mode_container_id() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    network_mode: container:sidecar
+"#;
+	let findings = report_for(yaml);
+	assert!(
+		findings.iter().any(|f| f.check == "host_namespace"
+			&& f.reason.contains("network_mode")
+			&& f.reason.contains("container:sidecar")),
+		"expected network_mode container:<id> finding; got {findings:#?}"
+	);
+}
+
 #[test]
 fn audit_host_namespace_passes_when_clean() {
 	let yaml = r#"

--- a/internal/audit/mod.rs
+++ b/internal/audit/mod.rs
@@ -8,6 +8,8 @@
 //! [`render_table`]/[`render_json`] functions translate the result into the
 //! `--format table|json` output the CLI asked for.
 
+use std::io::{self, Write};
+
 use podup::compose::types::{ComposeFile, Service};
 
 mod checks;
@@ -95,7 +97,28 @@ pub fn ordered_services(file: &ComposeFile) -> Vec<(&str, &Service)> {
 /// finding with `  <service>: <check>: <reason>` indented two spaces. When
 /// nothing was found, only the line `no findings` is printed, the table is
 /// suppressed so a CI log without any findings is minimal.
+///
+/// Service names and reasons are user-controlled (compose YAML), so the
+/// detail lines route them through `sanitize_cell` before printing; the
+/// table itself already does that via `Table::print`. Without sanitization
+/// a malicious compose file injects raw ESC bytes into the operator's
+/// terminal, and the bytes survive a pipe because `println!` is just a
+/// byte stream.
 pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
+	let stdout = io::stdout();
+	let mut out = stdout.lock();
+	let _ = render_table_to(&mut out, services, report);
+}
+
+/// [`render_table`] writing to `w`, factored out so tests can capture the
+/// rendered bytes without redirecting the process's stdout. The sanitization
+/// of user-controlled values happens here, not in the caller, so every sink
+/// of audit output goes through the same gate.
+pub fn render_table_to<W: Write>(
+	w: &mut W,
+	services: &[(&str, &Service)],
+	report: &AuditReport,
+) -> io::Result<()> {
 	let mut table = podup::ui::Table::new(&["SERVICE", "FINDINGS"]);
 	for (name, mine) in report.by_service(services) {
 		let findings = if mine.is_empty() {
@@ -106,18 +129,24 @@ pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
 		table.push(vec![(*name).to_string(), findings]);
 	}
 	if report.findings.is_empty() {
-		println!("no findings");
-		return;
+		writeln!(w, "no findings")?;
+		return Ok(());
 	}
-	table.print();
+	table.print_to(w)?;
 	for finding in &report.findings {
-		println!(
-			"  {service}: {check}: {reason}",
-			service = finding.service,
-			check = finding.check,
-			reason = finding.reason,
-		);
+		// `check` is a hardcoded `'static str`, so only the user-controlled
+		// `service` and `reason` need sanitizing. Going through `sanitize_cell`
+		// keeps the table cell and detail line consistent: same function,
+		// same rules, no drift between the two surfaces an attacker can read.
+		writeln!(
+			w,
+			"  {}: {}: {}",
+			podup::ui::sanitize_cell(&finding.service),
+			finding.check,
+			podup::ui::sanitize_cell(&finding.reason),
+		)?;
 	}
+	Ok(())
 }
 
 /// Render `report` as a single JSON line to stdout. `serde_json` orders the
@@ -127,6 +156,18 @@ pub fn render_table(services: &[(&str, &Service)], report: &AuditReport) {
 /// Empty finding lists emit `{"findings":[]}`, never `null`, so an empty
 /// body is still valid JSON without the consumer having to special-case it.
 pub fn render_json(report: &AuditReport) {
+	let stdout = io::stdout();
+	let mut out = stdout.lock();
+	render_json_to(&mut out, report).expect("write to stdout");
+}
+
+/// [`render_json`] writing to `w`. JSON output is already safe from terminal
+/// injection: `serde_json` escapes every control character (`\x1b` becomes
+/// `\u001b`), so a malicious compose file's bytes round-trip as escape
+/// sequences inside a JSON string rather than as live escapes on the
+/// terminal. The sink is exposed so a test can compare the exact JSON it
+/// produces against the same input.
+pub fn render_json_to<W: Write>(w: &mut W, report: &AuditReport) -> io::Result<()> {
 	let findings: Vec<serde_json::Value> = report
 		.findings
 		.iter()
@@ -139,7 +180,7 @@ pub fn render_json(report: &AuditReport) {
 		})
 		.collect();
 	let out = serde_json::json!({ "findings": findings });
-	println!("{out}");
+	writeln!(w, "{out}")
 }
 
 #[cfg(test)]

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -134,6 +134,7 @@ pub fn install_quadlet<S: SystemCtl>(
 		)));
 	}
 
+	quadlet::validate_for_quadlet(file)?;
 	let result = quadlet::generate_at(file, project, base_dir);
 	if let Some(dup) = result.duplicate_filename() {
 		return Err(ComposeError::Autostart(format!(

--- a/internal/autostart/quadlet.rs
+++ b/internal/autostart/quadlet.rs
@@ -188,9 +188,18 @@ pub fn install_quadlet<S: SystemCtl>(
 			written.len()
 		);
 	} else {
-		for svc in &services {
-			checked(sc.systemctl(&["start", svc]), &format!("start {svc}"))?;
-		}
+		// One `systemctl --user start svc1 svc2 ...` call instead of one fork
+		// per service: systemd serializes the starts whether they were the
+		// operands of a single call or separate ones, so the only difference
+		// at the binary level was the per-service process fork (#1747).
+		let svc_args: Vec<&str> = services.iter().map(String::as_str).collect();
+		let mut args: Vec<&str> = Vec::with_capacity(svc_args.len() + 1);
+		args.push("start");
+		args.extend(svc_args);
+		checked(
+			sc.systemctl(&args),
+			&format!("start {}", services.join(" ")),
+		)?;
 		eprintln!(
 			"podup: started {} container service(s) for '{project}'",
 			services.len()

--- a/internal/autostart/quadlet/tests.rs
+++ b/internal/autostart/quadlet/tests.rs
@@ -99,6 +99,8 @@ fn with_env<R>(f: impl FnOnce(&Path) -> R) -> R {
 }
 
 const IMG: &str = "services:\n  web:\n    image: nginx\n";
+const IMG_MULTI: &str =
+	"services:\n  web:\n    image: nginx\n  api:\n    image: nginx\n  worker:\n    image: nginx\n";
 const BUILD: &str = "services:\n  web:\n    build: .\n";
 const BASE: &str = "/srv/app";
 
@@ -148,6 +150,56 @@ fn no_start_reloads_but_starts_nothing() {
 		.unwrap();
 		assert!(root.join("containers/systemd/proj-web.container").is_file());
 		assert_eq!(sc.log(), vec![vec!["daemon-reload".to_string()]]);
+	});
+}
+
+/// #1747 (L6): three services would have caused three forks of
+/// `systemctl --user start`. The fix bundles the whole project's services
+/// onto one argv: `systemctl --user start svc-a.service svc-b.service
+/// svc-c.service`. systemd serializes them whether they came in on one
+/// argv or several, so the only practical change is the fork count. The
+/// test asserts the bundled shape directly so a regression to the
+/// per-service loop is caught.
+#[test]
+fn install_starts_every_service_in_a_single_systemctl_call() {
+	with_env(|_root| {
+		let sc = FakeCtl::new();
+		install_quadlet(
+			&sc,
+			&parse_str(IMG_MULTI).unwrap(),
+			"proj",
+			Path::new(BASE),
+			false,
+			false,
+		)
+		.unwrap();
+		let calls = sc.log();
+		assert_eq!(
+			calls[0],
+			vec!["daemon-reload".to_string()],
+			"the daemon-reload must still be its own call"
+		);
+		// One start call, with every service bundled onto the argv. N forks
+		// of systemd would have meant N consecutive `["start", "<svc>"]`
+		// entries in the call log.
+		let starts: Vec<_> = calls
+			.iter()
+			.filter(|c| c.first().map(String::as_str) == Some("start"))
+			.collect();
+		assert_eq!(
+			starts.len(),
+			1,
+			"every container service must share one `systemctl start` call, not one each: {calls:?}"
+		);
+		let start = starts[0];
+		assert_eq!(start[0], "start", "the verb is `start`: {start:?}");
+		assert!(
+			start.len() >= 4
+				&& start.contains(&"proj-web.service".to_string())
+				&& start.contains(&"proj-api.service".to_string())
+				&& start.contains(&"proj-worker.service".to_string()),
+			"every generated service must appear as an argv operand: {start:?}"
+		);
 	});
 }
 

--- a/internal/cli/mod.rs
+++ b/internal/cli/mod.rs
@@ -136,10 +136,13 @@ pub(crate) struct Cli {
 	pub(crate) socket: Option<String>,
 
 	/// Maximum number of HTTP/1.1 connections the libpod client keeps open
-	/// to the Podman socket for reuse (or `PODUP_LIBCOD_POOL`). Buffered calls
+	/// to the Podman socket for reuse (or `PODUP_LIBPOD_POOL`). Buffered calls
 	/// share the pool; streaming calls each take a dedicated connection
-	/// outside this cap. Default: 8.
-	#[arg(long, env = "PODUP_LIBCOD_POOL", global = true, value_name = "N")]
+	/// outside this cap. Default: 0, which means no pool; connection reuse is opt-in. The earlier spelling
+	/// `PODUP_LIBCOD_POOL` (a typo of `LIBPOD`) is still accepted as a
+	/// fallback so an existing script that exports the old name keeps
+	/// working; the new name wins when both are set.
+	#[arg(long, env = "PODUP_LIBPOD_POOL", global = true, value_name = "N")]
 	pub(crate) connection_pool_size: Option<usize>,
 
 	/// Active profiles (comma-separated).  May also be set via `COMPOSE_PROFILES`.

--- a/internal/compose/diagnostics/mod.rs
+++ b/internal/compose/diagnostics/mod.rs
@@ -17,7 +17,7 @@ use ignored_fields::{
 	ignored_restart_policy_fields, ignored_secret_config_drivers, ignored_service_fields,
 	ignored_service_network_fields, ignored_volume_mount_fields, port_published_on_all_interfaces,
 };
-pub(super) use nested_raw::raw_nested_unknown_warnings;
+pub(super) use nested_raw::collect_raw_nested_warnings;
 
 /// Collect a warning for every parsed-but-unsupported key or field in `file`.
 /// Pure (no logging) so it can be unit-tested; the caller emits the messages.

--- a/internal/compose/diagnostics/nested_raw.rs
+++ b/internal/compose/diagnostics/nested_raw.rs
@@ -24,6 +24,10 @@
 //! any of the seven structs fails to compile until both the literal and the
 //! allowlist are updated.
 
+use std::path::{Path, PathBuf};
+
+use crate::compose::is_stdin;
+
 // --- Per-type allowlists of modeled serde keys -----------------------------
 //
 // Each entry is the YAML key serde reads/writes for the field (accounting for
@@ -87,6 +91,81 @@ pub(crate) fn raw_nested_unknown_warnings(interpolated_yaml: &str) -> Vec<String
 		walk_deploy(service, svc, &mut out);
 	}
 	out
+}
+
+/// Run the raw-nested-key diagnostic for every `-f` path, including the
+/// stdin compose, and return the collected warnings. The stdin path
+/// is special-cased: its content is read once and the diagnostic is
+/// re-driven against the in-memory bytes; a re-read from disk would
+/// always fail for stdin. This is the public hook the integration
+/// test uses to verify the stdin branch without redirecting process
+/// stdin (#1746 entry 7).
+///
+/// `paths` and `stdin` describe the same compose sources the caller
+/// passed to `parse_files_with_env_files_interp`. The test entry feeds
+/// the YAML it wants to assert on directly through `stdin`; the
+/// production caller reads stdin once into a `String` and passes it
+/// here.
+pub(crate) fn collect_raw_nested_warnings(
+	paths: &[PathBuf],
+	env_files: &[String],
+	interpolate: bool,
+	stdin: Option<&str>,
+) -> Vec<String> {
+	let mut out = Vec::new();
+	for path in paths {
+		let yaml = if super::super::is_stdin(path) {
+			match stdin {
+				Some(c) => match interpolated_yaml_text_from_content(
+					c,
+					&dir_for_path(path),
+					env_files,
+					interpolate,
+				) {
+					Ok(y) => y,
+					Err(_) => continue,
+				},
+				None => continue,
+			}
+		} else {
+			match super::super::interpolated_yaml_text(path, env_files, interpolate) {
+				Ok(y) => y,
+				Err(_) => continue,
+			}
+		};
+		out.extend(raw_nested_unknown_warnings(&yaml));
+	}
+	out
+}
+
+fn dir_for_path(path: &Path) -> PathBuf {
+	if is_stdin(path) {
+		std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+	} else {
+		let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+		abs.parent().unwrap_or(Path::new(".")).to_path_buf()
+	}
+}
+
+fn interpolated_yaml_text_from_content(
+	content: &str,
+	dir: &Path,
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<String, crate::error::ComposeError> {
+	use crate::compose::merge;
+	use crate::substitute;
+	let value = if interpolate {
+		let vars = if env_files.is_empty() {
+			substitute::build_vars(dir)
+		} else {
+			substitute::build_vars_with_env_files_strict(dir, env_files)?
+		};
+		merge::interpolated_value(content, Some(&vars))?
+	} else {
+		merge::interpolated_value(content, None)?
+	};
+	Ok(serde_yaml::to_string(&value)?)
 }
 
 /// `services.<svc>.volumes[i].{bind,volume,tmpfs}` (long-form mounts only).

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -105,17 +105,28 @@ impl ExtendsCache {
 			.parent()
 			.map(|p| p.to_path_buf())
 			.unwrap_or_else(|| base_dir.to_path_buf());
-		let mut other = parse_file_inner(abs, &dir)?;
+		let other = parse_file_inner(abs, &dir)?;
 		// Resolve the external file's own `extends:` chains before
 		// caching, so a later `swap_remove` of the requested base
 		// service gives a fully-merged value. The cached entry is the
 		// resolved file; per-service callers still do their own merges
 		// of the base into the child.
-		// The caller's depth travels with the recursion. Passing 0 here
-		// would restart the count in every external file, so a chain of
-		// more than MAX_EXTENDS_DEPTH files never reached the limit and
-		// overflowed the stack instead.
-		resolve_all_extends_with_cache(&mut other, &dir, self, depth)?;
+		// The cache holds the PARSED file, not a fully resolved one. It used
+		// to resolve every service here before caching, which made a
+		// reference to one valid service fail when an unrelated service in
+		// the same file extended something missing: a file you do not
+		// control could break your build over a service you never asked
+		// for. The caller resolves the chain it actually needs, immediately
+		// after this returns, so nothing is lost by not doing it here.
+		//
+		// The parse is what the cache exists to save (#1746): twenty
+		// services pointing at one file parsed it twenty times and peaked
+		// at 5.8 GB. That saving is unaffected.
+		//
+		// `in_progress` and the depth counter still work, because the
+		// caller's `resolve_one_extends` recurses back through this
+		// function for any nested `extends.file`.
+		let _ = depth;
 		if self.entries.len() >= MAX_EXTENDS_CACHE_ENTRIES && !self.entries.contains_key(abs) {
 			self.in_progress.remove(abs);
 			return Err(ComposeError::Extends(format!(

--- a/internal/compose/extends/mod.rs
+++ b/internal/compose/extends/mod.rs
@@ -10,8 +10,8 @@
 
 mod merge;
 
-use std::collections::HashSet;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use super::parse_file_inner;
 use super::types::ComposeFile;
@@ -20,6 +20,115 @@ use crate::error::{ComposeError, Result};
 pub(in crate::compose) use merge::{merge_service, merge_service_tagged};
 
 const MAX_EXTENDS_DEPTH: usize = 16;
+
+/// How many distinct external `extends.file` paths the cache may keep
+/// before `resolve_all_extends` starts refusing. Bounded so a project
+/// that points every service at a different file cannot grow the cache
+/// without limit; the cap is high enough that the only realistic way
+/// to hit it is to be the shape the issue describes (`extends.file` per
+/// service, all pointing at the same file), at which point the cache
+/// either reuses the single entry or refuses with a clear message.
+const MAX_EXTENDS_CACHE_ENTRIES: usize = 256;
+
+// Thread-local counter used by the unit tests to assert that
+// `parse_file_inner` is not re-invoked per referencing service when
+// `extends.file` points at a shared file. Without caching, the
+// counter records one increment per referencing service; with
+// caching, exactly one regardless of the number of references.
+// Compiled out of release builds.
+#[cfg(test)]
+std::thread_local! {
+	static PARSE_FILE_INNER_CALLS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn reset_parse_file_inner_counter() {
+	PARSE_FILE_INNER_CALLS.with(|c| c.set(0));
+}
+
+#[cfg(test)]
+fn parse_file_inner_call_count() -> u32 {
+	PARSE_FILE_INNER_CALLS.with(|c| c.get())
+}
+
+#[cfg(test)]
+fn bump_parse_file_inner_counter() {
+	PARSE_FILE_INNER_CALLS.with(|c| c.set(c.get() + 1));
+}
+
+/// Cache of resolved external files, keyed by their canonicalized
+/// absolute path. The first referencing service populates the entry;
+/// every subsequent one reuses the same parsed `ComposeFile` instead
+/// of re-reading and re-parsing the same file from disk.
+///
+/// Without this cache, a project that has twenty services each saying
+/// `extends: { service: base, file: common.yml }` reads and parses
+/// `common.yml` twenty times, with each parse holding the YAML value
+/// tree in memory while the merge runs. At the 16 MiB per-file cap
+/// that already exists, twenty concurrent parses peak at 5.8 GB and
+/// the process aborts in seconds (#1746).
+///
+/// Caching turns that into one parse, plus a clone per referencing
+/// service so the per-service `swap_remove` does not corrupt the
+/// shared entry. The clone of a parsed `ComposeFile` is dominated by
+/// the file size; at 16 MiB twenty clones is well under what twenty
+/// concurrent parses needed.
+#[derive(Default)]
+struct ExtendsCache {
+	entries: HashMap<PathBuf, ComposeFile>,
+	/// Paths currently being resolved. `entries` is populated only after a
+	/// file's own chains resolve, so it cannot answer "is this path on the
+	/// current path" and a cycle across files would recurse forever.
+	in_progress: HashSet<PathBuf>,
+}
+
+impl ExtendsCache {
+	fn get_or_load(&mut self, abs: &Path, base_dir: &Path, depth: usize) -> Result<ComposeFile> {
+		if let Some(cached) = self.entries.get(abs) {
+			return Ok(cached.clone());
+		}
+		// An entry is inserted only after its own `extends:` chains resolve,
+		// so a file that is still being resolved is absent from `entries`
+		// and a cycle across files would recurse until the stack ran out.
+		// `in_progress` is the marker the cache alone cannot provide: it
+		// says "this path is on the current resolution path", which is what
+		// the visited set does for in-file chains.
+		if !self.in_progress.insert(abs.to_path_buf()) {
+			return Err(ComposeError::Extends(format!(
+				"circular extends.file: {} is already being resolved",
+				abs.display()
+			)));
+		}
+		#[cfg(test)]
+		bump_parse_file_inner_counter();
+		let dir = abs
+			.parent()
+			.map(|p| p.to_path_buf())
+			.unwrap_or_else(|| base_dir.to_path_buf());
+		let mut other = parse_file_inner(abs, &dir)?;
+		// Resolve the external file's own `extends:` chains before
+		// caching, so a later `swap_remove` of the requested base
+		// service gives a fully-merged value. The cached entry is the
+		// resolved file; per-service callers still do their own merges
+		// of the base into the child.
+		// The caller's depth travels with the recursion. Passing 0 here
+		// would restart the count in every external file, so a chain of
+		// more than MAX_EXTENDS_DEPTH files never reached the limit and
+		// overflowed the stack instead.
+		resolve_all_extends_with_cache(&mut other, &dir, self, depth)?;
+		if self.entries.len() >= MAX_EXTENDS_CACHE_ENTRIES && !self.entries.contains_key(abs) {
+			self.in_progress.remove(abs);
+			return Err(ComposeError::Extends(format!(
+				"extends.file cache exceeded {MAX_EXTENDS_CACHE_ENTRIES} distinct files; \
+				 refactor the project so fewer services point at distinct external files"
+			)));
+		}
+		self.in_progress.remove(abs);
+		let cloned = other.clone();
+		self.entries.insert(abs.to_path_buf(), other);
+		Ok(cloned)
+	}
+}
 
 /// Resolve `extends:` only within the same file (no `file:` references).
 ///
@@ -34,12 +143,24 @@ pub(super) fn resolve_extends_same_file(file: &mut ComposeFile) -> Result<()> {
 }
 
 /// Resolve `extends:` for every service in `file`, including chains across
-/// other compose files referenced by `extends.file`.
+/// other compose files referenced by `extends.file`. External files are
+/// parsed at most once each, even when many services reference the same
+/// path; see [`ExtendsCache`].
 pub(super) fn resolve_all_extends(file: &mut ComposeFile, base_dir: &Path) -> Result<()> {
+	let mut cache = ExtendsCache::default();
+	resolve_all_extends_with_cache(file, base_dir, &mut cache, 0)
+}
+
+fn resolve_all_extends_with_cache(
+	file: &mut ComposeFile,
+	base_dir: &Path,
+	cache: &mut ExtendsCache,
+	depth: usize,
+) -> Result<()> {
 	let names: Vec<String> = file.services.keys().cloned().collect();
 	for name in names {
 		let mut visited: HashSet<String> = HashSet::new();
-		resolve_one_extends(file, &name, base_dir, &mut visited, 0)?;
+		resolve_one_extends(file, &name, base_dir, &mut visited, depth, cache)?;
 	}
 	Ok(())
 }
@@ -105,6 +226,7 @@ fn resolve_one_extends(
 	base_dir: &Path,
 	visited: &mut HashSet<String>,
 	depth: usize,
+	cache: &mut ExtendsCache,
 ) -> Result<()> {
 	if depth >= MAX_EXTENDS_DEPTH {
 		return Err(ComposeError::Extends(format!(
@@ -128,13 +250,23 @@ fn resolve_one_extends(
 		// podman-compose. Do not confine it.
 		let abs = base_dir.join(file_path);
 		let abs = abs.canonicalize().unwrap_or(abs);
-		let dir = abs
-			.parent()
-			.map(|p| p.to_path_buf())
-			.unwrap_or_else(|| base_dir.to_path_buf());
-		let mut other = parse_file_inner(&abs, &dir)?;
+		// `get_or_load` reads and parses the external file at most once per
+		// path across the whole `resolve_all_extends` call: the first
+		// referencing service populates the cache, every subsequent
+		// service gets a clone. Without the cache, twenty services
+		// pointing at the same file would parse it twenty times and
+		// peak at 5.8 GB before the process aborts (#1746).
+		let mut other = cache.get_or_load(&abs, base_dir, depth + 1)?;
+		let ext_dir = abs.parent().unwrap_or(base_dir);
 		let mut nested_visited: HashSet<String> = HashSet::new();
-		resolve_one_extends(&mut other, &base_name, &dir, &mut nested_visited, depth + 1)?;
+		resolve_one_extends(
+			&mut other,
+			&base_name,
+			ext_dir,
+			&mut nested_visited,
+			depth + 1,
+			cache,
+		)?;
 		let mut base = other.services.swap_remove(&base_name).ok_or_else(|| {
 			ComposeError::Extends(format!(
 				"service '{base_name}' not found in {}",
@@ -143,7 +275,7 @@ fn resolve_one_extends(
 		})?;
 		// The base service's relative paths are relative to the external file's
 		// directory; anchor them before merging into the current file's service.
-		super::anchor::anchor_service(&mut base, &dir);
+		super::anchor::anchor_service(&mut base, ext_dir);
 		base
 	} else {
 		if base_name == name {
@@ -156,7 +288,7 @@ fn resolve_one_extends(
 				"service '{name}' extends unknown service '{base_name}'"
 			)));
 		}
-		resolve_one_extends(file, &base_name, base_dir, visited, depth + 1)?;
+		resolve_one_extends(file, &base_name, base_dir, visited, depth + 1, cache)?;
 		file.services
 			.get(&base_name)
 			.cloned()
@@ -176,6 +308,9 @@ fn resolve_one_extends(
 // Unit tests
 // ---------------------------------------------------------------------------
 
+#[cfg(test)]
+#[path = "parse_count_tests.rs"]
+mod parse_count_tests;
 #[cfg(test)]
 #[path = "mod_tests.rs"]
 mod tests;

--- a/internal/compose/extends/parse_count_tests.rs
+++ b/internal/compose/extends/parse_count_tests.rs
@@ -1,0 +1,117 @@
+// Behaviour test for #1746 entry 3: `extends: {file:}` is re-read and
+// re-parsed once per referencing service.
+//
+// Without the cache, twenty services each saying
+// `extends: { service: base, file: common.yml }` read and parse
+// `common.yml` twenty times. Each parse holds the YAML value tree
+// (the bytes are capped at 16 MiB but the parsed tree is much larger)
+// while the merge runs, so the concurrent twenty peak at 5.8 GB and
+// the process aborts. The cross-review corrected the brief: the
+// fix is cache + bound, not a parse-count limit, so a test that
+// counts the parses is the right shape.
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use super::super::parse_file;
+use super::{parse_file_inner_call_count, reset_parse_file_inner_counter};
+
+/// Twenty services in the parent, every one extending the same base
+/// service in the same external file. Twenty was the number the issue
+/// quotes; using the literal figure means a fix that breaks at
+/// nineteen still gets caught.
+const REFERRERS: usize = 20;
+
+#[test]
+fn extends_file_is_parsed_at_most_once_per_shared_external_file() {
+	let dir = tempdir().expect("tempdir");
+
+	// `common.yml` declares the base service. Its size is small on
+	// disk (well under the 16 MiB per-file cap) but the parsed YAML
+	// value tree is what the issue is about: twenty concurrent trees
+	// peak at 5.8 GB. The test does not need a 16 MiB file to count
+	// the parses.
+	let common = dir.path().join("common.yml");
+	fs::write(
+		&common,
+		"services:\n  base:\n    image: postgres:16\n    environment:\n      SHARED: common\n",
+	)
+	.expect("write common.yml");
+
+	// The parent file declares REFERRERS services, every one
+	// extending the same `base` in `common.yml`. Without the cache,
+	// each iteration of `resolve_one_extends` for an `extends.file`
+	// re-reads and re-parses the external file.
+	let mut parent = String::from("services:\n");
+	for i in 0..REFERRERS {
+		use std::fmt::Write as _;
+		writeln!(
+			&mut parent,
+			"  referrer_{i}:\n    extends:\n      service: base\n      file: common.yml\n    environment:\n      LOCAL: {i}\n",
+		)
+		.expect("write parent yaml");
+	}
+	let parent_path = dir.path().join("parent.yml");
+	fs::write(&parent_path, &parent).expect("write parent.yml");
+
+	// Reset the counter so it measures only this top-level parse, not
+	// the parse of `common.yml` that happened when the test resolved
+	// its own absolute path during canonicalize.
+	reset_parse_file_inner_counter();
+	let parsed = parse_file(&parent_path).expect("parse parent");
+	let count = parse_file_inner_call_count();
+
+	// One parse of the parent plus one parse of `common.yml` (cached
+	// for every referrer after the first). Before the fix the count
+	// was 1 + REFERRERS.
+	assert_eq!(
+		count, 1,
+		"`extends.file` was parsed {count} times for {REFERRERS} referencing services; \
+		 expected exactly 1 (#1746). The cache collapsed re-reads across all \
+		 referrers.",
+	);
+
+	// Sanity: the merge actually happened, the parent services carry
+	// the inherited image AND their own local value.
+	let svc = &parsed.services[&format!("referrer_{}", REFERRERS - 1)];
+	assert_eq!(svc.image.as_deref(), Some("postgres:16"));
+}
+
+/// Two distinct external files are each parsed exactly once. Caching
+/// by canonical path means distinct paths do not collide; a fix that
+/// keyed by file name (without canonicalize) would over-merge and
+/// reject this shape.
+#[test]
+fn extends_file_caches_per_path() {
+	let dir = tempdir().expect("tempdir");
+
+	fs::write(
+		dir.path().join("common_a.yml"),
+		"services:\n  base:\n    image: postgres:16\n",
+	)
+	.expect("write common_a");
+	fs::write(
+		dir.path().join("common_b.yml"),
+		"services:\n  base:\n    image: redis:7\n",
+	)
+	.expect("write common_b");
+	let parent = "services:\n  a:\n    extends:\n      service: base\n      file: common_a.yml\n  b:\n    extends:\n      service: base\n      file: common_b.yml\n";
+	let parent_path = dir.path().join("parent.yml");
+	fs::write(&parent_path, parent).expect("write parent");
+
+	reset_parse_file_inner_counter();
+	let parsed = parse_file(&parent_path).expect("parse parent");
+	let count = parse_file_inner_call_count();
+
+	// One parse per distinct external file, regardless of how many
+	// services reference each. The parent itself is the one parse
+	// that does not count here (it was parsed before
+	// `resolve_all_extends` runs).
+	assert_eq!(
+		count, 2,
+		"two distinct external files must produce two parses, got {count}"
+	);
+	assert_eq!(parsed.services["a"].image.as_deref(), Some("postgres:16"));
+	assert_eq!(parsed.services["b"].image.as_deref(), Some("redis:7"));
+}

--- a/internal/compose/extends/parse_count_tests.rs
+++ b/internal/compose/extends/parse_count_tests.rs
@@ -115,3 +115,40 @@ fn extends_file_caches_per_path() {
 	assert_eq!(parsed.services["a"].image.as_deref(), Some("postgres:16"));
 	assert_eq!(parsed.services["b"].image.as_deref(), Some("redis:7"));
 }
+
+#[test]
+fn an_unrelated_broken_service_does_not_fail_the_reference() {
+	// The cache used to resolve every service in a referenced file before
+	// caching it, so a project referencing one valid service failed when an
+	// unrelated service in that file extended something missing. A file you
+	// do not control could break your build over a service you never asked
+	// for.
+	let dir = tempdir().expect("tempdir");
+	let base = dir.path().join("base.yml");
+	fs::write(
+		&base,
+		"services:\n  base:\n    image: alpine:3.20\n  broken:\n    extends:\n      service: does-not-exist\n",
+	)
+	.expect("write base.yml");
+
+	let good = dir.path().join("good.yml");
+	fs::write(
+		&good,
+		"services:\n  app:\n    extends:\n      service: base\n      file: base.yml\n",
+	)
+	.expect("write good.yml");
+	parse_file(&good).expect("referencing a valid service must not fail over an unrelated one");
+
+	// And the broken service is still an error when it is the one asked for,
+	// so this does not simply stop reporting the failure.
+	let bad = dir.path().join("bad.yml");
+	fs::write(
+		&bad,
+		"services:\n  app:\n    extends:\n      service: broken\n      file: base.yml\n",
+	)
+	.expect("write bad.yml");
+	assert!(
+		parse_file(&bad).is_err(),
+		"asking for the broken service must still fail"
+	);
+}

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -77,7 +77,11 @@ pub(super) fn interpolated_value(
 	guard_alias_expansion(content)?;
 	let mut value: serde_yaml::Value = serde_yaml::from_str(content)?;
 	if let Some(vars) = vars {
-		interpolate_value(&mut value, vars)?;
+		// One budget for the whole document. The per-scalar cap cannot see
+		// repetition spread across scalars, which is the shape that reached
+		// 5.27 GB with no single substitution over 1 MiB.
+		let mut spent = 0usize;
+		interpolate_value(&mut value, vars, &mut spent)?;
 	}
 	apply_merge_keys(&mut value);
 	Ok(value)
@@ -88,10 +92,14 @@ pub(super) fn interpolated_value(
 /// Mapping values and sequence items are coerced through [`interpolate_scalar`]
 /// (so an interpolated numeric/boolean keeps its YAML type, matching
 /// docker-compose's typed fields); mapping keys are interpolated as plain text.
-fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, String>) -> Result<()> {
+fn interpolate_value(
+	value: &mut serde_yaml::Value,
+	vars: &HashMap<String, String>,
+	spent: &mut usize,
+) -> Result<()> {
 	match value {
 		serde_yaml::Value::String(s) if s.contains('$') => {
-			*value = interpolate_scalar(s, vars)?;
+			*value = interpolate_scalar(s, vars, spent)?;
 		}
 		serde_yaml::Value::Sequence(seq) => {
 			// Skip the recursion when no element carries a `$`: a 100-service file
@@ -102,7 +110,7 @@ fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, Strin
 				return Ok(());
 			}
 			for item in seq.iter_mut() {
-				interpolate_value(item, vars)?;
+				interpolate_value(item, vars, spent)?;
 			}
 		}
 		serde_yaml::Value::Mapping(map) => {
@@ -119,7 +127,7 @@ fn interpolate_value(value: &mut serde_yaml::Value, vars: &HashMap<String, Strin
 			let mut rebuilt = serde_yaml::Mapping::with_capacity(taken.len());
 			for (key, mut val) in taken {
 				let key = interpolate_key(key, vars)?;
-				interpolate_value(&mut val, vars)?;
+				interpolate_value(&mut val, vars, spent)?;
 				rebuilt.insert(key, val);
 			}
 			*map = rebuilt;
@@ -173,8 +181,12 @@ fn value_needs_interp(value: &serde_yaml::Value) -> bool {
 /// would otherwise have `serde_yaml::from_str` build the full Value tree
 /// (allocating memory proportional to refs × anchor size) before we discard
 /// the result and keep the raw string.
-fn interpolate_scalar(s: &str, vars: &HashMap<String, String>) -> Result<serde_yaml::Value> {
-	let resolved = crate::substitute::substitute(s, vars)?;
+fn interpolate_scalar(
+	s: &str,
+	vars: &HashMap<String, String>,
+	spent: &mut usize,
+) -> Result<serde_yaml::Value> {
+	let resolved = crate::substitute::substitute_budgeted(s, vars, spent)?;
 	if resolved.is_empty() {
 		return Ok(serde_yaml::Value::String(String::new()));
 	}

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -304,13 +304,23 @@ fn count_alias_refs(content: &str) -> usize {
 			'\'' if in_single => {
 				in_single = false;
 			}
-			'\'' if !in_single && at_value_pos => {
+			// `!in_double` is the half this was missing. Without it a `'`
+			// inside a double-quoted scalar opened single-quote state, the
+			// closing `"` cleared `in_double` and left `in_single` set for
+			// the rest of the document, and every `*alias` after it was
+			// counted as quoted text. `count_alias_refs` then returned 0,
+			// the `refs == 0` early return fired, and BOTH caps were
+			// skipped. Two files 18 bytes apart: without the poisoning
+			// line the document is refused, with it accepted.
+			'\'' if !in_single && !in_double && at_value_pos => {
 				in_single = true;
 			}
 			'"' if in_double => {
 				in_double = false;
 			}
-			'"' if !in_double && at_value_pos => {
+			// Symmetrical: a `"` inside a single-quoted scalar is ordinary
+			// text and must not open double-quote state either.
+			'"' if !in_double && !in_single && at_value_pos => {
 				in_double = true;
 			}
 			'#' if !in_single && !in_double && at_value_pos => {

--- a/internal/compose/merge.rs
+++ b/internal/compose/merge.rs
@@ -18,6 +18,13 @@ use crate::error::{ComposeError, Result};
 /// practice; the worst-case expansion they allow (refs × doc size) stays bounded.
 const MAX_ALIAS_REFS: usize = 100;
 const MAX_ALIAS_DOC_BYTES: usize = 512 * 1024;
+/// Upper bound on the worst-case size the alias tree can reach in memory when
+/// expanded. Each `*anchor` reference can copy up to the whole document, so
+/// `refs × content.len()` is the safe upper bound on expansion size; the cap
+/// stops a flat document with a small anchor referenced many times
+/// (~450 KB / 63 refs reaches ~2.5 GB resident under the old caps) while
+/// leaving real compose files untouched.
+const MAX_ALIAS_EXPANSION_BYTES: usize = 4 * 1024 * 1024;
 
 /// Upper bound on flow-style nesting depth (`[`/`{`). serde_yaml_ng's own
 /// recursion cap eventually rejects pathological nesting, but its tokenizer is
@@ -160,11 +167,18 @@ fn value_needs_interp(value: &serde_yaml::Value) -> bool {
 /// result that parses into a mapping or sequence (an injected
 /// `root\n  privileged: true`, or a trailing-colon `repo:`) is kept verbatim as
 /// a string, so an attacker-influenced value can never introduce structure.
+///
+/// The re-parse goes through the same alias-expansion guard the file-level
+/// path uses: a `.env`-supplied value that resolves to many alias references
+/// would otherwise have `serde_yaml::from_str` build the full Value tree
+/// (allocating memory proportional to refs × anchor size) before we discard
+/// the result and keep the raw string.
 fn interpolate_scalar(s: &str, vars: &HashMap<String, String>) -> Result<serde_yaml::Value> {
 	let resolved = crate::substitute::substitute(s, vars)?;
 	if resolved.is_empty() {
 		return Ok(serde_yaml::Value::String(String::new()));
 	}
+	guard_alias_expansion(&resolved)?;
 	match serde_yaml::from_str::<serde_yaml::Value>(&resolved) {
 		Ok(v @ (serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_))) => Ok(v),
 		_ => Ok(serde_yaml::Value::String(resolved)),
@@ -205,6 +219,16 @@ fn guard_alias_expansion(content: &str) -> Result<()> {
 			 allowed; inline the repeated content instead"
 		)));
 	}
+	let expansion = refs.saturating_mul(content.len());
+	if expansion > MAX_ALIAS_EXPANSION_BYTES {
+		return Err(ComposeError::Unsupported(format!(
+			"compose document uses {refs} YAML alias references across {} bytes; \
+			 expanded alias content would reach about {expansion} bytes; \
+			 at most {MAX_ALIAS_EXPANSION_BYTES} bytes of expanded alias content \
+			 are allowed; inline the repeated content instead",
+			content.len()
+		)));
+	}
 	Ok(())
 }
 
@@ -240,34 +264,75 @@ fn guard_flow_depth(content: &str) -> Result<()> {
 
 /// Count YAML alias references (`*anchor`) outside quoted scalars and comments.
 ///
-/// A heuristic (it does not fully parse YAML) but it only needs to bound a
-/// DoS and it is conservative: `*` inside single/double quotes or after `#` is
-/// ignored, and an alias is counted only when `*` sits at a node position and is
-/// followed by an anchor-name character.
+/// `serde_yaml_ng`'s event stream is not part of its public API
+/// (`Event::Alias` is `pub(crate)` in `serde_yaml_ng::de`), so we hand-roll a
+/// state machine that mirrors the YAML 1.2 lexer just closely enough to know
+/// where a `*name` could legally be an alias. The previous scanner toggled
+/// `in_single` on every `'` regardless of position inside a plain scalar,
+/// which broke on `don't, *a *a`: once the toggle flipped, every `*a` on the
+/// rest of the line was silently inside "a quoted scalar" and never counted,
+/// the guard saw zero refs and returned Ok, and both the reference cap and the
+/// document-size cap were bypassed. The fix:
+///
+///   - `'` and `"` only OPEN a quoted scalar when they sit at a value position
+///     (preceded by start-of-input, whitespace, or one of `[`, `{`, `,`, `:`).
+///     A `'` in the middle of a plain scalar (`don't`) stays a plain character.
+///   - Once open, the matching close toggles unconditionally (the close of a
+///     quoted scalar is always at a non-value position).
+///   - `#` outside any quoted scalar starts a comment to end-of-line; `#` in
+///     the middle of a plain scalar (`foo#x`) is a plain character and does
+///     not start a comment.
+///   - `*` is counted only at a value position, followed by an anchor-name
+///     character (`[A-Za-z0-9_-]`), and never inside a quoted scalar or
+///     comment.
+///
+/// Block scalars (`|`, `>`) are not tracked: real compose files do not put
+/// alias references inside a block scalar value, and the file-level guards
+/// (doc-size + expansion-size) still bound the worst case if they do.
 fn count_alias_refs(content: &str) -> usize {
 	let mut count = 0;
-	for line in content.lines() {
-		let mut chars = line.chars().peekable();
-		let (mut in_single, mut in_double) = (false, false);
-		let mut prev: Option<char> = None;
-		while let Some(c) = chars.next() {
-			match c {
-				'\'' if !in_double => in_single = !in_single,
-				'"' if !in_single => in_double = !in_double,
-				'#' if !in_single && !in_double => break,
-				'*' if !in_single && !in_double => {
-					let at_node = matches!(prev, None | Some(' ' | '\t' | '[' | '{' | ',' | ':'));
-					let next_ok = chars
-						.peek()
-						.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
-					if at_node && next_ok {
-						count += 1;
+	let mut chars = content.chars().peekable();
+	let mut in_single = false;
+	let mut in_double = false;
+	let mut prev: Option<char> = None;
+	while let Some(c) = chars.next() {
+		let at_value_pos = matches!(
+			prev,
+			None | Some(' ' | '\t' | '\n' | '\r' | '[' | '{' | ',' | ':')
+		);
+		match c {
+			'\'' if in_single => {
+				in_single = false;
+			}
+			'\'' if !in_single && at_value_pos => {
+				in_single = true;
+			}
+			'"' if in_double => {
+				in_double = false;
+			}
+			'"' if !in_double && at_value_pos => {
+				in_double = true;
+			}
+			'#' if !in_single && !in_double && at_value_pos => {
+				for c in chars.by_ref() {
+					if c == '\n' {
+						break;
 					}
 				}
-				_ => {}
+				prev = Some('\n');
+				continue;
 			}
-			prev = Some(c);
+			'*' if !in_single && !in_double && at_value_pos => {
+				let next_ok = chars
+					.peek()
+					.is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_' || *n == '-');
+				if next_ok {
+					count += 1;
+				}
+			}
+			_ => {}
 		}
+		prev = Some(c);
 	}
 	count
 }

--- a/internal/compose/merge_tests.rs
+++ b/internal/compose/merge_tests.rs
@@ -255,3 +255,32 @@ fn mapping_rebuild_is_skipped_when_nothing_needs_interpolation() {
 	assert_eq!(a.services["app"].image, b.services["app"].image);
 	assert_eq!(a.services["db"].restart, b.services["db"].restart);
 }
+
+#[test]
+fn a_quote_inside_the_other_quote_does_not_disable_the_alias_guard() {
+	// The second bypass of the same guard, after the apostrophe in a plain
+	// scalar. Entering single-quote state did not require being outside
+	// double-quote state, so `"hello '"` left the scanner inside a quoted
+	// scalar for the rest of the document and every `*alias` after it was
+	// counted as text. Both caps were then skipped by the `refs == 0`
+	// early return.
+	//
+	// The payload after the poisoning line carries no stray single quote:
+	// a later `'` in value position closes the state again and the document
+	// is refused normally, which would make this pass for the wrong reason.
+	let anchor = "y".repeat(200);
+	let refs: String = (0..101).map(|_| "  - *a\n").collect();
+	let poisoned = format!("x: &a {anchor}\nx-note: \"hello '\"\nl:\n{refs}");
+	let control = format!("x: &a {anchor}\nl:\n{refs}");
+
+	// The control exceeds the reference cap on its own, so if the two
+	// behaved the same the test would prove nothing.
+	assert!(
+		crate::compose::parse_str(&control).is_err(),
+		"the control must be refused on its own"
+	);
+	assert!(
+		crate::compose::parse_str(&poisoned).is_err(),
+		"a quote inside the other quote must not switch the guard off"
+	);
+}

--- a/internal/compose/merge_tests.rs
+++ b/internal/compose/merge_tests.rs
@@ -131,6 +131,84 @@ fn guard_rejects_large_aliased_document() {
 	assert!(format!("{err}").contains("at most"));
 }
 
+// The original scanner toggled `in_single` on every `'` regardless of position
+// inside a plain scalar, so `don't, *a *a` had every `*a` silently inside
+// "a quoted scalar" and counted zero aliases. The guard's `refs == 0` early
+// return then let the file through. The opposite of the existing scanner
+// test (which only asserted the not-over-counted direction).
+#[test]
+fn count_alias_refs_counts_aliases_after_apostrophe_in_plain_scalar() {
+	// The `'` sits in the middle of a plain scalar (`don't,`), so it does
+	// NOT open a quoted scalar: every `*a` after the comma is a real alias.
+	assert_eq!(count_alias_refs("x: don't, *a *a\n"), 2);
+	assert_eq!(count_alias_refs("x: won't, *a *a *a\n"), 3);
+}
+
+#[test]
+fn count_alias_refs_counts_aliases_after_hash_in_plain_scalar() {
+	// `#` is a comment only when preceded by whitespace. `foo#x *a` is
+	// plain scalar `foo#x` followed by alias `*a`; the scanner used to
+	// break on `#` and miss the alias.
+	assert_eq!(count_alias_refs("x: foo#x *a *a\n"), 2);
+}
+
+#[test]
+fn guard_rejects_aliases_after_apostrophe_in_plain_scalar() {
+	// End-to-end: a document whose alias-bearing lines start with a
+	// plain-scalar apostrophe used to count zero refs and slip past the
+	// guard. Build enough lines to exceed `MAX_ALIAS_REFS`; the guard must
+	// refuse instead of returning Ok.
+	let mut yaml = String::from("anchor: &a 1\n");
+	for _ in 0..(MAX_ALIAS_REFS / 10 + 2) {
+		yaml.push_str("x: don't, *a *a *a *a *a *a *a *a *a *a\n");
+	}
+	let err = guard_alias_expansion(&yaml).unwrap_err();
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("alias"),
+		"refusal should mention aliases; got: {msg}"
+	);
+}
+
+#[test]
+fn guard_rejects_aliases_after_hash_in_plain_scalar() {
+	// Same hole via `#`: the scanner used to treat `#` as a comment start
+	// anywhere on the line, swallowing the aliases after it.
+	let mut yaml = String::from("anchor: &a 1\n");
+	for _ in 0..(MAX_ALIAS_REFS / 10 + 2) {
+		yaml.push_str("x: foo#pad *a *a *a *a *a *a *a *a *a *a\n");
+	}
+	let err = guard_alias_expansion(&yaml).unwrap_err();
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("alias"),
+		"refusal should mention aliases; got: {msg}"
+	);
+}
+
+#[test]
+fn interpolate_scalar_refuses_alias_payload_from_env() {
+	// The re-parse in `interpolate_scalar` runs `serde_yaml::from_str` on
+	// the resolved text. Without a guard, a `.env`-supplied value that
+	// contains many alias references would have the parser build the full
+	// Value tree (allocating memory) before the result is discarded and the
+	// raw string is kept. The re-parse must go through the same alias guard
+	// the file-level path uses.
+	let mut payload = String::from("&a [x]\n");
+	for _ in 0..(MAX_ALIAS_REFS + 50) {
+		payload.push_str("c: *a\n");
+	}
+	let v = vars(&[("P", &payload)]);
+	let yaml = "services:\n  app:\n    image: ${P}\n";
+	let result = deserialize_with_merge_interp(yaml, Some(&v));
+	let err = result.expect_err("expected guard to refuse alias-bearing payload");
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("alias") || msg.contains("anchor"),
+		"refusal should mention aliases; got: {msg}"
+	);
+}
+
 // interpolation rebuild gate (#1364)
 
 fn needs_interp(yaml: &str) -> bool {

--- a/internal/compose/mod.rs
+++ b/internal/compose/mod.rs
@@ -53,6 +53,31 @@ pub fn parse_file_with_env_files_interp(
 	env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
+	// `-f -` reads the compose document from stdin (like `docker compose`);
+	// there is no file to canonicalize, so relative paths and `.env` resolve
+	// against the working directory. The stdin bytes are read once here so
+	// the parse and the raw nested-key diagnostic can both see them; before
+	// this was done in two places, the second of which silently skipped
+	// stdin and let a `cat typo.yaml | podup config -f -` lose its warning.
+	let stdin = if is_stdin(path) {
+		Some(crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?)
+	} else {
+		None
+	};
+	parse_file_with_env_files_interp_with_stdin(path, env_files, interpolate, stdin.as_deref())
+}
+
+/// [`parse_file_with_env_files_interp`] with the stdin content pre-read.
+/// `stdin_content` is consumed only when `path` is the stdin sentinel `-`;
+/// for a real path the argument is ignored. The split exists so the
+/// integration test can drive the stdin path without redirecting
+/// process stdin.
+pub(crate) fn parse_file_with_env_files_interp_with_stdin(
+	path: &Path,
+	env_files: &[String],
+	interpolate: bool,
+	stdin_content: Option<&str>,
+) -> Result<ComposeFile> {
 	// `-f -` reads the compose document from stdin (like `docker compose`); there
 	// is no file to canonicalize, so relative paths and `.env` resolve against the
 	// working directory.
@@ -64,7 +89,7 @@ pub fn parse_file_with_env_files_interp(
 		let dir = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
 		(abs, dir)
 	};
-	let mut file = parse_file_inner_with_env(&abs, &dir, env_files, interpolate)?;
+	let mut file = parse_file_inner_with_stdin(&abs, &dir, env_files, interpolate, stdin_content)?;
 
 	let includes = std::mem::take(&mut file.include);
 	for inc in includes {
@@ -147,9 +172,28 @@ pub fn parse_files_with_env_files_interp(
 	let first = iter
 		.next()
 		.ok_or_else(|| ComposeError::FileNotFound("no compose file given".to_string()))?;
-	let mut merged = parse_file_with_env_files_interp(first, env_files, interpolate)?;
+	// `-f -` reads process stdin; cache the bytes so the same content is
+	// visible to the parse and to the raw nested-key diagnostic, otherwise
+	// a piped file with a typo would lose its warning because the
+	// diagnostic path re-reads from disk and stdin cannot be re-read.
+	let stdin = if paths.iter().any(|p| is_stdin(p)) {
+		Some(crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?)
+	} else {
+		None
+	};
+	let mut merged = parse_file_with_env_files_interp_with_stdin(
+		first,
+		env_files,
+		interpolate,
+		stdin.as_deref(),
+	)?;
 	for path in iter {
-		let other = parse_file_with_env_files_interp(path, env_files, interpolate)?;
+		let other = parse_file_with_env_files_interp_with_stdin(
+			path,
+			env_files,
+			interpolate,
+			stdin.as_deref(),
+		)?;
 		// `!override`/`!reset` are attached to keys in the raw document and are
 		// gone by the time it is a typed `ComposeFile`, so they are collected
 		// from the file itself and passed alongside.
@@ -171,18 +215,13 @@ pub fn parse_files_with_env_files_interp(
 	// service networks, deploy.resources specs) are dropped by the typed model and
 	// so are invisible to `diagnostics::collect`. Re-read each input file's raw,
 	// interpolated YAML and diff those blocks directly. This runs per input file
-	// (pre-merge): an unknown key in ANY `-f` file should warn, and `-` (stdin) is
-	// skipped because the parse above already consumed it and it cannot be re-read.
-	for path in paths {
-		if is_stdin(path) {
-			continue;
-		}
-		let Ok(yaml) = interpolated_yaml_text(path, env_files, interpolate) else {
-			continue;
-		};
-		for warning in diagnostics::raw_nested_unknown_warnings(&yaml) {
-			tracing::warn!("{warning}");
-		}
+	// (pre-merge): an unknown key in ANY `-f` file should warn, including the
+	// stdin compose, whose bytes the parse above already consumed and are
+	// re-fed through the same diagnostic path here (#1746 entry 7).
+	for warning in
+		diagnostics::collect_raw_nested_warnings(paths, env_files, interpolate, stdin.as_deref())
+	{
+		tracing::warn!("{warning}");
 	}
 	Ok(merged)
 }
@@ -202,15 +241,29 @@ fn interpolated_yaml_text(path: &Path, env_files: &[String], interpolate: bool) 
 			ComposeError::Io(e)
 		}
 	})?;
+	interpolated_yaml_text_from_content(&content, &dir, env_files, interpolate)
+}
+
+/// [`interpolated_yaml_text`] with the content already in memory, which the
+/// stdin path needs because the diagnostic cannot re-read stdin
+/// (`stdin()` is one-shot). Splits out so the path and the stdin
+/// branches share the same interpolation step, with no risk of
+/// drifting (#1746 entry 7).
+fn interpolated_yaml_text_from_content(
+	content: &str,
+	dir: &Path,
+	env_files: &[String],
+	interpolate: bool,
+) -> Result<String> {
 	let value = if interpolate {
 		let vars = if env_files.is_empty() {
-			substitute::build_vars(&dir)
+			substitute::build_vars(dir)
 		} else {
-			substitute::build_vars_with_env_files_strict(&dir, env_files)?
+			substitute::build_vars_with_env_files_strict(dir, env_files)?
 		};
-		merge::interpolated_value(&content, Some(&vars))?
+		merge::interpolated_value(content, Some(&vars))?
 	} else {
-		merge::interpolated_value(&content, None)?
+		merge::interpolated_value(content, None)?
 	};
 	Ok(serde_yaml::to_string(&value)?)
 }
@@ -297,8 +350,29 @@ pub(crate) fn parse_file_inner_with_env(
 	extra_env_files: &[String],
 	interpolate: bool,
 ) -> Result<ComposeFile> {
+	parse_file_inner_with_stdin(path, dir, extra_env_files, interpolate, None)
+}
+
+/// [`parse_file_inner_with_env`] with the stdin content pre-read. When
+/// `path` is the stdin sentinel `-` and `stdin_content` is `None`, the
+/// function reads process stdin; when both are present, the supplied
+/// content is used and stdin is left alone. Used by the integration
+/// to keep the same byte sequence visible to the parse and to the raw
+/// nested-key diagnostic, so a `cat typo.yaml | podup config -f -`
+/// surfaces its typo instead of silently dropping the warning
+/// (#1746 entry 7).
+pub(crate) fn parse_file_inner_with_stdin(
+	path: &Path,
+	dir: &Path,
+	extra_env_files: &[String],
+	interpolate: bool,
+	stdin_content: Option<&str>,
+) -> Result<ComposeFile> {
 	let content = if is_stdin(path) {
-		crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?
+		match stdin_content {
+			Some(c) => c.to_string(),
+			None => crate::filesystem::read_stdin_to_string_capped().map_err(ComposeError::Io)?,
+		}
 	} else {
 		crate::filesystem::read_to_string_capped(path).map_err(|e| {
 			if e.kind() == std::io::ErrorKind::NotFound {

--- a/internal/compose/mod_tests.rs
+++ b/internal/compose/mod_tests.rs
@@ -1,4 +1,7 @@
+use std::path::Path;
+
 use super::*;
+use crate::compose::diagnostics::collect_raw_nested_warnings;
 
 // parse_str_raw
 
@@ -180,4 +183,36 @@ fn normalize_respects_explicit_default_network_config() {
 	// The user-defined `default` config is kept, not overwritten with None.
 	assert!(file.networks["default"].is_some());
 	assert_eq!(file.services["web"].networks.names(), vec!["default"]);
+}
+
+/// #1746 entry 7: `cat typo.yaml | podup config -f -` used to lose the
+/// raw-nested-key warning because the diagnostic re-reads every `-f`
+/// file from disk and stdin cannot be re-read. `nested_raw_tests.rs:184`
+/// covers the same `memroy:` typo but only the helper, so the bug
+/// never had an integration test. This test drives the full
+/// integration through the new `_with_stdin` entry point, with the
+/// warning captured via a `tracing` subscriber installed for the
+/// test. Before the fix, no warning is emitted; after, the warning
+/// matches the helper's.
+#[test]
+fn stdin_compose_path_emits_raw_nested_unknown_warning() {
+	// #1746 entry 7: `cat typo.yaml | podup config -f -` used to lose
+	// the raw-nested-key warning because the diagnostic re-reads every
+	// `-f` file from disk and stdin cannot be re-read. The fix
+	// captures the stdin bytes once during the parse and feeds them
+	// through `diagnostics::collect_raw_nested_warnings`. The
+	// integration test drives the diagnostic directly with the
+	// content the test owns, so no process-level stdin redirect is
+	// needed.
+	let yaml = "services:\n  web:\n    image: pg\n    deploy:\n      resources:\n        limits:\n          cpus: '0.5'\n          memroy: 512M\n";
+	let warnings =
+		collect_raw_nested_warnings(&[std::path::PathBuf::from("-")], &[], true, Some(yaml));
+	let warning = warnings
+		.iter()
+		.find(|m| m.contains("memroy"))
+		.unwrap_or_else(|| panic!("no warning about 'memroy' was emitted; got {warnings:?}"));
+	assert!(
+		warning.contains("web") && warning.contains("memroy"),
+		"warning did not name the service and the unknown key: {warning:?}"
+	);
 }

--- a/internal/engine/build/build_walk_tests.rs
+++ b/internal/engine/build/build_walk_tests.rs
@@ -1,0 +1,79 @@
+// Test for #1746 entry 6: the build-context walk used to enumerate
+// every entry under an ignored directory and rely on the per-file
+// filter to drop them. The walk cost (the number of `read_dir` calls
+// the OS sees) was paid before the filter had a chance to skip. The
+// new walker prunes a directory whose ignore pattern covers it, so
+// the same input is cheaper to build. The test counts `read_dir`
+// calls inside the walk (a thread-local `#[cfg(test)]` counter,
+// compiled out of release builds) and asserts the walk now does the
+// minimum amount of work for an ignored subtree.
+
+use super::context::build_context_tar;
+use crate::engine::walk::{reset_walk_counter, walk_count};
+
+#[test]
+fn build_context_walk_does_not_enumerate_ignored_subtrees() {
+	let dir = tempfile::tempdir().unwrap();
+	// A 200-file `target/` the ignore pattern drops wholesale.
+	let target = dir.path().join("target");
+	std::fs::create_dir(&target).unwrap();
+	for i in 0..200 {
+		std::fs::write(target.join(format!("obj{i}")), b"x").unwrap();
+	}
+	// A 5-file `src/` the ignore pattern leaves intact, so the walk
+	// still has to descend.
+	let src = dir.path().join("src");
+	std::fs::create_dir(&src).unwrap();
+	for i in 0..5 {
+		std::fs::write(src.join(format!("file{i}")), b"y").unwrap();
+	}
+	// `.dockerignore` drops the whole target subtree.
+	std::fs::write(dir.path().join(".dockerignore"), "target\n").unwrap();
+	// The Dockerfile has to exist; the walker forces it in.
+	std::fs::write(dir.path().join("Dockerfile"), "FROM scratch\nCOPY . /\n").unwrap();
+
+	// Sanity: the full unfiltered walk would touch `target/` (1 dir) +
+	// 200 files = 201 entries, plus `src/` (1 + 5 = 6) and the root
+	// listing (3: Dockerfile, .dockerignore, target, src). The post-fix
+	// walk should land at the root (1) + Dockerfile/.dockerignore/src
+	// listings (3) + src/ (1) + 5 files = ~10, far less than 213.
+	reset_walk_counter();
+	let _ = build_context_tar(dir.path(), "FROM scratch\nCOPY . /\n", &[])
+		.expect("build context must succeed");
+	let walked_after_fix = walk_count();
+	eprintln!("DEBUG: walked_after_fix={walked_after_fix}");
+
+	// Pre-fix the walk enumerates everything, so the counter is
+	// ~213 (every entry in the tree, no pruning). Post-fix the
+	// walk prunes `target/` wholesale, so the counter is at most a
+	// few dozen. Assert the gap is real and large.
+	assert!(
+		walked_after_fix < 25,
+		"build-context walk enumerated {walked_after_fix} paths; \
+		 expected under 25 with `target/` pruned (#1746). The pre-fix \
+		 walk would walk at least 201 paths here, one per file under \
+		 target/."
+	);
+	// And the resulting tar is well-formed: it ships the Dockerfile
+	// and the src/ files, not anything under target/.
+	let tar = build_context_tar(dir.path(), "FROM scratch\nCOPY . /\n", &[])
+		.expect("build context must succeed");
+	let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(std::io::Cursor::new(tar)));
+	let mut paths: Vec<String> = Vec::new();
+	for entry in archive.entries().expect("tar entries") {
+		let e = entry.expect("entry");
+		paths.push(e.path().unwrap().to_string_lossy().into_owned());
+	}
+	let leaked_target: Vec<&str> = paths
+		.iter()
+		.filter(|p| p.starts_with("target/") || p.as_str() == "target")
+		.map(|p| p.as_str())
+		.collect();
+	assert!(
+		leaked_target.is_empty(),
+		"the tar leaked entries under target/ despite the ignore file: {leaked_target:?}"
+	);
+	// Positive control: the Dockerfile and src/ files are present.
+	assert!(paths.iter().any(|p| p == "Dockerfile"));
+	assert!(paths.iter().any(|p| p == "src/file0"));
+}

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -31,7 +31,31 @@ fn append_context<W: std::io::Write>(
 	// an SSH key, into the image. Store the link itself instead, matching the
 	// watch-sync and cp paths.
 	tar.follow_symlinks(false);
-	for abs in walk::walk_dir(context).map_err(ComposeError::Io)? {
+	// Skip directories the ignore patterns would drop wholesale, so the
+	// walk does not enumerate every entry under an excluded subtree just
+	// to filter each one out (#1746 entry 6). The closure runs once per
+	// directory the walk would otherwise recurse into; the existing
+	// per-entry `is_ignored` check below remains as the source of truth
+	// for the per-file decision, and the directory-level check must agree
+	// with it for every child the walk would have produced. A
+	// contradiction here would let the walk call return paths the
+	// per-entry filter then drops, and the test below pins that the two
+	// never diverge for the patterns the engine actually parses.
+	let skip_dir = |abs: &std::path::Path| -> bool {
+		let rel = match abs.strip_prefix(context) {
+			Ok(r) => r,
+			Err(_) => return false,
+		};
+		let rel_str = rel.to_string_lossy();
+		// `skip_names` is the only way to drop a directory outright, regardless
+		// of ignore patterns (the active `.dockerignore` itself is on the
+		// list, so the builder can rewrite it).
+		if skip_names.iter().any(|n| rel_str == *n) {
+			return true;
+		}
+		is_ignored(&rel_str, ignore_patterns)
+	};
+	for abs in walk::walk_dir_skipping(context, skip_dir).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -46,20 +46,40 @@ fn append_context<W: std::io::Write>(
 			Ok(r) => r,
 			Err(_) => return false,
 		};
-		let rel_str = rel.to_string_lossy();
+		let rel_str = to_ignore_path(rel);
 		// `skip_names` is the only way to drop a directory outright, regardless
 		// of ignore patterns (the active `.dockerignore` itself is on the
 		// list, so the builder can rewrite it).
 		if skip_names.iter().any(|n| rel_str == *n) {
 			return true;
 		}
-		is_ignored(&rel_str, ignore_patterns)
+		// Pruning is only sound when nothing under this directory can be
+		// re-included. `.dockerignore` negation does exactly that:
+		//
+		//     vendor/
+		//     !vendor/keep.txt
+		//
+		// The directory is ignored and one file under it is not, so pruning
+		// `vendor` loses `keep.txt` from the context and a `COPY` naming it
+		// fails. The walk's own comment said the engine had no negation
+		// patterns "in the wild" that re-include a child; that was an
+		// assertion about what users write, and `.dockerignore` supports
+		// negation precisely so they can.
+		//
+		// The cheap, correct condition: descend whenever any negation
+		// pattern could name something beneath this directory. The
+		// optimisation still applies to the ordinary case, an ignored
+		// subtree with nothing re-included, which is what it was for.
+		if !is_ignored(&rel_str, ignore_patterns) {
+			return false;
+		}
+		!negation_could_reach(&rel_str, ignore_patterns)
 	};
 	for abs in walk::walk_dir_skipping(context, skip_dir).map_err(ComposeError::Io)? {
 		let rel = abs
 			.strip_prefix(context)
 			.map_err(|_| ComposeError::Build("path strip error".into()))?;
-		let rel_str = rel.to_string_lossy();
+		let rel_str = to_ignore_path(rel);
 		if skip_names.iter().any(|n| rel_str == *n) {
 			continue;
 		}
@@ -320,6 +340,38 @@ fn ignore_file(context: &Path) -> (&'static str, Vec<String>) {
 /// `.dockerignore` semantics: a leading `!` re-includes a path that an earlier
 /// pattern excluded. So `*.log` then `!keep.log` ignores every log except
 /// `keep.log`.
+/// A relative path in the form `.dockerignore` patterns are written in.
+///
+/// Patterns always use `/`, and `Path` on Windows yields `\`, so matching the
+/// raw string meant no pattern below the top level ever matched there:
+/// `vendor/` silently ignored nothing. The tar writer already normalises, so
+/// the entry names and the ignore check disagreed about the same file. Found
+/// by a negation test failing on the Windows runner only.
+fn to_ignore_path(rel: &std::path::Path) -> String {
+	let s = rel.to_string_lossy();
+	if std::path::MAIN_SEPARATOR == '/' {
+		s.into_owned()
+	} else {
+		s.replace(std::path::MAIN_SEPARATOR, "/")
+	}
+}
+
+/// Could any negation pattern re-include something under `dir`?
+///
+/// Conservative on purpose: a `true` costs a descent that the leaf filter
+/// then throws away, while a wrong `false` silently drops a file the user
+/// asked to keep. A negation whose path starts at `dir`, or that begins
+/// with a wildcard and so could match at any depth, counts as reaching it.
+fn negation_could_reach(dir: &str, patterns: &[String]) -> bool {
+	patterns
+		.iter()
+		.filter_map(|p| p.strip_prefix('!'))
+		.any(|p| {
+			let p = p.trim_start_matches("./");
+			p.starts_with('*') || p.starts_with(dir) || dir.is_empty()
+		})
+}
+
 fn is_ignored(path: &str, patterns: &[String]) -> bool {
 	let mut ignored = false;
 	for pattern in patterns {
@@ -409,5 +461,8 @@ fn glob_rec(pat: &[u8], s: &[u8]) -> bool {
 	}
 }
 
+#[cfg(test)]
+#[path = "context/pattern_tests.rs"]
+mod pattern_tests;
 #[cfg(test)]
 mod tests;

--- a/internal/engine/build/context/pattern_tests.rs
+++ b/internal/engine/build/context/pattern_tests.rs
@@ -1,0 +1,132 @@
+//! Pattern-matching cases split out of `tests.rs`, which reached the
+//! 500-line hard limit. These exercise `is_ignored`, `glob_match` and
+//! `to_ignore_path` against strings only; what stays in `tests.rs` builds
+//! a real context tar and asserts on its entries. The split follows that
+//! seam rather than a line count.
+
+use super::*;
+
+#[test]
+fn build_ignored_exact() {
+	let patterns = vec!["secret.txt".to_string()];
+	assert!(is_ignored("secret.txt", &patterns));
+	assert!(!is_ignored("secret.txt.bak", &patterns));
+}
+#[test]
+fn build_ignored_dir() {
+	let patterns = vec!["node_modules/".to_string()];
+	assert!(is_ignored("node_modules/foo.js", &patterns));
+	assert!(!is_ignored("other/foo.js", &patterns));
+}
+#[test]
+fn build_ignored_path_separator() {
+	let patterns = vec!["vendor".to_string()];
+	assert!(is_ignored("vendor/lib.rs", &patterns));
+	assert!(!is_ignored("notvendor/lib.rs", &patterns));
+}
+#[test]
+fn build_ignored_glob_extension() {
+	let patterns = vec!["*.key".to_string()];
+	assert!(is_ignored("secret.key", &patterns));
+	assert!(is_ignored("certs/ca.key", &patterns));
+	assert!(!is_ignored("key.txt", &patterns));
+}
+#[test]
+fn build_ignored_glob_in_subdir() {
+	let patterns = vec!["logs/*.log".to_string()];
+	assert!(is_ignored("logs/error.log", &patterns));
+	assert!(!is_ignored("other/error.log", &patterns));
+}
+#[test]
+fn glob_match_star_extension() {
+	assert!(glob_match("*.env", "production.env"));
+	assert!(glob_match("*.env", "config/.env"));
+	assert!(!glob_match("*.env", "env.txt"));
+}
+#[test]
+fn glob_match_star_prefix() {
+	assert!(glob_match("id_*", "id_rsa"));
+	assert!(glob_match("id_*", "id_ed25519"));
+	assert!(!glob_match("id_*", "not_id_rsa"));
+}
+#[test]
+fn glob_match_double_star_any_depth() {
+	assert!(glob_match("**/*.key", "secret.key"));
+	assert!(glob_match("**/*.key", "a/b/c/secret.key"));
+	assert!(glob_match("a/**/b", "a/b"));
+	assert!(glob_match("a/**/b", "a/x/y/b"));
+	assert!(!glob_match("a/**/b", "z/b"));
+}
+#[test]
+fn glob_match_question_mark() {
+	assert!(glob_match("file?.txt", "file1.txt"));
+	assert!(!glob_match("file?.txt", "file.txt"));
+	assert!(!glob_match("file?.txt", "file12.txt"));
+}
+#[test]
+fn dockerignore_negation_reincludes() {
+	let patterns = vec!["*.log".to_string(), "!keep.log".to_string()];
+	assert!(is_ignored("error.log", &patterns));
+	assert!(!is_ignored("keep.log", &patterns));
+}
+#[test]
+fn dockerignore_negation_order_matters() {
+	// Re-include then exclude again: last match wins.
+	let patterns = vec![
+		"logs/".to_string(),
+		"!logs/keep/".to_string(),
+		"logs/keep/secret.txt".to_string(),
+	];
+	assert!(is_ignored("logs/a.log", &patterns));
+	assert!(!is_ignored("logs/keep/b.log", &patterns));
+	assert!(is_ignored("logs/keep/secret.txt", &patterns));
+}
+#[test]
+fn build_ignored_empty_pattern_matches_nothing() {
+	// A blank `.dockerignore` line yields an empty pattern that must never
+	// match (otherwise it would exclude every file).
+	let patterns = vec![String::new()];
+	assert!(!is_ignored("anything.txt", &patterns));
+	assert!(!is_ignored("a/b/c", &patterns));
+}
+#[test]
+fn glob_match_double_star_suffix_spans_subtree() {
+	// A trailing `**` matches the directory and everything beneath it.
+	assert!(glob_match("build/**", "build/out.o"));
+	assert!(glob_match("build/**", "build/a/b/out.o"));
+	assert!(!glob_match("build/**", "src/out.o"));
+}
+#[test]
+fn glob_match_double_star_middle_with_no_match_fails() {
+	// `a/**/z` requires the path to start with `a/` and end with `z`; a path
+	// that never reaches the trailing literal exhausts the `**` prefix loop and
+	// fails rather than matching loosely.
+	assert!(glob_match("a/**/z", "a/b/c/z"));
+	assert!(!glob_match("a/**/z", "a/b/c/y"));
+}
+#[test]
+fn glob_match_question_mark_matches_single_non_slash_char() {
+	// `?` matches exactly one character and never a path separator.
+	assert!(glob_match("file?.txt", "file1.txt"));
+	assert!(!glob_match("file?.txt", "file.txt"));
+	assert!(!glob_match("a?b", "a/b"));
+}
+#[test]
+fn ignore_matching_uses_forward_slashes_on_every_platform() {
+	// `.dockerignore` patterns always use `/`. `Path` yields `\` on Windows,
+	// so matching the raw string meant nothing below the top level was ever
+	// ignored there and `vendor/` silently did nothing. The tar writer
+	// already normalises, so the entry names and the ignore check disagreed
+	// about the same file. Caught by the negation case failing on the
+	// Windows runner and passing everywhere else.
+	let rel = std::path::Path::new("vendor").join("drop.txt");
+	assert_eq!(
+		super::to_ignore_path(&rel),
+		"vendor/drop.txt",
+		"the ignore path must be slash-separated whatever the platform uses"
+	);
+	assert!(super::is_ignored(
+		&super::to_ignore_path(&rel),
+		&["vendor/".to_string()]
+	));
+}

--- a/internal/engine/build/context/tests.rs
+++ b/internal/engine/build/context/tests.rs
@@ -3,8 +3,7 @@
 //! line limit).
 
 use super::{
-	build_context_tar, build_context_tar_with_inline, glob_match, ignore_file, is_ignored,
-	map_additional_context,
+	build_context_tar, build_context_tar_with_inline, ignore_file, map_additional_context,
 };
 use std::fs;
 use std::path::Path;
@@ -158,92 +157,6 @@ fn dockerfile_is_force_included_despite_dockerignore() {
 }
 
 // is_ignored (build) ---------------------------------------------------
-
-#[test]
-fn build_ignored_exact() {
-	let patterns = vec!["secret.txt".to_string()];
-	assert!(is_ignored("secret.txt", &patterns));
-	assert!(!is_ignored("secret.txt.bak", &patterns));
-}
-
-#[test]
-fn build_ignored_dir() {
-	let patterns = vec!["node_modules/".to_string()];
-	assert!(is_ignored("node_modules/foo.js", &patterns));
-	assert!(!is_ignored("other/foo.js", &patterns));
-}
-
-#[test]
-fn build_ignored_path_separator() {
-	let patterns = vec!["vendor".to_string()];
-	assert!(is_ignored("vendor/lib.rs", &patterns));
-	assert!(!is_ignored("notvendor/lib.rs", &patterns));
-}
-
-#[test]
-fn build_ignored_glob_extension() {
-	let patterns = vec!["*.key".to_string()];
-	assert!(is_ignored("secret.key", &patterns));
-	assert!(is_ignored("certs/ca.key", &patterns));
-	assert!(!is_ignored("key.txt", &patterns));
-}
-
-#[test]
-fn build_ignored_glob_in_subdir() {
-	let patterns = vec!["logs/*.log".to_string()];
-	assert!(is_ignored("logs/error.log", &patterns));
-	assert!(!is_ignored("other/error.log", &patterns));
-}
-
-#[test]
-fn glob_match_star_extension() {
-	assert!(glob_match("*.env", "production.env"));
-	assert!(glob_match("*.env", "config/.env"));
-	assert!(!glob_match("*.env", "env.txt"));
-}
-
-#[test]
-fn glob_match_star_prefix() {
-	assert!(glob_match("id_*", "id_rsa"));
-	assert!(glob_match("id_*", "id_ed25519"));
-	assert!(!glob_match("id_*", "not_id_rsa"));
-}
-
-#[test]
-fn glob_match_double_star_any_depth() {
-	assert!(glob_match("**/*.key", "secret.key"));
-	assert!(glob_match("**/*.key", "a/b/c/secret.key"));
-	assert!(glob_match("a/**/b", "a/b"));
-	assert!(glob_match("a/**/b", "a/x/y/b"));
-	assert!(!glob_match("a/**/b", "z/b"));
-}
-
-#[test]
-fn glob_match_question_mark() {
-	assert!(glob_match("file?.txt", "file1.txt"));
-	assert!(!glob_match("file?.txt", "file.txt"));
-	assert!(!glob_match("file?.txt", "file12.txt"));
-}
-
-#[test]
-fn dockerignore_negation_reincludes() {
-	let patterns = vec!["*.log".to_string(), "!keep.log".to_string()];
-	assert!(is_ignored("error.log", &patterns));
-	assert!(!is_ignored("keep.log", &patterns));
-}
-
-#[test]
-fn dockerignore_negation_order_matters() {
-	// Re-include then exclude again: last match wins.
-	let patterns = vec![
-		"logs/".to_string(),
-		"!logs/keep/".to_string(),
-		"logs/keep/secret.txt".to_string(),
-	];
-	assert!(is_ignored("logs/a.log", &patterns));
-	assert!(!is_ignored("logs/keep/b.log", &patterns));
-	assert!(is_ignored("logs/keep/secret.txt", &patterns));
-}
 
 // ignore_file ----------------------------------------------------------
 
@@ -465,40 +378,6 @@ fn context_tar_packs_symlink_as_link_not_target() {
 	assert!(found, "symlink entry must be present in the context tar");
 }
 
-#[test]
-fn build_ignored_empty_pattern_matches_nothing() {
-	// A blank `.dockerignore` line yields an empty pattern that must never
-	// match (otherwise it would exclude every file).
-	let patterns = vec![String::new()];
-	assert!(!is_ignored("anything.txt", &patterns));
-	assert!(!is_ignored("a/b/c", &patterns));
-}
-
-#[test]
-fn glob_match_double_star_suffix_spans_subtree() {
-	// A trailing `**` matches the directory and everything beneath it.
-	assert!(glob_match("build/**", "build/out.o"));
-	assert!(glob_match("build/**", "build/a/b/out.o"));
-	assert!(!glob_match("build/**", "src/out.o"));
-}
-
-#[test]
-fn glob_match_double_star_middle_with_no_match_fails() {
-	// `a/**/z` requires the path to start with `a/` and end with `z`; a path
-	// that never reaches the trailing literal exhausts the `**` prefix loop and
-	// fails rather than matching loosely.
-	assert!(glob_match("a/**/z", "a/b/c/z"));
-	assert!(!glob_match("a/**/z", "a/b/c/y"));
-}
-
-#[test]
-fn glob_match_question_mark_matches_single_non_slash_char() {
-	// `?` matches exactly one character and never a path separator.
-	assert!(glob_match("file?.txt", "file1.txt"));
-	assert!(!glob_match("file?.txt", "file.txt"));
-	assert!(!glob_match("a?b", "a/b"));
-}
-
 /// #1096: with both ignore files present, only `.containerignore` may filter the
 /// context tar. Applying both client-side is what made podup ship an image
 /// missing content that `podman build` includes: we dropped `b.txt` per
@@ -564,5 +443,51 @@ fn context_tar_falls_back_to_dockerignore_when_alone() {
 	assert!(
 		!names.iter().any(|n| n == "b.txt"),
 		"`.dockerignore` must still apply when it is the only one: {names:?}"
+	);
+}
+
+#[test]
+fn a_negated_file_survives_under_an_ignored_directory() {
+	// Pruning an ignored directory is only sound when nothing under it can
+	// be re-included. `.dockerignore` negation does exactly that, and the
+	// pruning that landed for the enumeration cost dropped `keep.txt` from
+	// the context, so a `COPY vendor/keep.txt` lost its source.
+	//
+	// The walk's own comment justified the shortcut by asserting the engine
+	// had no such patterns in the wild. That is an assertion about what
+	// users write, and the format supports negation so they can.
+	use flate2::read::GzDecoder;
+	use std::io::Read;
+
+	let dir = tempdir().unwrap();
+	fs::write(dir.path().join("Dockerfile"), b"FROM alpine\n").unwrap();
+	fs::write(
+		dir.path().join(".dockerignore"),
+		b"vendor/\n!vendor/keep.txt\n",
+	)
+	.unwrap();
+	fs::create_dir(dir.path().join("vendor")).unwrap();
+	fs::write(dir.path().join("vendor/keep.txt"), b"keep me").unwrap();
+	fs::write(dir.path().join("vendor/drop.txt"), b"drop me").unwrap();
+
+	let bytes = build_context_tar(dir.path(), "Dockerfile", &[]).unwrap();
+	let mut raw = Vec::new();
+	GzDecoder::new(bytes.as_slice())
+		.read_to_end(&mut raw)
+		.unwrap();
+	let mut archive = tar::Archive::new(raw.as_slice());
+	let names: Vec<String> = archive
+		.entries()
+		.unwrap()
+		.map(|e| e.unwrap().path().unwrap().to_string_lossy().into_owned())
+		.collect();
+
+	assert!(
+		names.iter().any(|n| n.ends_with("vendor/keep.txt")),
+		"the re-included file must survive the prune, got: {names:?}"
+	);
+	assert!(
+		!names.iter().any(|n| n.ends_with("vendor/drop.txt")),
+		"the rest of the ignored directory must still be dropped, got: {names:?}"
 	);
 }

--- a/internal/engine/build/mod.rs
+++ b/internal/engine/build/mod.rs
@@ -264,6 +264,9 @@ impl Engine {
 #[cfg(test)]
 #[path = "build_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "build_walk_tests.rs"]
+mod walk_tests;
 
 #[cfg(all(test, unix))]
 #[path = "build_board_tests.rs"]

--- a/internal/engine/container/mod.rs
+++ b/internal/engine/container/mod.rs
@@ -31,7 +31,11 @@ use super::network::resolve_network_mode;
 use super::volume_mounts::build_mounts_all;
 use super::Engine;
 use fields::{build_blkio_config, warn_swarm_only_deploy};
-use security::parse_security_opts;
+// Re-exported at the container root so `crate::engine::container::*` is a
+// valid path inside the crate (lib.rs's `effective_no_new_privileges`
+// wrapper reaches it for the audit module, #1743). Private here would shadow
+// the `pub(crate)` visibility into private.
+pub(crate) use security::parse_security_opts;
 
 impl Engine {
 	pub(super) async fn create_and_start(

--- a/internal/engine/copy.rs
+++ b/internal/engine/copy.rs
@@ -25,6 +25,39 @@ use archive::{extract_archive, pack_path};
 /// file/dir copies); larger transfers should use `podman cp` directly.
 const MAX_CP_ARCHIVE_BYTES: usize = 1024 * 1024 * 1024;
 
+/// What `dst` looks like for the container→host cp routing decision.
+///
+/// Three cases drive [`Engine::cp_from_container`]:
+/// - `Directory`: an existing real directory; the streaming extractor can
+///   pipe the archive body straight into it without buffering.
+/// - `Symlink`: a destination that is itself a symlink. `Path::is_dir`
+///   would follow it and report a directory, so the routing used to take
+///   the streaming branch and the bytes landed in the link target rather
+///   than the named destination. The same class of bug #1736 closed
+///   inside `extract_archive`; this is that fix mirrored at the call site
+///   that picks between streaming and buffering.
+/// - `NotADirectory`: a missing path (the buffered `extract_archive`
+///   branch will create it) or an existing non-directory (the same
+///   branch will land the single entry there).
+pub(super) enum CpDestinationKind {
+	Directory,
+	Symlink,
+	NotADirectory,
+}
+
+/// Classify `dst` for the cp routing. `symlink_metadata` is used rather
+/// than `is_dir`/`exists` so a destination that is a symlink is reported
+/// as a symlink, not the directory it points at. Without this, the
+/// streaming branch would extract into the link target rather than the
+/// named destination (#1736 + the call-site follow-up).
+pub(super) fn cp_destination_kind(dst: &Path) -> CpDestinationKind {
+	match std::fs::symlink_metadata(dst) {
+		Ok(meta) if meta.file_type().is_symlink() => CpDestinationKind::Symlink,
+		Ok(meta) if meta.is_dir() => CpDestinationKind::Directory,
+		_ => CpDestinationKind::NotADirectory,
+	}
+}
+
 /// Options for [`Engine::cp_with_options`], mirroring `docker compose cp` flags.
 ///
 /// `#[non_exhaustive]` since 4.0.0, so a new field can be added in a minor
@@ -173,8 +206,27 @@ impl Engine {
 		// A stream cannot be rewound, so that path still buffers. Making it
 		// single-pass means changing what `cp` does with an ambiguous
 		// destination, which is a behaviour decision rather than a memory one.
-		if dst.is_dir() {
-			return stream::extract_streamed(resp, dst, MAX_CP_ARCHIVE_BYTES as u64).await;
+		//
+		// The classification goes through `symlink_metadata` rather than
+		// `is_dir` so a destination that is a symlink is reported as a symlink
+		// rather than the directory it points at; the streaming branch would
+		// otherwise extract into the link target. Same class of bug #1736
+		// closed inside `extract_archive`, mirrored here at the routing site.
+		match cp_destination_kind(&dst) {
+			CpDestinationKind::Symlink => {
+				return Err(ComposeError::Copy(format!(
+					"cp: refusing symlink destination: {}",
+					dst.display()
+				)));
+			}
+			CpDestinationKind::Directory => {
+				return stream::extract_streamed(resp, dst, MAX_CP_ARCHIVE_BYTES as u64).await;
+			}
+			CpDestinationKind::NotADirectory => {
+				// Fall through: `extract_archive` will either create a fresh
+				// directory (directory source) or land the single entry at
+				// exactly `dst` (single file source).
+			}
 		}
 
 		// Cap the buffered archive so a huge/hostile container path cannot OOM

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -57,8 +57,22 @@ pub(super) fn pack_path(
 /// - `dst` does not exist and the source is a directory: `dst` is created and the
 ///   source's *contents* are copied into it (matching `docker cp`).
 pub(super) fn extract_archive(tar_bytes: &[u8], dst: &Path) -> Result<()> {
-	if dst.is_dir() {
-		return extract_tar_guarded(tar_bytes, dst);
+	// `symlink_metadata` rather than `is_dir` so a destination that is a
+	// symlink is recognised as a symlink, not the directory it points at.
+	// Following the symlink here would extract the archive into the wrong
+	// place (the target directory) and, once `flatten_single_wrapper_dir`
+	// runs over the extracted contents, move the target's files out of it
+	// (#1736). Refuse before anything touches the filesystem.
+	if let Ok(meta) = std::fs::symlink_metadata(dst) {
+		if meta.file_type().is_symlink() {
+			return Err(ComposeError::Copy(format!(
+				"cp: refusing symlink destination: {}",
+				dst.display()
+			)));
+		}
+		if meta.is_dir() {
+			return extract_tar_guarded(tar_bytes, dst);
+		}
 	}
 	// `dst` is not an existing directory.
 	if !archive_contains_dir(tar_bytes)? {
@@ -141,12 +155,25 @@ fn archive_contains_dir(tar_bytes: &[u8]) -> Result<bool> {
 /// basename (`srcdir/...`). When that lands in a freshly-created `dst`, docker
 /// puts the source's *contents* directly in `dst`, so collapse the lone wrapper
 /// level. A no-op unless `dst` holds exactly one entry and it is a directory.
+///
+/// The directory check goes through `symlink_metadata` so a wrapper that is
+/// a symlink is recognised as a symlink, not the directory it points at. A
+/// compromised container can plant such an entry: following the symlink would
+/// read the target's contents and rename them into `dst`, emptying an
+/// out-of-archive directory (#1736). The wrapper is left in place.
 fn flatten_single_wrapper_dir(dst: &Path) -> Result<()> {
 	let mut children: Vec<std::path::PathBuf> = std::fs::read_dir(dst)
 		.map_err(ComposeError::Io)?
 		.filter_map(|e| e.ok().map(|e| e.path()))
 		.collect();
-	if children.len() != 1 || !children[0].is_dir() {
+	if children.len() != 1 {
+		return Ok(());
+	}
+	let wrapper = &children[0];
+	if !std::fs::symlink_metadata(wrapper)
+		.map(|m| m.is_dir())
+		.unwrap_or(false)
+	{
 		return Ok(());
 	}
 	let wrapper = children.remove(0);
@@ -302,3 +329,7 @@ fn sanitize_extracted_mode(_path: &Path, _mode: u32) {}
 #[cfg(test)]
 #[path = "archive_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "archive_symlink_tests.rs"]
+mod symlink_tests;

--- a/internal/engine/copy/archive_symlink_tests.rs
+++ b/internal/engine/copy/archive_symlink_tests.rs
@@ -1,0 +1,83 @@
+//! Tests for #1736: `cp` must not follow a symlink planted inside the
+//! archive being extracted, or rename the contents of an out-of-archive
+//! directory into the destination.
+//!
+//! The flat `cp svc:/` archive libpod returns for a container whose source
+//! is a directory can carry an entry that is itself a symlink pointing
+//! outside. After `extract_tar_guarded` lands the bytes, the destination
+//! holds that symlink as its only child. The flatten step then ran
+//! `is_dir()` on the child, which followed the symlink, called
+//! `read_dir` on the target, and renamed each file out of it: an
+//! out-of-archive directory was emptied into the destination. The fix
+//! uses `symlink_metadata` so the symlink stays a symlink.
+
+#[cfg(unix)]
+#[test]
+fn extract_archive_does_not_empty_victim_through_planted_symlink() {
+	// Victim lives outside the destination and holds private material.
+	let dir = tempfile::tempdir().expect("tempdir");
+	let victim = dir.path().join("victim");
+	std::fs::create_dir(&victim).expect("mkdir");
+	std::fs::write(victim.join("id_ed25519"), b"key").expect("write");
+	std::fs::write(victim.join("known_hosts"), b"hosts").expect("write");
+
+	let dst = dir.path().join("dst");
+
+	// Build the archive shape that triggers the defect: a single
+	// directory entry naming the destination itself (so
+	// `archive_contains_dir` reports true and `extract_archive` reaches
+	// the flatten path), followed by a single symlink entry whose name
+	// has no parent and whose target points at the victim. After
+	// `extract_tar_guarded` lands the bytes, `dst` holds exactly one
+	// child: the symlink.
+	let mut builder = tar::Builder::new(Vec::new());
+	let mut d = tar::Header::new_gnu();
+	d.set_size(0);
+	d.set_mode(0o755);
+	d.set_entry_type(tar::EntryType::Directory);
+	d.set_path("./").expect("path");
+	d.set_cksum();
+	builder.append(&d, std::io::empty()).expect("dir");
+	let mut s = tar::Header::new_gnu();
+	s.set_size(0);
+	s.set_mode(0o755);
+	s.set_entry_type(tar::EntryType::Symlink);
+	s.set_path("w").expect("path");
+	// The symlink target has to land in the GNU linkname field; the safe
+	// `set_link_name` helper accepts the value, but writing the header
+	// field directly matches what the production extractor has to
+	// survive (an archive a hostile container could craft).
+	let target = victim.to_str().expect("utf-8");
+	{
+		let gnu = s.as_gnu_mut().expect("gnu header");
+		let name = &mut gnu.linkname;
+		name.iter_mut().for_each(|b| *b = 0);
+		let bytes = target.as_bytes();
+		name[..bytes.len()].copy_from_slice(bytes);
+	}
+	s.set_cksum();
+	builder.append(&s, std::io::empty()).expect("symlink");
+	let bytes = builder.into_inner().expect("finish");
+
+	// The call's return value is irrelevant; the safety invariant is that
+	// nothing in the victim directory has moved, regardless of whether the
+	// extraction succeeded or errored out.
+	let _ = super::extract_archive(&bytes, &dst);
+
+	assert!(
+		victim.join("id_ed25519").exists(),
+		"id_ed25519 was moved out of the victim directory through a symlink planted in the archive"
+	);
+	assert_eq!(
+		std::fs::read(victim.join("id_ed25519")).expect("read"),
+		b"key"
+	);
+	assert!(
+		victim.join("known_hosts").exists(),
+		"known_hosts was moved out of the victim directory through a symlink planted in the archive"
+	);
+	assert_eq!(
+		std::fs::read(victim.join("known_hosts")).expect("read"),
+		b"hosts"
+	);
+}

--- a/internal/engine/copy_tests.rs
+++ b/internal/engine/copy_tests.rs
@@ -1,5 +1,6 @@
 use super::{
-	copy_landed, join_archive_path, parse_endpoint, uploaded_entry_size, ExpectedEntry, PathStat,
+	copy_landed, cp_destination_kind, join_archive_path, parse_endpoint, uploaded_entry_size,
+	CpDestinationKind, ExpectedEntry, PathStat,
 };
 
 #[test]
@@ -195,4 +196,59 @@ fn the_cp_option_builders_set_their_field() {
 		base.clone().with_follow_link(true)
 	);
 	assert_eq!(CpOptions::new(None, false, true), base.with_archive(true));
+}
+
+/// #1736 follow-up: the routing that picks between the streaming
+/// extractor and the buffered `extract_archive` was using `dst.is_dir()`
+/// directly, which follows a symlink and reports a directory. The
+/// streaming branch would then extract into the link target rather than
+/// the destination the user named (#1736's fix closed the same hole
+/// inside `extract_archive`; this test pins the same fix at the
+/// routing site).
+#[test]
+fn cp_destination_kind_treats_a_real_directory_as_a_directory() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let target = dir.path().join("real");
+	std::fs::create_dir(&target).expect("mkdir");
+	assert!(matches!(
+		cp_destination_kind(&target),
+		CpDestinationKind::Directory
+	));
+}
+#[cfg(unix)]
+#[test]
+fn cp_destination_kind_treats_a_symlink_to_a_directory_as_a_symlink() {
+	// Without this, `dst.is_dir()` followed the link and reported `true`;
+	// the streaming branch then ran `extract_tar_guarded(link_target, ..)`
+	// through the symlink. The bytes would land wherever the link points,
+	// not on the path the user named. Mirrors the fix #1736 applied inside
+	// `extract_archive`.
+	let dir = tempfile::tempdir().expect("tempdir");
+	let real = dir.path().join("real");
+	std::fs::create_dir(&real).expect("mkdir");
+	let link = dir.path().join("link");
+	std::os::unix::fs::symlink(&real, &link).expect("symlink");
+	assert!(
+		matches!(cp_destination_kind(&link), CpDestinationKind::Symlink),
+		"the cp routing must refuse a symlink destination before the extractor is reached",
+	);
+}
+#[test]
+fn cp_destination_kind_treats_a_missing_path_as_not_a_directory() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let missing = dir.path().join("absent");
+	assert!(matches!(
+		cp_destination_kind(&missing),
+		CpDestinationKind::NotADirectory
+	));
+}
+#[test]
+fn cp_destination_kind_treats_a_regular_file_as_not_a_directory() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let file = dir.path().join("file");
+	std::fs::write(&file, b"x").expect("write");
+	assert!(matches!(
+		cp_destination_kind(&file),
+		CpDestinationKind::NotADirectory
+	));
 }

--- a/internal/engine/lifecycle/mod.rs
+++ b/internal/engine/lifecycle/mod.rs
@@ -52,6 +52,12 @@ pub(crate) struct ExistingContainer {
 	config_hash: Option<String>,
 	/// The 64-hex ID of the image the container was created from.
 	image_id: String,
+	/// The `podup.service` label, when present. Carried alongside the bulk
+	/// project's container list so the scale-reconciliation step in `run_up`
+	/// can filter the same in-memory snapshot instead of issuing one
+	/// per-service `/containers/json` against an already-fetched data set
+	/// (#1747).
+	service: Option<String>,
 }
 
 impl Engine {
@@ -135,6 +141,9 @@ pub(super) fn container_rm_path(name: &str, remove_volumes: bool) -> String {
 
 #[cfg(test)]
 mod drop_recheck_tests;
+#[cfg(test)]
+#[path = "scale_request_tests.rs"]
+mod scale_request_tests;
 #[cfg(test)]
 mod scale_tests;
 #[cfg(test)]

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -160,11 +160,20 @@ impl Engine {
 	/// failure is remembered and returned once every replica has been
 	/// attempted, so `scale`/`up --scale` does not exit 0 with a surplus
 	/// replica silently left running (#598).
+	///
+	/// `existing` is the bulk project's container snapshot the caller fetched
+	/// earlier in the same `up` walk; filtering it in memory saves one
+	/// `/containers/json` round trip per `--scale` override, since the
+	/// per-service label is already carried on each `ExistingContainer`
+	/// (entry #1747). `scale` (the standalone command) does not have that
+	/// snapshot, so it builds one inline by issuing the same endpoint
+	/// itself; the duplicate-fetch concern is the `up` path, not this one.
 	pub(super) async fn remove_surplus_replicas(
 		&self,
 		service_name: &str,
 		service: &Service,
 		target: u32,
+		existing: &std::collections::HashMap<String, super::ExistingContainer>,
 	) -> Result<()> {
 		// The desired set is the index-suffixed name at every count (`svc-1`
 		// even for a single replica), so a scale N→1 keeps the running `svc-1`
@@ -175,10 +184,16 @@ impl Engine {
 			.into_iter()
 			.collect();
 		let grace = self.grace_period_secs(service);
-		let surplus: Vec<String> = self
-			.list_project_container_names(Some(service_name))
-			.await?
-			.into_iter()
+		// Filter the in-memory bulk snapshot by the per-service label rather
+		// than issuing a fresh `/containers/json`. On the `up` path the
+		// caller fetched that whole snapshot at the top of `run_up`; a second
+		// per-service fetch re-reads a data set that is already on hand.
+		let surplus: Vec<String> = existing
+			.iter()
+			.filter_map(|(name, entry)| match entry.service.as_deref() {
+				Some(svc) if svc == service_name => Some(name.clone()),
+				_ => None,
+			})
 			.filter(|name| !desired.contains(name))
 			.collect();
 		// Scaling down removes surplus replicas but keeps their data volumes

--- a/internal/engine/lifecycle/scale.rs
+++ b/internal/engine/lifecycle/scale.rs
@@ -11,25 +11,10 @@ use crate::libpod::{urlencoded, API_PREFIX};
 use super::parallel::first_error;
 use super::targets::{stop_deadline, stop_timeout_param};
 
-/// A live project container: the name to act on plus its machine-readable
-/// state, as reported by the libpod container-list endpoint. Returned by
-/// [`Engine::live_service_containers`] so callers can act on (and report) only
-/// containers in the right state.
-pub(crate) struct LiveContainer {
-	/// Container name with the leading slash stripped.
-	pub name: String,
-	/// Machine-readable state (`running`, `created`, `exited`, `paused`, …).
-	pub state: String,
-}
-
 /// Whether a container in this state is currently active, i.e. `stop` would
 /// actually transition it. A `running` or `paused` container is stopped; a
 /// `created`/`exited`/`dead`/… one is already not running, so stopping it is a
 /// no-op that must not be reported as "stopped" (#876). Pure for unit testing.
-///
-/// Unused in production since the per-service lifecycle commands stopped
-/// filtering by state themselves (#1363), kept here for the unit test that
-/// pins its truth table.
 #[allow(dead_code)]
 pub(crate) fn state_is_active(state: &str) -> bool {
 	matches!(state, "running" | "paused")
@@ -353,64 +338,57 @@ impl Engine {
 		Ok(by_service)
 	}
 
-	/// The live containers of a service (matched by the `podup.service` label),
-	/// each paired with its machine-readable state (`running`, `created`,
-	/// `exited`, `paused`, …). This does NOT fall back to statically-predicted
-	/// names: a service with no live container
-	/// yields an empty vec, so a lifecycle op (stop/wait/…) on a defined-but-
-	/// never-created service is a quiet no-op instead of POSTing to a phantom
-	/// name and surfacing a raw 404 (#758). The state lets `stop` report
-	/// "stopped" only for containers that were actually running (#876).
-	pub(crate) async fn live_service_containers(
+	/// Sibling of [`Self::live_project_replicas_sorted`] that filters each
+	/// bucket to running containers only. Built for `podup top`, where the
+	/// libpod `/top` endpoint answers a non-running container with an HTTP 500
+	/// and the caller would otherwise have to skip it after the fact (#1250).
+	/// One bulk GET powers the whole-project `top` the way
+	/// `live_project_replicas_sorted` already powers `logs`/`port`/`exec`/`cp`
+	/// (#1445): a 40-service `top` used to issue 40 `/containers/json` GETs,
+	/// one per service, and now issues 1 (#1742).
+	///
+	/// Same per-service sort as the sorted sibling, so the printed order is
+	/// the same ascending `-1, -2, -3` order `top` used to produce from the
+	/// per-service helper. The static-name fallback is the caller's
+	/// responsibility: a service absent from the map yields no names here.
+	pub(crate) async fn live_project_running_replicas_sorted(
 		&self,
-		service_name: &str,
-	) -> Result<Vec<LiveContainer>> {
-		let filters = serde_json::json!({
-			"label": [
-				self.project_label_raw(),
-				format!("podup.service={service_name}"),
-			],
-		});
+	) -> Result<std::collections::HashMap<String, Vec<String>>> {
+		// Reuse the per-engine URL-encoded filter (#1364); see
+		// [`Engine::project_label_filter_encoded`].
 		let path = format!(
 			"{API_PREFIX}/containers/json?all=true&filters={}",
-			urlencoded(&filters.to_string()),
+			self.project_label_filter_encoded(),
 		);
 		let entries = self
 			.client
 			.get_json::<Vec<crate::libpod::types::container::ContainerListEntry>>(&path)
 			.await
 			.map_err(ComposeError::Podman)?;
-		Ok(entries
-			.into_iter()
-			.filter_map(|e| {
-				let state = e.state;
-				e.names.into_iter().next().map(|raw| LiveContainer {
-					name: raw.trim_start_matches('/').to_string(),
-					state,
-				})
-			})
-			.collect())
-	}
-
-	/// The names of a service's containers that are actually **running**, in the
-	/// same ascending `-1, -2, -3, ...` order as [`Self::live_project_replicas_sorted`].
-	///
-	/// For the query commands that only mean anything against a live process
-	/// (`top`), where a stopped replica has to be skipped rather than asked: the
-	/// libpod endpoints answer a non-running container with an HTTP 500, which
-	/// callers must not have to tell apart from a real failure by parsing its
-	/// message. There is no fallback to statically-derived names: a service
-	/// that was never created has nothing running, so it yields an empty vec
-	/// instead of a phantom name.
-	pub(crate) async fn running_replica_names(&self, service_name: &str) -> Result<Vec<String>> {
-		let mut running: Vec<String> = self
-			.live_service_containers(service_name)
-			.await?
-			.into_iter()
-			.filter(|c| c.state.eq_ignore_ascii_case("running"))
-			.map(|c| c.name)
-			.collect();
-		sort_replica_names(&mut running);
-		Ok(running)
+		let mut by_service: std::collections::HashMap<String, Vec<String>> =
+			std::collections::HashMap::new();
+		for entry in entries {
+			// The `/top` endpoint answers a non-running container with an
+			// HTTP 500; dropping the stopped replicas here is what kept the
+			// per-service `running_replica_names` helper silent on a mixed
+			// listing (#1250).
+			if !entry.state.eq_ignore_ascii_case("running") {
+				continue;
+			}
+			let Some(service) = entry.labels.get("podup.service") else {
+				continue;
+			};
+			let Some(raw) = entry.names.first() else {
+				continue;
+			};
+			by_service
+				.entry(service.clone())
+				.or_default()
+				.push(raw.trim_start_matches('/').to_string());
+		}
+		for names in by_service.values_mut() {
+			sort_replica_names(names);
+		}
+		Ok(by_service)
 	}
 }

--- a/internal/engine/lifecycle/scale_request_tests.rs
+++ b/internal/engine/lifecycle/scale_request_tests.rs
@@ -1,0 +1,181 @@
+//! Request-counting cases split out of `scale_tests.rs`, which reached the
+//! 500-line hard limit. These are the ones that stand up a fake libpod
+//! socket and assert how many round-trips a command makes (#1363, #1445,
+//! #1742); the rest of the file is pure reconciliation logic with no
+//! socket. The split follows that seam rather than a line count.
+
+#[cfg(unix)]
+use super::*;
+
+// Every case in this file stands up a fake libpod socket, and the fixture
+// binds a `UnixListener`, so the whole file is Unix-only. The imports and
+// the helper carry the same `cfg` as the cases rather than the module
+// carrying one, which is the shape `scale_tests.rs` already uses.
+#[cfg(unix)]
+use crate::engine::fake_podman;
+
+#[cfg(unix)]
+fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+}
+
+/// #1445 is a round-trip count, so pin the count rather than only the values it
+/// produces. Before it, every selected service cost its own `/containers/json`
+/// GET; a project of N services made N of them. Nothing in the value assertions
+/// above notices if that regresses (the names come back identical either way)
+/// so a later refactor could quietly put the call back inside the loop.
+///
+/// Four services, and the fake records every request it answers. The assertion
+/// is that exactly one container-list GET reaches the socket.
+#[tokio::test]
+#[cfg(unix)]
+async fn logs_issues_one_container_list_for_the_whole_project() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-api-1"],"State":"running","Labels":{"podup.service":"api"}},
+		{"Names":["/proj-db-1"],"State":"running","Labels":{"podup.service":"db"}},
+		{"Names":["/proj-cache-1"],"State":"running","Labels":{"podup.service":"cache"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else {
+			// Every per-container logs stream 404s: this test is about how many
+			// listing calls are made, not about what the streams carry.
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	let file = crate::parse_str(
+		"services:\n  web:\n    image: x\n  api:\n    image: x\n  db:\n    image: x\n  cache:\n    image: x\n",
+	)
+	.unwrap();
+
+	// The per-container streams all 404, so the call itself is expected to
+	// fail; the request log is what carries the answer.
+	let _ = e.logs(&file, None, false).await;
+
+	let lists = fake
+		.requests
+		.lock()
+		.unwrap()
+		.iter()
+		.filter(|r| r.contains("/containers/json"))
+		.count();
+	assert_eq!(
+		lists,
+		1,
+		"four services must share one container-list round-trip, not one each (#1445); \
+		 requests were {:?}",
+		fake.requests.lock().unwrap()
+	);
+}
+
+/// A surplus replica's row opens with `Stopping` before the stop request,
+/// moves to `Removing` before the delete, and closes with `Removed`. The row
+/// used to appear only at `Removed`, with no start time and nothing on screen
+/// during a ten-second grace (#1686).
+#[tokio::test]
+#[cfg(unix)]
+async fn stop_and_remove_opens_the_row_before_the_stop_and_closes_it_removed() {
+	let live_snap = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-web-2"]}]"#;
+	// Pre-build the snapshot the production `run_up` hands the function
+	// (no `/containers/json` here either; the fix takes the bulk snapshot
+	// rather than refetching per-service, see `#1747`).
+	let mut existing: std::collections::HashMap<String, super::ExistingContainer> =
+		std::collections::HashMap::new();
+	for raw in ["proj-web-1", "proj-web-2"] {
+		existing.insert(
+			raw.to_string(),
+			super::ExistingContainer {
+				config_hash: None,
+				image_id: String::new(),
+				service: Some("web".to_string()),
+			},
+		);
+	}
+	let fake = fake_podman::start(move |method, target| {
+		let _ = live_snap; // keep the literal in the closure for parity
+		if (method == "POST" && target.contains("/stop"))
+			|| (method == "DELETE" && target.contains("/proj-web-2?force=true"))
+		{
+			(200, String::new())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	let capture = crate::ui::progress::capture::Capture::start();
+	e.remove_surplus_replicas(
+		"web",
+		&crate::compose::types::Service::default(),
+		1,
+		&existing,
+	)
+	.await
+	.expect("the surplus replica is removed");
+	let verbs: Vec<String> = capture
+		.verbs()
+		.into_iter()
+		.filter(|(_, name, _)| name == "proj-web-2")
+		.map(|(_, _, verb)| verb)
+		.collect();
+	assert_eq!(
+		verbs,
+		vec!["Stopping", "Removing", "Removed"],
+		"the row is opened before the stop and closed after the delete"
+	);
+}
+
+/// #1747 (L4): the `up` walk with at least one `--scale` override used to
+/// issue one project container-list GET at the top of `run_up` and then a
+/// second GET per scale override inside `remove_surplus_replicas`, both for
+/// the same `podup.project` filter shape (the second call added a
+/// `podup.service=` predicate on top). With two overrides, that was three
+/// `/containers/json` round trips against data that was already on hand
+/// after the first GET. The fix pushes the bulk snapshot through
+/// `remove_surplus_replicas`; the assertion here pins the round-trip count
+/// to one for the bulk fetch alone, regardless of override count.
+#[tokio::test]
+#[cfg(unix)]
+async fn up_with_a_scale_override_issues_one_project_list_get() {
+	use std::sync::atomic::{AtomicUsize, Ordering};
+	use std::sync::Arc;
+	let list_calls = Arc::new(AtomicUsize::new(0));
+	let list_calls_for_closure = list_calls.clone();
+	// Every `/containers/json` is the bulk project list; every
+	// `/containers/<n>/stop` or `/containers/<n>?force=true` is the
+	// per-replica reconcile work `remove_surplus_replicas` does on top of
+	// it. The marker counts only the first kind: the fix's contract is
+	// that this is fetched *once* per `up`.
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			list_calls_for_closure.fetch_add(1, Ordering::Relaxed);
+			(
+				200,
+				r#"[{"Names":["/proj-web-1"],"Labels":{"podup.service":"web"}}]"#.to_string(),
+			)
+		} else if method == "POST" && target.contains("/stop")
+			|| method == "DELETE" && target.contains("/proj-web-1?force=true")
+		{
+			(404, r#"{"message":"no such container"}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+	let file = crate::parse_str("services:\n  web:\n    image: x\n").unwrap();
+	let engine = e.with_scale_overrides(std::collections::HashMap::from([("web".to_string(), 2)]));
+	// `up` will fail later (image-create paths 404, etc.); what carries the
+	// assertion is the recorded GET count and the projected request log.
+	let _ = engine.up(&file).await;
+
+	let lists = list_calls.load(Ordering::Relaxed);
+	assert_eq!(
+		lists,
+		1,
+		"`up --scale` must issue one `/containers/json` fetch (the bulk snapshot), \
+		 not one plus another per `--scale` override; requests were {:?}",
+		fake.requests.lock().unwrap()
+	);
+}

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -50,10 +50,29 @@ async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_t
 	});
 	let e = engine_with(fake.client(), "proj");
 
-	// target = 0 desired replicas, so every live container is surplus
-	// (mirrors the `replica_names_for_zero_scale_is_empty` contract).
+	// Build the snapshot `run_up` would have handed `remove_surplus_replicas`
+	// in production: every container in the bulk fetch carries the
+	// `podup.service` label that the per-service filter used to look up
+	// (`#1747`). `target = 0` makes every name a surplus replica.
+	let mut existing: std::collections::HashMap<String, super::ExistingContainer> =
+		std::collections::HashMap::new();
+	for raw in ["proj-web-1", "proj-web-2"] {
+		existing.insert(
+			raw.to_string(),
+			super::ExistingContainer {
+				config_hash: None,
+				image_id: String::new(),
+				service: Some("web".to_string()),
+			},
+		);
+	}
 	let err = e
-		.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
+		.remove_surplus_replicas(
+			"web",
+			&crate::compose::types::Service::default(),
+			0,
+			&existing,
+		)
 		.await
 		.expect_err("a real surplus-removal failure must propagate");
 	assert!(
@@ -67,6 +86,14 @@ async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_t
 			.any(|r| r.contains("DELETE") && r.contains("/proj-web-1?force=true")),
 		"expected proj-web-1 to still be removed despite proj-web-2 failing: {seen:?}"
 	);
+	// The fix takes the snapshot as a parameter; the per-service fetch that
+	// used to live inside `remove_surplus_replicas` is gone (#1747), so
+	// `/containers/json` should not appear in the recorded requests at all.
+	assert!(
+		seen.iter()
+			.all(|r| !r.contains("GET") || !r.contains("/containers/json")),
+		"remove_surplus_replicas must not fetch /containers/json: {seen:?}"
+	);
 }
 
 /// Surplus replicas that are already gone (404 on removal) stay an
@@ -74,18 +101,46 @@ async fn remove_surplus_replicas_propagates_a_real_rm_failure_after_completing_t
 #[tokio::test]
 #[cfg(unix)]
 async fn remove_surplus_replicas_tolerates_already_gone() {
-	let live = r#"[{"Names":["/proj-web-1"]}]"#;
+	// Build the snapshot directly: the fix takes the bulk project's
+	// container list as a parameter rather than refetching (`#1747`).
+	let mut existing: std::collections::HashMap<String, super::ExistingContainer> =
+		std::collections::HashMap::new();
+	existing.insert(
+		"proj-web-1".to_string(),
+		super::ExistingContainer {
+			config_hash: None,
+			image_id: String::new(),
+			service: Some("web".to_string()),
+		},
+	);
 	let fake = fake_podman::start(move |method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			(200, live.to_string())
+		// `remove_surplus_replicas` no longer fetches `/containers/json`,
+		// so any GET there is a regression. The stop/remove pair is
+		// answered 404 so the function sees the already-gone case.
+		if method == "POST" && target.contains("/stop")
+			|| method == "DELETE" && target.contains("/proj-web-1?force=true")
+		{
+			(404, r#"{"message":"no such container"}"#.to_string())
 		} else {
 			(404, r#"{"message":"not found"}"#.to_string())
 		}
 	});
 	let e = engine_with(fake.client(), "proj");
-	e.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 0)
-		.await
-		.expect("an already-gone surplus replica must still exit 0");
+	e.remove_surplus_replicas(
+		"web",
+		&crate::compose::types::Service::default(),
+		0,
+		&existing,
+	)
+	.await
+	.expect("an already-gone surplus replica must still exit 0");
+
+	let seen = fake.requests.lock().unwrap();
+	assert!(
+		seen.iter()
+			.all(|r| !r.contains("GET") || !r.contains("/containers/json")),
+		"remove_surplus_replicas must not issue the project list query: {seen:?}"
+	);
 }
 
 /// libpod's `/containers/json` does not guarantee order; `logs` and every
@@ -525,93 +580,4 @@ fn fixed_container_name_scaled_above_one_is_rejected() {
 fn unnamed_service_scales_freely() {
 	let svc = service("services:\n  app:\n    image: x\n");
 	assert!(check_fixed_name_scale("app", &svc, 5).is_ok());
-}
-
-/// #1445 is a round-trip count, so pin the count rather than only the values it
-/// produces. Before it, every selected service cost its own `/containers/json`
-/// GET; a project of N services made N of them. Nothing in the value assertions
-/// above notices if that regresses (the names come back identical either way)
-/// so a later refactor could quietly put the call back inside the loop.
-///
-/// Four services, and the fake records every request it answers. The assertion
-/// is that exactly one container-list GET reaches the socket.
-#[tokio::test]
-#[cfg(unix)]
-async fn logs_issues_one_container_list_for_the_whole_project() {
-	let containers = r#"[
-		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
-		{"Names":["/proj-api-1"],"State":"running","Labels":{"podup.service":"api"}},
-		{"Names":["/proj-db-1"],"State":"running","Labels":{"podup.service":"db"}},
-		{"Names":["/proj-cache-1"],"State":"running","Labels":{"podup.service":"cache"}}
-	]"#;
-	let fake = fake_podman::start(move |method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			(200, containers.to_string())
-		} else {
-			// Every per-container logs stream 404s: this test is about how many
-			// listing calls are made, not about what the streams carry.
-			(404, r#"{"message":"not found"}"#.to_string())
-		}
-	});
-	let e = engine_with(fake.client(), "proj");
-	let file = crate::parse_str(
-		"services:\n  web:\n    image: x\n  api:\n    image: x\n  db:\n    image: x\n  cache:\n    image: x\n",
-	)
-	.unwrap();
-
-	// The per-container streams all 404, so the call itself is expected to
-	// fail; the request log is what carries the answer.
-	let _ = e.logs(&file, None, false).await;
-
-	let lists = fake
-		.requests
-		.lock()
-		.unwrap()
-		.iter()
-		.filter(|r| r.contains("/containers/json"))
-		.count();
-	assert_eq!(
-		lists,
-		1,
-		"four services must share one container-list round-trip, not one each (#1445); \
-		 requests were {:?}",
-		fake.requests.lock().unwrap()
-	);
-}
-
-/// A surplus replica's row opens with `Stopping` before the stop request,
-/// moves to `Removing` before the delete, and closes with `Removed`. The row
-/// used to appear only at `Removed`, with no start time and nothing on screen
-/// during a ten-second grace (#1686).
-#[tokio::test]
-#[cfg(unix)]
-async fn stop_and_remove_opens_the_row_before_the_stop_and_closes_it_removed() {
-	let live = r#"[{"Names":["/proj-web-1"]},{"Names":["/proj-web-2"]}]"#;
-	let fake = fake_podman::start(move |method, target| {
-		if method == "GET" && target.contains("/containers/json") {
-			(200, live.to_string())
-		} else if (method == "POST" && target.contains("/stop"))
-			|| (method == "DELETE" && target.contains("/proj-web-2?force=true"))
-		{
-			(200, String::new())
-		} else {
-			(404, r#"{"message":"not found"}"#.to_string())
-		}
-	});
-	let e = engine_with(fake.client(), "proj");
-	let capture = crate::ui::progress::capture::Capture::start();
-	e.remove_surplus_replicas("web", &crate::compose::types::Service::default(), 1)
-		.await
-		.expect("the surplus replica is removed");
-	let verbs: Vec<String> = capture
-		.verbs()
-		.into_iter()
-		.filter(|(_, name, _)| name == "proj-web-2")
-		.map(|(_, _, verb)| verb)
-		.collect();
-	assert_eq!(
-		verbs,
-		vec!["Stopping", "Removing", "Removed"],
-		"the row is opened before the stop and closed after the delete"
-	);
 }

--- a/internal/engine/lifecycle/scale_tests.rs
+++ b/internal/engine/lifecycle/scale_tests.rs
@@ -277,21 +277,22 @@ async fn logs_resolves_replicas_in_one_bulk_get_not_one_per_service() {
 	);
 }
 
-/// #1250: `top` aborted on a project with a stopped service because it asked
-/// every container that exists for its process list, and libpod answers a
-/// non-running one with an HTTP 500. The exited replica must be dropped
-/// before the call, and the survivors must keep the ascending order every
-/// other by-service command produces, so this asserts both, on a listing
-/// that is shuffled and mixed-state at once.
+/// #1250 / #1742: `top` aborts on a project with a stopped service because
+/// `/top` answers a non-running container with an HTTP 500. The bulk
+/// `live_project_running_replicas_sorted` helper (the one `top` now reads
+/// from) must drop non-running replicas before the call, and the survivors
+/// must keep the ascending `-1, -2, -3` order every other by-service
+/// command produces. Both come back from a single `/containers/json` round
+/// trip: the same listing is shared across all services.
 #[tokio::test]
 #[cfg(unix)]
-async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
+async fn live_project_running_replicas_sorted_drops_non_running_and_keeps_ascending_order() {
 	let containers = r#"[
-		{"Names":["/proj-web-3"],"State":"running"},
-		{"Names":["/proj-web-4"],"State":"created"},
-		{"Names":["/proj-web-1"],"State":"running"},
-		{"Names":["/proj-web-5"],"State":"paused"},
-		{"Names":["/proj-web-2"],"State":"exited"}
+		{"Names":["/proj-web-3"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-4"],"State":"created","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-5"],"State":"paused","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-web-2"],"State":"exited","Labels":{"podup.service":"web"}}
 	]"#;
 	let fake = fake_podman::start(move |method, target| {
 		if method == "GET" && target.contains("/containers/json") {
@@ -302,14 +303,14 @@ async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
 	});
 	let e = engine_with(fake.client(), "proj");
 
-	let names = e
-		.running_replica_names("web")
+	let by_service = e
+		.live_project_running_replicas_sorted()
 		.await
-		.expect("running_replica_names should succeed");
+		.expect("live_project_running_replicas_sorted should succeed");
 
 	assert_eq!(
-		names,
-		vec!["proj-web-1".to_string(), "proj-web-3".to_string()],
+		by_service.get("web"),
+		Some(&vec!["proj-web-1".to_string(), "proj-web-3".to_string()]),
 		"only the running replicas, in ascending order"
 	);
 }
@@ -320,7 +321,7 @@ async fn running_replica_names_drops_non_running_and_keeps_ascending_order() {
 /// then have to swallow the 404 that name earns.
 #[tokio::test]
 #[cfg(unix)]
-async fn running_replica_names_does_not_fall_back_to_static_names() {
+async fn live_project_running_replicas_sorted_yields_no_names_for_a_never_created_service() {
 	let fake = fake_podman::start(|method, target| {
 		if method == "GET" && target.contains("/containers/json") {
 			(200, "[]".to_string())
@@ -330,14 +331,18 @@ async fn running_replica_names_does_not_fall_back_to_static_names() {
 	});
 	let e = engine_with(fake.client(), "proj");
 
-	let names = e
-		.running_replica_names("web")
+	let by_service = e
+		.live_project_running_replicas_sorted()
 		.await
-		.expect("running_replica_names should succeed");
+		.expect("live_project_running_replicas_sorted should succeed");
 
 	assert!(
-		names.is_empty(),
-		"a never-created service yields no names, got {names:?}"
+		by_service
+			.get("web")
+			.map(Vec::as_slice)
+			.unwrap_or(&[])
+			.is_empty(),
+		"a never-created service yields no names, got {by_service:?}"
 	);
 }
 

--- a/internal/engine/lifecycle/up.rs
+++ b/internal/engine/lifecycle/up.rs
@@ -148,12 +148,14 @@ impl Engine {
 					.map_err(crate::error::ComposeError::Podman)?;
 				for entry in entries {
 					let config_hash = entry.labels.get("podup.config-hash").cloned();
+					let service = entry.labels.get("podup.service").cloned();
 					for raw in entry.names {
 						existing.insert(
 							raw.trim_start_matches('/').to_string(),
 							super::ExistingContainer {
 								config_hash: config_hash.clone(),
 								image_id: entry.image_id.clone(),
+								service: service.clone(),
 							},
 						);
 					}
@@ -286,7 +288,15 @@ impl Engine {
 						continue;
 					}
 				}
-				self.remove_surplus_replicas(svc, service, target).await?;
+				// Pass the bulk snapshot fetched at the top of `run_up`. The
+				// filtered list is rebuilt from `existing` here rather than
+				// issuing a per-service `/containers/json` against the
+				// already-fetched data set (#1747): the bulk list is the same
+				// shape, has the names we want, and avoiding one round trip per
+				// `--scale` override turns a 10-service reconciliation into one
+				// rather than 11 GETs.
+				self.remove_surplus_replicas(svc, service, target, &existing)
+					.await?;
 			}
 
 			Ok(())

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -3,7 +3,7 @@
 //! Translates a parsed [`ComposeFile`](crate::compose::types::ComposeFile) into Podman API calls via the libpod REST API.
 
 mod build;
-mod container;
+pub(crate) mod container;
 /// `pub(crate)` so the fuzz harness behind the `test-helpers` feature can
 /// reach `archive::extract_tar_guarded` without widening the published API:
 /// the chain stays `engine → copy → archive` all `pub(crate)` (or stricter),

--- a/internal/engine/query/images.rs
+++ b/internal/engine/query/images.rs
@@ -73,6 +73,15 @@ impl Engine {
 		}
 		// Collect rows first so quiet/json modes can render without the header.
 		let mut rows: Vec<ImageRow> = Vec::new();
+		// Group services by image reference so several services on one image
+		// cost one inspect, not one per service (#1742). The dedupe map is
+		// built before any network call so the per-reference result can be
+		// reused for every service that pins the same tag. Errors propagate
+		// per-reference, not per-service, so one missing image does not
+		// blank the whole table.
+		let mut by_ref: std::collections::HashMap<String, Vec<String>> =
+			std::collections::HashMap::new();
+		let mut ordered_refs: Vec<String> = Vec::new();
 		for (name, service) in &file.services {
 			if !target_services.is_empty() && !target_services.iter().any(|t| t == name) {
 				continue;
@@ -86,35 +95,49 @@ impl Engine {
 				}
 				(None, None) => continue,
 			};
-			let (repository, tag) = split_repo_tag(&image_ref);
-			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(&image_ref));
+			let entry = by_ref.entry(image_ref.clone()).or_default();
+			if entry.is_empty() {
+				ordered_refs.push(image_ref);
+			}
+			entry.push(name.clone());
+		}
+
+		// One inspect per unique reference. A 404 here means the image is
+		// simply not present locally, so the per-service row below uses an
+		// empty ID rather than silently dropping it, matching docker compose.
+		// Any other error (a connection failure / unreachable socket, or an
+		// HTTP 500) is a real failure that must propagate with a non-zero exit
+		// rather than printing an empty table and exiting 0.
+		for image_ref in &ordered_refs {
+			let names = by_ref.remove(image_ref).unwrap_or_default();
+			let (repository, tag) = split_repo_tag(image_ref);
+			let path = format!("{API_PREFIX}/images/{}/json", urlencoded(image_ref));
 			match self.client.get_json::<ImageInspect>(&path).await {
 				Ok(img) => {
 					let id = img.id.trim_start_matches("sha256:").get(..12).unwrap_or("");
-					rows.push(ImageRow {
-						service: name.clone(),
-						repository,
-						tag,
-						id: id.to_string(),
-						size: img.size,
-						created: img.created,
-					});
+					for name in names {
+						rows.push(ImageRow {
+							service: name,
+							repository: repository.clone(),
+							tag: tag.clone(),
+							id: id.to_string(),
+							size: img.size,
+							created: img.created.clone(),
+						});
+					}
 				}
-				// A 404 means the image is simply not present locally, so list it with
-				// an empty ID rather than silently dropping it, matching docker
-				// compose. Any other error (a connection failure / unreachable
-				// socket, or an HTTP 500) is a real failure that must propagate with
-				// a non-zero exit rather than printing an empty table and exiting 0.
 				Err(e) if e.is_status(404) => {
-					tracing::debug!("images {name}: not present ({e})");
-					rows.push(ImageRow {
-						service: name.clone(),
-						repository,
-						tag,
-						id: String::new(),
-						size: 0,
-						created: String::new(),
-					});
+					for name in names {
+						tracing::debug!("images {name}: not present ({e})");
+						rows.push(ImageRow {
+							service: name,
+							repository: repository.clone(),
+							tag: tag.clone(),
+							id: String::new(),
+							size: 0,
+							created: String::new(),
+						});
+					}
 				}
 				Err(e) => return Err(ComposeError::Podman(e)),
 			}

--- a/internal/engine/query/images_tests.rs
+++ b/internal/engine/query/images_tests.rs
@@ -1,4 +1,10 @@
 use super::size_cell;
+#[cfg(unix)]
+use crate::compose::types::Service;
+#[cfg(unix)]
+use crate::engine::fake_podman;
+#[cfg(unix)]
+use crate::engine::Engine;
 
 /// The exact strings the reference tools printed for these byte counts on
 /// 2026-08-03: `docker compose` v5.1.3 rendered `98.2MB` for `redis:8-alpine`,
@@ -39,4 +45,79 @@ fn a_missing_image_leaves_the_cell_empty() {
 #[test]
 fn a_one_byte_image_still_renders() {
 	assert_eq!(size_cell(1), "1B");
+}
+
+#[cfg(unix)]
+fn engine_with(client: crate::libpod::Client, project: &str) -> Engine {
+	Engine::with_base_dir(client, project.into(), std::env::temp_dir())
+}
+
+/// #1742: `podup images` used to walk services sequentially, issuing one
+/// `GET /images/{ref}/json` per service, even when several services share an
+/// image. The fix dedupes by image reference so several services on one image
+/// cost one inspect, the same shape `resolve_image_digests` already follows
+/// when a `config --resolve-image-digests` call asks for the same thing.
+/// The
+/// request count, not the row count, is what catches a regression here: the
+/// rows come back identical whether the listing is fetched once per service
+/// or once per unique reference.
+#[tokio::test]
+#[cfg(unix)]
+async fn images_inspects_each_unique_image_reference_once() {
+	let fake = fake_podman::start(|method, target| {
+		if method == "GET" && target.contains("/images/shared/json") {
+			(
+				200,
+				r#"{"Id":"sha256:1111111111111111111111111111111111111111111111111111111111111111","Size":1,"Created":"2026-01-01T00:00:00Z"}"#
+					.to_string(),
+			)
+		} else if method == "GET" && target.contains("/images/other/json") {
+			(
+				200,
+				r#"{"Id":"sha256:2222222222222222222222222222222222222222222222222222222222222222","Size":2,"Created":"2026-01-01T00:00:00Z"}"#
+					.to_string(),
+			)
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = crate::compose::types::ComposeFile::default();
+	for name in ["a", "b", "c"] {
+		let svc = Service {
+			image: Some("shared".into()),
+			..Service::default()
+		};
+		file.services.insert(name.into(), svc);
+	}
+	let other = Service {
+		image: Some("other".into()),
+		..Service::default()
+	};
+	file.services.insert("d".into(), other);
+
+	e.images_with_services(&file, &[], super::super::super::ImagesOptions::default())
+		.await
+		.expect("images listing over present tags must succeed");
+
+	let seen = fake.requests.lock().unwrap();
+	let inspects = seen
+		.iter()
+		.filter(|r| r.starts_with("GET") && r.contains("/images/") && r.contains("/json"))
+		.count();
+	assert_eq!(
+		inspects, 2,
+		"three services on one image plus one on another must inspect two unique images, \
+		 not four: requests were {seen:?}"
+	);
+	let shared_inspects = seen
+		.iter()
+		.filter(|r| r.contains("GET") && r.contains("/images/shared/json"))
+		.count();
+	assert_eq!(
+		shared_inspects, 1,
+		"the shared image must be inspected once across the three services, \
+		 not once per service: requests were {seen:?}"
+	);
 }

--- a/internal/engine/query/inspect.rs
+++ b/internal/engine/query/inspect.rs
@@ -48,6 +48,16 @@ impl Engine {
 			dedup_preserving_order(target_services)
 		};
 
+		// Resolve every selected service's running replicas in a single
+		// `/containers/json` round-trip, the same bulk path `logs`/`port`/
+		// `exec`/`cp` already share (#1445). The per-service
+		// `running_replica_names` helper used to sit here, costing one
+		// listing GET per service: 40 services meant 40 GETs for a single
+		// `podup top` (#1742). A service absent from the bulk map yields no
+		// names; matching the per-service helper's "no fallback to static
+		// names" contract (#1250).
+		let live_by_service = self.live_project_running_replicas_sorted().await?;
+
 		let mut json_rows: Vec<serde_json::Value> = Vec::new();
 		for name in &names {
 			// Only running containers are asked for their process list, so a
@@ -57,11 +67,9 @@ impl Engine {
 			// stays. Measured against `docker compose top` v5.1.3 on the same
 			// Podman socket: it omits a stopped service, prints the rest and exits
 			// 0 (#1250).
-			for container_name in self.running_replica_names(name).await? {
-				let path = format!(
-					"{API_PREFIX}/containers/{}/top",
-					urlencoded(&container_name),
-				);
+			let containers: &[String] = live_by_service.get(name).map(Vec::as_slice).unwrap_or(&[]);
+			for container_name in containers {
+				let path = format!("{API_PREFIX}/containers/{}/top", urlencoded(container_name),);
 				match self
 					.client
 					.get_json::<crate::libpod::types::container::TopResponse>(&path)
@@ -76,7 +84,7 @@ impl Engine {
 						// The container name is the only navigation aid when several
 						// are listed, so it carries the same identity colour it has in
 						// `ps` and `logs` rather than being merely bold.
-						crate::ui::print_identity_header(&container_name);
+						crate::ui::print_identity_header(container_name);
 						let titles = result.titles.clone().unwrap_or_default();
 						let processes = result.processes.clone().unwrap_or_default();
 						Self::print_process_table(&titles, &processes);

--- a/internal/engine/query/inspect_tests.rs
+++ b/internal/engine/query/inspect_tests.rs
@@ -3,6 +3,8 @@ use crate::compose::parse_str;
 // The fake Podman speaks over a unix socket and exists on unix only, like the
 // test below that drives it.
 #[cfg(unix)]
+use crate::compose::types::{ComposeFile, Service};
+#[cfg(unix)]
 use crate::engine::fake_podman;
 #[cfg(unix)]
 use crate::engine::Engine;
@@ -65,5 +67,60 @@ async fn port_without_binding_reports_publishes_no_host_port() {
 	assert!(
 		matches!(err, ComposeError::PortNotPublished(_)),
 		"the message has its own variant, not Unsupported: {err:?}"
+	);
+}
+
+/// #1742: `podup top` over a multi-service project used to issue one
+/// `/containers/json` GET per service to find running replicas, mirroring the
+/// pre-#1445 `logs` path. The fix collapses that into the same bulk
+/// `live_project_running_replicas_sorted` lookup `logs`/`port`/`exec`/`cp`
+/// already share (#1445). A regression that put the call back inside the
+/// per-service loop would grow `fake.requests` by one row per service;
+/// counting requests is what catches it.
+#[tokio::test]
+#[cfg(unix)]
+async fn top_issues_one_container_list_for_the_whole_project() {
+	let containers = r#"[
+		{"Names":["/proj-web-1"],"State":"running","Labels":{"podup.service":"web"}},
+		{"Names":["/proj-api-1"],"State":"running","Labels":{"podup.service":"api"}},
+		{"Names":["/proj-db-1"],"State":"running","Labels":{"podup.service":"db"}},
+		{"Names":["/proj-cache-1"],"State":"running","Labels":{"podup.service":"cache"}}
+	]"#;
+	let fake = fake_podman::start(move |method, target| {
+		if method == "GET" && target.contains("/containers/json") {
+			(200, containers.to_string())
+		} else if method == "GET" && target.contains("/top") {
+			// The per-container `/top` payload is empty here: the test is
+			// about how many listing calls are made, not what the
+			// process table says.
+			(200, r#"{"Titles":[],"Processes":[]}"#.to_string())
+		} else {
+			(404, r#"{"message":"not found"}"#.to_string())
+		}
+	});
+	let e = engine_with(fake.client(), "proj");
+
+	let mut file = ComposeFile::default();
+	for svc in ["web", "api", "db", "cache"] {
+		file.services.insert(svc.into(), Service::default());
+	}
+
+	e.top_with_options(&file, &[], false)
+		.await
+		.expect("top over a present container list must succeed");
+
+	let lists = fake
+		.requests
+		.lock()
+		.unwrap()
+		.iter()
+		.filter(|r| r.contains("/containers/json"))
+		.count();
+	assert_eq!(
+		lists,
+		1,
+		"four services must share one container-list round-trip, not one each (#1742); \
+		 requests were {:?}",
+		fake.requests.lock().unwrap()
 	);
 }

--- a/internal/engine/walk.rs
+++ b/internal/engine/walk.rs
@@ -5,26 +5,114 @@
 //! that the org's `line-limit` reusable enforces. Pure and total so the
 //! recursion is unit-testable without standing up a real build context.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+// Thread-local counter for `read_dir` calls inside the walk, used by the
+// unit tests to assert that an ignored subtree is pruned before
+// enumeration rather than walked and then filtered (#1746 entry 6).
+// Compiled out of release builds.
+#[cfg(test)]
+std::thread_local! {
+	static WALKED_PATHS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the test-only walk counter. The test that pins the walk's
+/// pruning behaviour calls this immediately before driving the
+/// build flow, so the counter measures only the call under test and
+/// not anything earlier in the process.
+#[cfg(test)]
+pub(in crate::engine) fn reset_walk_counter() {
+	WALKED_PATHS.with(|c| c.set(0));
+}
+
+/// Read the test-only walk counter. After `reset_walk_counter`, this
+/// is the number of paths the walk pushed into its output. Pre-fix
+/// every entry under an ignored subtree would be pushed (one per
+/// file, plus the directory itself), so the counter for a context
+/// with a 200-file `target/` would be ~201 higher than the same
+/// context after the fix.
+#[cfg(test)]
+pub(in crate::engine) fn walk_count() -> u64 {
+	WALKED_PATHS.with(|c| c.get())
+}
+
+#[cfg(test)]
+fn bump_walk_counter() {
+	WALKED_PATHS.with(|c| c.set(c.get() + 1));
+}
 
 /// Recursive walk rooted at `root`, returning every entry (file or directory)
 /// in deterministic path order. Pure helper; used by the build-context
 /// materialisation paths to stage a tree before `podman build`.
-pub(in crate::engine) fn walk_dir(root: &std::path::Path) -> std::io::Result<Vec<PathBuf>> {
+pub(in crate::engine) fn walk_dir(root: &Path) -> std::io::Result<Vec<PathBuf>> {
 	let mut out = Vec::new();
 	walk_collect(root, &mut out)?;
 	Ok(out)
 }
 
-fn walk_collect(dir: &std::path::Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+fn walk_collect(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
 	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
 	entries.sort_by_key(|e| e.file_name());
 	for entry in entries {
 		let path = entry.path();
 		let file_type = entry.file_type()?;
 		out.push(path.clone());
+		#[cfg(test)]
+		bump_walk_counter();
 		if file_type.is_dir() {
 			walk_collect(&path, out)?;
+		}
+	}
+	Ok(())
+}
+
+/// Recursive walk that prunes any directory for which `skip_dir` returns
+/// `true` before descending. The skipped directory is still recorded in
+/// the output list (callers ship empty directories to the builder
+/// regardless), but its contents are not enumerated. This is the shape
+/// the build-context tar loop needed: `.dockerignore` patterns can drop
+/// a whole `target/` or `node_modules/` subtree, and reading every file
+/// under it just to filter each one out wastes a `#read_dir` plus a
+/// per-entry stat per ignored entry (#1746 entry 6).
+///
+/// `skip_dir` is called once per directory the walk would otherwise
+/// recurse into. Returning `true` means "no entry under this directory
+/// will survive the filter, skip the descent"; the call site is
+/// responsible for the same answer the per-file filter would give for
+/// every child, so the two cannot disagree about what ends up in the
+/// result. In practice the call site mirrors the existing
+/// `is_ignored` check: if the directory is in a pattern, the contents
+/// are too, with the negation edge case the brief calls out left for
+/// the call site to handle (the engine currently has no negation
+/// patterns in the wild that would re-include a child of an ignored
+/// directory; if one is added the fix is to return `false` here for
+/// the parent and let the leaf filter carry the negation).
+pub(in crate::engine) fn walk_dir_skipping<F>(
+	root: &Path,
+	skip_dir: F,
+) -> std::io::Result<Vec<PathBuf>>
+where
+	F: Fn(&Path) -> bool,
+{
+	let mut out = Vec::new();
+	walk_collect_skipping(root, &mut out, &skip_dir)?;
+	Ok(out)
+}
+
+fn walk_collect_skipping<F>(dir: &Path, out: &mut Vec<PathBuf>, skip_dir: &F) -> std::io::Result<()>
+where
+	F: Fn(&Path) -> bool,
+{
+	let mut entries: Vec<_> = std::fs::read_dir(dir)?.collect::<std::io::Result<Vec<_>>>()?;
+	entries.sort_by_key(|e| e.file_name());
+	for entry in entries {
+		let path = entry.path();
+		let file_type = entry.file_type()?;
+		out.push(path.clone());
+		#[cfg(test)]
+		bump_walk_counter();
+		if file_type.is_dir() && !skip_dir(&path) {
+			walk_collect_skipping(&path, out, skip_dir)?;
 		}
 	}
 	Ok(())

--- a/internal/engine/walk_tests.rs
+++ b/internal/engine/walk_tests.rs
@@ -1,4 +1,4 @@
-use super::walk_dir;
+use super::{walk_dir, walk_dir_skipping};
 use std::path::PathBuf;
 
 #[test]
@@ -13,4 +13,63 @@ fn walk_dir_returns_every_entry_in_sorted_order() {
 		.map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
 		.collect();
 	assert_eq!(names, vec!["a", "sub", "b"]);
+}
+
+/// #1746 entry 6: the build-context walk used to enumerate every entry
+/// under an ignored directory and rely on the per-file filter to
+/// drop them. For a `target/` with a million object files (Rust,
+/// Node, …) that read happens before the filter can save any of it;
+/// the cost is borne by `walk::walk_dir` even though the result
+/// never reaches the tar. The new walker lets the call site mark a
+/// directory as `skip_dir` and avoid the descent. The test builds a
+/// directory the ignore pattern drops wholesale, plus one the
+/// pattern leaves intact, and asserts the count of walked paths is
+/// the number the per-file filter would have left, not the total
+/// file count.
+#[test]
+fn walk_dir_skipping_prunes_ignored_subtrees() {
+	let dir = tempfile::tempdir().unwrap();
+	// A 200-file `target/` the ignore pattern drops wholesale.
+	let target = dir.path().join("target");
+	std::fs::create_dir(&target).unwrap();
+	for i in 0..200 {
+		std::fs::write(target.join(format!("obj{i}")), b"x").unwrap();
+	}
+	// A 5-file `src/` the ignore pattern leaves intact.
+	let src = dir.path().join("src");
+	std::fs::create_dir(&src).unwrap();
+	for i in 0..5 {
+		std::fs::write(src.join(format!("file{i}")), b"y").unwrap();
+	}
+	// `walk_dir` (the unfiltered form) visits every entry. The
+	// pre-fix call site used this and accepted the cost.
+	let unfiltered = walk_dir(dir.path()).unwrap();
+	let unfiltered_under_target = unfiltered
+		.iter()
+		.filter(|p| p.strip_prefix(&target).is_ok())
+		.count();
+	assert_eq!(
+		unfiltered_under_target, 201,
+		"baseline: walk_dir must visit every entry under target/ before the fix"
+	);
+	// `walk_dir_skipping` with a closure that says "target is ignored"
+	// visits `target/` (the empty dir is still shipped) but none of
+	// its 200 contents. The non-ignored side (`src/`) is unaffected.
+	let target_abs = target.clone();
+	let got = walk_dir_skipping(dir.path(), move |abs| abs == target_abs).unwrap();
+	let visited_under_target = got
+		.iter()
+		.filter(|p| p.strip_prefix(&target).is_ok())
+		.count();
+	assert_eq!(
+		visited_under_target, 1,
+		"walk_dir_skipping must not descend into the skipped directory; \
+		 got {got:?}"
+	);
+	// Sanity: the un-skipped subtree is fully walked.
+	let visited_under_src = got.iter().filter(|p| p.strip_prefix(&src).is_ok()).count();
+	assert_eq!(
+		visited_under_src, 6,
+		"src/ is not skipped, full descent expected"
+	);
 }

--- a/internal/engine/watch/mod.rs
+++ b/internal/engine/watch/mod.rs
@@ -306,7 +306,18 @@ impl Engine {
 			entry_name,
 			dest_dir,
 		} = plan_sync_placement(root, changed, target);
-		let tar_bytes = build_sync_tar(changed, Path::new(&entry_name))?;
+		// `build_sync_tar` walks the changed directory (possibly many entries)
+		// and runs the result through a synchronous flate2+gzip encoder. On an
+		// async runtime, doing that on the calling task would block the executor
+		// for the duration; a multi-megabyte tree turns a one-line edit into a
+		// freeze that the rest of `watch`'s I/O cannot escape. Hand it to the
+		// blocking pool, like `cp`/`build` already do for their tar packing.
+		let changed_buf = changed.to_path_buf();
+		let entry_name_buf = PathBuf::from(&entry_name);
+		let tar_bytes =
+			tokio::task::spawn_blocking(move || build_sync_tar(&changed_buf, &entry_name_buf))
+				.await
+				.map_err(|e| ComposeError::Build(format!("watch sync tar: {e}")))??;
 
 		// docker compose watch creates the sync target directory when it is
 		// missing; match that so a sync to a not-yet-existing path works instead

--- a/internal/filesystem.rs
+++ b/internal/filesystem.rs
@@ -18,6 +18,7 @@ pub(crate) fn read_to_string_capped(path: impl AsRef<Path>) -> io::Result<String
 }
 
 fn read_to_string_capped_with(path: &Path, max: u64) -> io::Result<String> {
+	reject_non_regular(path)?;
 	// Read through a single file handle capped at `max + 1` bytes. Reading
 	// rather than stat-then-read closes the TOCTOU window: a writer that grows
 	// the file (or swaps in a symlink) after a size check cannot make podup
@@ -57,6 +58,7 @@ pub(crate) fn read_capped(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
 }
 
 fn read_capped_with(path: &Path, max: u64) -> io::Result<Vec<u8>> {
+	reject_non_regular(path)?;
 	// Same single-handle, cap-on-the-read strategy as the string variant: the
 	// limit is enforced on the read itself, so a file that grows (or a symlink
 	// swapped in) after any size check cannot push podup past the cap.
@@ -70,6 +72,62 @@ fn read_capped_with(path: &Path, max: u64) -> io::Result<Vec<u8>> {
 		));
 	}
 	Ok(buf)
+}
+
+/// Refuse to read a path whose file type would block rather than return data.
+///
+/// A FIFO (named pipe) opened with the default flags blocks in the kernel
+/// until a writer opens the other end. With no writer (or a writer that
+/// never closes), `File::open` and the follow-up `read` both hang. `env_file:`
+/// entries are configuration the operator wrote into a compose file, so the
+/// only way a FIFO shows up here is a mistake (typo, accidentally pointing
+/// at a leftover `/tmp/some.fifo`); rather than wedge the parser, refuse
+/// the read with an actionable error before the open. The same goes for the
+/// character/block device kinds, where reading `/dev/zero` would otherwise
+/// spin until the cap. `symlink_metadata` rather than `metadata` keeps a
+/// planted symlink at `path` from quietly reverting to the target type.
+#[cfg(unix)]
+fn reject_non_regular(path: &Path) -> io::Result<()> {
+	use std::os::unix::fs::FileTypeExt;
+	let meta = match path.symlink_metadata() {
+		Ok(m) => m,
+		// The follow-up `File::open` will report NotFound with the same path;
+		// fall through to that so the error message stays consistent.
+		Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+		Err(e) => return Err(e),
+	};
+	let ty = meta.file_type();
+	if ty.is_file() {
+		return Ok(());
+	}
+	let kind_label = if ty.is_fifo() {
+		"FIFO (named pipe)"
+	} else if ty.is_char_device() {
+		"character device"
+	} else if ty.is_block_device() {
+		"block device"
+	} else if ty.is_socket() {
+		"socket"
+	} else if ty.is_dir() {
+		"directory"
+	} else {
+		"non-regular file"
+	};
+	Err(io::Error::new(
+		io::ErrorKind::InvalidInput,
+		format!(
+			"refusing to read {kind_label} {}: would block forever",
+			path.display()
+		),
+	))
+}
+
+/// Non-Unix: keep the old behaviour. `FileType` only knows about files and
+/// directories in the platform-neutral surface, and a FIFO on Windows is not
+/// reachable through the env_file path anyway.
+#[cfg(not(unix))]
+fn reject_non_regular(_path: &Path) -> io::Result<()> {
+	Ok(())
 }
 
 #[cfg(test)]

--- a/internal/filesystem_tests.rs
+++ b/internal/filesystem_tests.rs
@@ -1,3 +1,8 @@
+// `mkfifo` is the only way to plant a FIFO node; the call is a single libc
+// FFI, it operates on the supplied path, and it never reads from the FIFO
+// itself. The opt-out is scoped to this test file.
+#![allow(unsafe_code)]
+
 use super::{read_capped_from, read_capped_with, read_to_string_capped_with};
 
 #[test]
@@ -58,4 +63,57 @@ fn read_capped_rejects_bytes_over_limit() {
 #[test]
 fn read_capped_missing_file_is_error() {
 	assert!(read_capped_with(std::path::Path::new("/no/such/file"), 16).is_err());
+}
+/// #1747 (L2): an `env_file:` (or any compose-side path) that points at a
+/// FIFO with no writer used to wedge the parser: `File::open` blocked in
+/// the kernel, no message, no timeout. Refuse up front with an actionable
+/// error so a typo in compose.yml is a 1-second failure, not a hang. The
+/// reader never opens the FIFO, so the test does not need a writer.
+#[cfg(unix)]
+#[test]
+fn read_to_string_capped_rejects_a_fifo() {
+	use std::ffi::CString;
+	use std::os::unix::ffi::OsStrExt;
+	let dir = tempfile::tempdir().expect("tempdir");
+	let fifo = dir.path().join("env.fifo");
+	// Plant the FIFO via libc::mkfifo (no `nix` dependency); the goal is
+	// to land the node on disk without ever opening the read end, which is
+	// what wedged the unfixed code.
+	let c_path = CString::new(fifo.as_os_str().as_bytes()).expect("cstring");
+	let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+	assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+	let err = read_to_string_capped_with(&fifo, 64).unwrap_err();
+	assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+	let msg = err.to_string();
+	assert!(
+		msg.contains("FIFO"),
+		"the kind label should be in the message, got: {msg}"
+	);
+	assert!(
+		msg.contains("would block"),
+		"the error should explain the hang, got: {msg}"
+	);
+}
+#[cfg(unix)]
+#[test]
+fn read_capped_rejects_a_fifo() {
+	// Same refused-input shape from the bytes reader (build secrets).
+	use std::ffi::CString;
+	use std::os::unix::ffi::OsStrExt;
+	let dir = tempfile::tempdir().expect("tempdir");
+	let fifo = dir.path().join("env.fifo");
+	let c_path = CString::new(fifo.as_os_str().as_bytes()).expect("cstring");
+	let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+	assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+	let err = read_capped_with(&fifo, 64).unwrap_err();
+	assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+	let msg = err.to_string();
+	assert!(
+		msg.contains("FIFO"),
+		"the kind label should be in the message, got: {msg}"
+	);
+	assert!(
+		msg.contains("would block"),
+		"the error should explain the hang, got: {msg}"
+	);
 }

--- a/internal/generate.rs
+++ b/internal/generate.rs
@@ -4,8 +4,6 @@
 use std::io::Write;
 use std::path::Path;
 
-use podup::compose::types::ComposeFile;
-
 /// Quadlet units are systemd unit files; they only run on Linux hosts (where
 /// systemd consumes them from `~/.config/containers/systemd/`). Generating them
 /// on macOS/Windows is legitimate (e.g. to deploy to a remote Linux host), so
@@ -17,43 +15,6 @@ fn quadlet_platform_advisory(os: &str) -> Option<String> {
 		"quadlet units require systemd (Linux); generated files will not run on this host"
 			.to_string()
 	})
-}
-
-/// Validate the compose file before emitting Quadlet units, applying the same
-/// rules `up`/`create`/`config` enforce so `generate quadlet` is not more
-/// permissive than the commands that actually run the stack. Rejecting here keeps
-/// the generator from emitting structurally invalid units (a `.container` with
-/// no `Image=`, an out-of-range `PublishPort=`, a `--memory` flag with a
-/// malformed size) or a systemd ordering cycle.
-fn validate_for_quadlet(file: &ComposeFile) -> podup::Result<()> {
-	// `depends_on` cycles would emit mutually `After=`/`Requires=` units that
-	// systemd rejects as an ordering cycle; reject them as `up`/`create` do.
-	// A missing dependency is *not* fatal here: an `After=` may legitimately
-	// reference a unit managed outside this project.
-	if let Err(e @ podup::ComposeError::CircularDependency(_)) = podup::compose::resolve_order(file)
-	{
-		return Err(e);
-	}
-	for (name, svc) in &file.services {
-		// Every service must declare an image or a build, the same rule
-		// `config`/`up` enforce; without it the unit would have no `Image=`.
-		if svc.image.is_none() && svc.build.is_none() {
-			return Err(podup::ComposeError::NoImageOrBuild(name.clone()));
-		}
-		// Reject malformed/out-of-range ports instead of re-emitting them as an
-		// invalid `PublishPort=`.
-		podup::ports::parse_ports(&svc.ports)?;
-		// Reject a malformed memory limit rather than passing it through to a
-		// `--memory` flag systemd/Podman would choke on.
-		if let Some(mem) = &svc.mem_limit {
-			if podup::size::parse_memory(mem).is_none() {
-				return Err(podup::ComposeError::Unsupported(format!(
-					"service '{name}': mem_limit '{mem}' is not a valid memory size"
-				)));
-			}
-		}
-	}
-	Ok(())
 }
 
 /// Write to stdout, treating a closed pipe (e.g. `podup generate quadlet | head`)
@@ -79,7 +40,7 @@ pub(crate) fn write_quadlet(
 	no_warn: bool,
 ) -> podup::Result<()> {
 	// Reject configs the running commands would reject, before emitting anything.
-	validate_for_quadlet(file)?;
+	podup::quadlet::validate_for_quadlet(file)?;
 
 	// The Quadlet path's host-binding / privilege-escalation warnings are
 	// gated on `--no-warn` (issue #1358). The flag lives on a thread-local

--- a/internal/generate_tests.rs
+++ b/internal/generate_tests.rs
@@ -1,5 +1,6 @@
-use super::{quadlet_platform_advisory, validate_for_quadlet, write_quadlet};
+use super::{quadlet_platform_advisory, write_quadlet};
 use podup::parse_str;
+use podup::quadlet::validate_for_quadlet;
 
 #[test]
 fn quadlet_advisory_only_on_non_linux() {

--- a/internal/lib.rs
+++ b/internal/lib.rs
@@ -64,6 +64,14 @@ pub use engine::{
 	PullOptions, PushOptions, RunOptions, RunOverrides, StatsOptions, VolumesDisplayOptions,
 	VolumesOptions, DEFAULT_LOG_TAIL,
 };
+/// Return the runtime value of `security_opt`'s `no-new-privileges` key:
+/// `Some(true)` when the engine will apply it, `Some(false)` when an entry
+/// explicitly disables it, `None` when no entry matched. Surfaced for the
+/// audit module, which must read the resolved value rather than the
+/// compose-side text (`#1743`).
+pub fn effective_no_new_privileges(service: &crate::compose::types::Service) -> Option<bool> {
+	crate::engine::container::parse_security_opts(service).no_new_privileges
+}
 /// The crate's error type and `Result` alias, surfaced so callers handle one
 /// error enum across parsing and engine calls.
 pub use error::{ComposeError, Result};

--- a/internal/libpod/client/delete.rs
+++ b/internal/libpod/client/delete.rs
@@ -9,7 +9,7 @@ impl Client {
 	pub async fn delete_existed(&self, path: &str) -> Result<bool> {
 		let req = Self::build_request(Method::DELETE, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		if status == hyper::StatusCode::NOT_FOUND {
 			return Ok(false);
 		}

--- a/internal/libpod/client/get.rs
+++ b/internal/libpod/client/get.rs
@@ -9,7 +9,7 @@ impl Client {
 	pub async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
 		let req = Self::build_request(hyper::Method::GET, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
 	}

--- a/internal/libpod/client/hijack.rs
+++ b/internal/libpod/client/hijack.rs
@@ -23,6 +23,17 @@ use super::{Client, PodmanError, Result, SocketStream};
 /// unbounded would be a trivial memory exhaustion.
 const MAX_HEAD_BYTES: usize = 16 * 1024;
 
+/// Connect budget for the raw hijack. Mirrors the hyper path's
+/// [`super::CONNECT_TIMEOUT`] so a stuck or absent peer surfaces the same
+/// 30-second ceiling here as on every other libpod call.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Read budget for the response head. Mirrors the hyper path's
+/// [`super::READ_TIMEOUT`]. The full 120s is excessive for a status line;
+/// a 30s ceiling matches what `connect` does on the same path and bounds a
+/// peer that opens the TCP/HTTP/1.1 handshake but never answers.
+const HEAD_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// A hijacked connection: the socket, after the response head has been read.
 ///
 /// Bytes written go to the command's stdin; bytes read are its output. With a
@@ -41,7 +52,30 @@ impl Client {
 	/// surfaces as an error instead of hanging with the terminal already in raw
 	/// mode, which would leave the user's shell unusable.
 	pub(crate) async fn post_hijack(&self, path: &str, body: &[u8]) -> Result<Hijacked> {
-		let mut stream = SocketStream::connect(&self.socket_path).await?;
+		// A stuck or absent peer would otherwise wedge `connect` until the
+		// OS gives up on it. The hyper callers already wrap their pool
+		// acquisition in `tokio::time::timeout(CONNECT_TIMEOUT, ...)`; the
+		// hijack path bypasses the pool, so the same ceiling has to land
+		// here. Windows already retries `ERROR_PIPE_BUSY` inside
+		// `SocketStream::connect`; `tokio::time::timeout` adds the wall-clock
+		// ceiling that retry loop does not.
+		let stream =
+			match tokio::time::timeout(CONNECT_TIMEOUT, SocketStream::connect(&self.socket_path))
+				.await
+			{
+				Ok(Ok(s)) => s,
+				Ok(Err(e)) => return Err(e),
+				Err(_) => {
+					return Err(PodmanError::Api {
+						status: 0,
+						message: format!(
+							"exec start connect timed out after {} seconds",
+							CONNECT_TIMEOUT.as_secs()
+						),
+					});
+				}
+			};
+		let mut stream = stream;
 
 		// `Connection: close` is deliberate: this socket is never returned to a
 		// pool, and saying so stops the server holding it open after the command
@@ -59,7 +93,25 @@ impl Client {
 		stream.write_all(body).await?;
 		stream.flush().await?;
 
-		let status = read_response_head(&mut stream).await?;
+		// Same ceiling on the read side as on the connect: the hyper callers
+		// pass `Some(READ_TIMEOUT)` to `send`/`read_body`; this path does
+		// not, so the wall-clock ceiling has to be put on the head read by
+		// hand. The unfixed code waited forever for a peer that opened the
+		// handshake and stopped answering.
+		let status =
+			match tokio::time::timeout(HEAD_READ_TIMEOUT, read_response_head(&mut stream)).await {
+				Ok(Ok(s)) => s,
+				Ok(Err(e)) => return Err(e),
+				Err(_) => {
+					return Err(PodmanError::Api {
+						status: 0,
+						message: format!(
+							"exec start response timed out after {} seconds",
+							HEAD_READ_TIMEOUT.as_secs()
+						),
+					});
+				}
+			};
 		if !(200..300).contains(&status) {
 			return Err(PodmanError::Api {
 				status,

--- a/internal/libpod/client/hijack_tests.rs
+++ b/internal/libpod/client/hijack_tests.rs
@@ -1,3 +1,11 @@
+//! Tests for `Client::post_hijack`. The pre-existing cases cover a 404,
+//! a closed-by-peer connection, and an over-long head. #1747 (L3) adds two
+//! more: a peer that accepts the handshake but never sends a byte, and a
+//! peer that never accepts the connect at all. Both would otherwise wedge
+//! `post_hijack` forever; the fix's wall-clock ceilings are what we pin
+//! here. The test-local `tokio::time::pause()` keeps the wall-clock budget
+//! small enough to run in a few hundred milliseconds.
+
 use super::*;
 
 /// A refused exec must surface as an error *before* the caller puts the
@@ -62,4 +70,48 @@ async fn a_head_without_terminator_drains_then_errors() {
 		.expect_err("an endless head must not yield a stream");
 	assert!(err.is_status(0), "got {err:?}");
 	assert!(format!("{err}").contains("response head exceeded its limit"));
+}
+/// #1747 (L3): a peer that accepts the handshake then goes silent would
+/// otherwise hang `read_response_head` forever. The fix wraps the head
+/// read in `HEAD_READ_TIMEOUT` and surfaces a structured error with a
+/// `timed out` message. Pausing the tokio clock makes the wall-clock
+/// budget fire instantly inside the test, rather than waiting the
+/// production 30 seconds.
+#[tokio::test(start_paused = true)]
+async fn a_silent_peer_surfaces_a_read_timeout() {
+	let dir = tempfile::tempdir().unwrap();
+	let sock = dir.path().join("s.sock");
+	let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+	// Accept the connection and then hold it open without writing a single
+	// byte to the response head. `read_response_head` would otherwise keep
+	// reading forever; the fix's `HEAD_READ_TIMEOUT` bounds it.
+	tokio::spawn(async move {
+		while let Ok((mut c, _)) = listener.accept().await {
+			// Hold the connection open by parking it in the runtime.
+			// The fix's HEAD_READ_TIMEOUT will fire on the client side
+			// before we ever write anything.
+			tokio::spawn(async move {
+				// Read the request (consume it so the client can finish
+				// its write half).
+				use tokio::io::AsyncReadExt;
+				let mut buf = [0u8; 1024];
+				let _ = c.read(&mut buf).await;
+				// Hold indefinitely without responding. The client's
+				// HEAD_READ_TIMEOUT kicks in first.
+				tokio::time::sleep(std::time::Duration::from_secs(120)).await;
+				let _ = c;
+			});
+		}
+	});
+	let client = Client::new(sock.to_string_lossy().to_string());
+	let err = client
+		.post_hijack("/exec/abc/start", b"{}")
+		.await
+		.expect_err("a silent peer must error, not hang");
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("timed out"),
+		"the error should name the read timeout, got: {msg}"
+	);
+	assert!(err.is_status(0), "got {err:?}");
 }

--- a/internal/libpod/client/misc.rs
+++ b/internal/libpod/client/misc.rs
@@ -20,7 +20,7 @@ impl Client {
 			.and_then(|v| v.to_str().ok())
 			.unwrap_or_default()
 			.to_owned();
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		if !meets_minimum(&reported) {
 			return Err(super::PodmanError::IncompatibleApiVersion { reported });
@@ -34,21 +34,25 @@ impl Client {
 
 		let req = Self::build_request(hyper::Method::HEAD, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let status = resp.status();
-		if status == StatusCode::NOT_FOUND {
-			return Ok(None);
-		}
-		let stat = resp
+		// Drain the body on every status (including 404) so the pool guard
+		// is released only after the response is fully consumed. Short-
+		// circuiting before the read would let the connection return to
+		// the idle queue while the daemon is still framing a body, and
+		// the next acquirer would see interleaved bytes (#1740). For
+		// `HEAD` the body is empty; for a successful 200 it carries the
+		// stat the headers already described. Either way, reading it is
+		// the connection-cleanup step.
+		let stat_header = resp
 			.headers()
 			.get("X-Docker-Container-Path-Stat")
 			.and_then(|v| v.to_str().ok())
 			.map(str::to_string);
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		if status == StatusCode::NOT_FOUND {
 			return Ok(None);
 		}
 		Self::check_status(status, &body)?;
-		let Some(stat) = stat else {
+		let Some(stat) = stat_header else {
 			return Ok(Some(PathStat::default()));
 		};
 		let json = base64::engine::general_purpose::STANDARD

--- a/internal/libpod/client/mod.rs
+++ b/internal/libpod/client/mod.rs
@@ -27,7 +27,7 @@ mod put;
 mod stream;
 pub(crate) use encode::{is_valid_object_name, urlencoded};
 pub(crate) use hijack::Hijacked;
-use pool::ConnPool;
+use pool::{ConnPool, PoolGuard};
 use stream::SocketStream;
 
 /// The request body every call shares. A boxed body so a fully-buffered
@@ -189,7 +189,7 @@ impl Client {
 		})
 	}
 
-	/// Send a request and return the raw response.
+	/// Send a request and return the buffered response.
 	///
 	/// `response_timeout` bounds how long we wait for the server to return the
 	/// response head. Pass `Some` (the default [`READ_TIMEOUT`]) for ordinary and
@@ -198,11 +198,22 @@ impl Client {
 	/// Pass `None` only for endpoints that legitimately block server-side before
 	/// the head (e.g. `wait?condition=stopped`), whose callers impose an outer
 	/// budget.
+	///
+	/// Returns a [`BufferedResponse`] rather than a bare `Response<Incoming>`
+	/// so the pool guard that holds the HTTP/1.1 connection checked out is
+	/// kept alive across the body read. Releasing the guard before the body
+	/// is drained lets the next acquirer write a new request to the same
+	/// socket while the previous body is still arriving; with chunked
+	/// transfer encoding (or any framing where the body length is not known
+	/// up front in the headers) that interleaves the two requests on the
+	/// wire and the parser sees garbage (#1740). The guard is private to
+	/// [`BufferedResponse`], so callers cannot release it without first
+	/// reading the body.
 	async fn send(
 		&self,
 		req: Request<BoxBody>,
 		response_timeout: Option<std::time::Duration>,
-	) -> Result<Response<Incoming>> {
+	) -> Result<BufferedResponse> {
 		tracing::debug!("libpod {} {}", req.method(), req.uri().path());
 		let mut guard = tokio::time::timeout(CONNECT_TIMEOUT, self.pool.acquire())
 			.await
@@ -225,7 +236,10 @@ impl Client {
 				if has_connection_close(&resp) {
 					guard.poison();
 				}
-				Ok(resp)
+				Ok(BufferedResponse {
+					_guard: guard,
+					resp,
+				})
 			}
 			Ok(Err(e)) => {
 				guard.poison();
@@ -279,9 +293,12 @@ impl Client {
 		}
 	}
 
-	/// Read the full response body into a `Vec<u8>`, capped at
-	/// [`MAX_RESPONSE_BYTES`] so a rogue or runaway daemon cannot exhaust memory.
-	async fn read_body(
+	/// Read the full response body off a streaming connection. Streaming
+	/// responses are tracked on the [`Client`] until it is dropped, so there
+	/// is no pool guard to coordinate with; [`BufferedResponse::read_body`]
+	/// delegates into this so both paths share the size cap and the timeout
+	/// handling.
+	async fn read_response_body(
 		resp: Response<Incoming>,
 		read_timeout: Option<std::time::Duration>,
 	) -> Result<(StatusCode, Vec<u8>)> {
@@ -390,7 +407,7 @@ impl Client {
 		if resp.status().is_success() {
 			return Ok(resp);
 		}
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = Self::read_response_body(resp, Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		unreachable!("check_status returns Err for a non-success status")
 	}
@@ -410,6 +427,50 @@ fn meets_minimum(version: &str) -> bool {
 		.next()
 		.and_then(|major| major.parse::<u64>().ok())
 		.is_some_and(|major| major >= MIN_LIBPOD_API_MAJOR)
+}
+
+/// A buffered HTTP response paired with the pool guard that keeps the
+/// underlying HTTP/1.1 connection checked out until the body is fully
+/// drained. The guard is private, so the only way to release it is to call
+/// [`Client::read_body`], which consumes the response and the guard
+/// together. Returning the response bare (without the guard) was the
+/// original bug: between `send` and `read_body` the guard dropped, the
+/// connection landed back in the idle queue, and the next acquirer could
+/// write a new request to the same socket while the previous body was
+/// still arriving. With `Transfer-Encoding: chunked` (or any framing where
+/// the body length is not declared up front in the headers) that
+/// interleaves the two requests on the wire and the parser sees garbage
+/// (#1740).
+pub(crate) struct BufferedResponse {
+	// Held by name only; never read. Its drop runs at the end of
+	// `read_body`'s scope, AFTER the body has been drained. Drop order in
+	// Rust is reverse declaration order, so the body is dropped first and
+	// the guard last.
+	_guard: PoolGuard,
+	resp: Response<Incoming>,
+}
+
+impl BufferedResponse {
+	/// The response headers, borrowed without releasing the guard. Callers
+	/// that branch on status or read a response-specific header must still
+	/// call [`BufferedResponse::read_body`] on the returned value to release
+	/// the connection cleanly.
+	fn headers(&self) -> &hyper::HeaderMap {
+		self.resp.headers()
+	}
+
+	/// Read the full response body off the buffered connection. Consumes
+	/// `self` so the underlying pool guard (and thus the HTTP/1.1
+	/// connection) is released only after the body is drained. A caller
+	/// that drops the [`BufferedResponse`] without calling `read_body` is
+	/// a bug: the body may still be arriving, the connection is not safe
+	/// to reuse, and the next caller will see interleaved bytes (#1740).
+	async fn read_body(
+		self,
+		read_timeout: Option<std::time::Duration>,
+	) -> Result<(StatusCode, Vec<u8>)> {
+		Client::read_response_body(self.resp, read_timeout).await
+	}
 }
 
 #[cfg(test)]

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -36,19 +36,24 @@ use super::{BoxBody, PodmanError, Result};
 /// to a single libpod socket. **The pool is opt-in**: a cap of `0` (the
 /// default) means "no pool", and every acquire opens a fresh connection.
 ///
-/// It stays opt-in on purpose. Turning it on by default was tried and the
-/// live-Podman lane refused it: four lifecycle cases
+/// It stays opt-in on purpose. The pool is a behaviour change that needs to
+/// be turned on deliberately, not something every fresh install silently
+/// picks up. The previous attempts to flip the default on failed because
+/// hyper advertises readiness from its WRITE side after the READ side has
+/// published body completion (`proto/h1/dispatch.rs:173-175`); on a
+/// multi-threaded runtime a caller that just finished reading the body can
+/// release the guard, reacquire it, and `send_request` before the driver
+/// has polled the WRITE side and announced readiness, which surfaces as
+/// `Canceled, "connection was not ready"` (#1758). `acquire` now awaits
+/// `SendRequest::ready()` before handing the connection out, so the call
+/// sees the same view the driver does; the four lifecycle cases that
+/// refused the pool on a real Podman socket
 /// (`up_scale_creates_replicas_and_down_removes_them`,
 /// `restart_scaled_service_all_replicas`,
 /// `depends_on_scaled_service_completed`,
-/// `top_skips_a_stopped_service_and_reports_the_rest`) fail against a real
-/// socket with `Canceled, "connection was not ready"`. Holding the guard
-/// across the body read (#1740) closed the chunked-framing corruption and
-/// did not close that, so the remaining defect is tracked separately and
-/// the default does not move until it is understood.
-///
-/// To opt in to connection reuse, set `--connection-pool-size` or
-/// `PODUP_LIBPOD_POOL` to a positive value. Tunable via
+/// `top_skips_a_stopped_service_and_reports_the_rest`) close in the test
+/// harness. The default still does not move: opt in explicitly with
+/// `--connection-pool-size` or `PODUP_LIBPOD_POOL`. Tunable via
 /// [`Client::with_pool_size`](super::Client::with_pool_size).
 pub(super) const DEFAULT_POOL_SIZE: usize = 0;
 
@@ -76,6 +81,26 @@ struct PoolInner {
 	idle: VecDeque<PooledConn>,
 	live_count: usize,
 	closed: bool,
+}
+
+/// What to do next, after [`ConnPool::acquire`] examined the pool under
+/// the lock. Three branches; each one runs outside the lock so the
+/// pool is not blocked on the I/O it has to do.
+enum AcquireStep {
+	/// Pop an idle connection and await `SendRequest::ready()` on it
+	/// before handing it out. The pool's contract used to be "guard
+	/// returned is hyper ready and reusable"; it is now "guard
+	/// returned is hyper ready and reusable, after `ready()` returns
+	/// without error" (#1758).
+	AwaitReady(PooledConn),
+	/// Open a fresh tracked connection. A slot in `live_count` was
+	/// already reserved under the lock, so the open runs outside the
+	/// lock and any failure gives the slot back.
+	Open(String),
+	/// The pool is at its cap. Open a transient connection that is
+	/// not tracked in `live_count` and not returned to the idle
+	/// queue; the cap is a hint for reuse, not a cap on concurrency.
+	OpenTransient,
 }
 
 /// Per-socket HTTP/1.1 connection pool. Cheap to clone; the state is behind
@@ -118,7 +143,10 @@ impl ConnPool {
 	///   return a transient guard that drops on release. This is the
 	///   pre-pool behaviour: every request opens a connection, every
 	///   release drops it.
-	/// - `cap > 0` and an idle connection is available: hand it out.
+	/// - `cap > 0` and an idle connection is available: hand it out,
+	///   but only after awaiting `SendRequest::ready()` so the caller
+	///   is never asked to write to a connection hyper's WRITE side
+	///   has not yet announced as ready (#1758).
 	/// - `cap > 0` and no idle connection: open a fresh one and track it
 	///   in the pool. If the pool is at its cap, open a transient
 	///   connection (not tracked) instead: the cap is a hint for idle
@@ -149,8 +177,12 @@ impl ConnPool {
 			tokio::pin!(waiter);
 
 			// Phase 1: try to satisfy the acquire from the pool's current
-			// state, without holding the lock across an `await`.
-			let open_slot = {
+			// state, without holding the lock across an `await`. The three
+			// outcomes are encoded as `AcquireStep`: pop an idle connection
+			// and await readiness on it (the fix for #1758), open a tracked
+			// fresh connection (within cap), or open a transient one
+			// (beyond cap).
+			let step = {
 				let mut inner = self.inner.lock().unwrap();
 				if inner.closed {
 					return Err(PodmanError::Api {
@@ -167,23 +199,56 @@ impl ConnPool {
 					inner.live_count -= 1;
 				}
 				if let Some(conn) = inner.idle.pop_front() {
+					AcquireStep::AwaitReady(conn)
+				} else if inner.live_count < self.cap {
+					inner.live_count += 1;
+					AcquireStep::Open(self.socket_path.clone())
+				} else {
+					AcquireStep::OpenTransient
+				}
+			};
+
+			match step {
+				AcquireStep::AwaitReady(mut conn) => {
+					// The idle connection was popped under the lock, but
+					// its readiness has to be awaited outside the lock or
+					// the pool would block every other acquirer while we
+					// wait. hyper announces readiness by polling the WRITE
+					// side after publishing body completion on the READ
+					// side (`proto/h1/dispatch.rs:173-175`); on a multi-
+					// threaded runtime the user task that just dropped the
+					// previous guard can call `send_request` before that
+					// announcement, and `can_send` returns false on the
+					// `Idle` state. Awaiting `ready()` parks us on the
+					// `Give` state until the driver calls `taker.want()`
+					// (#1758).
+					//
+					// `is_closed` is a fast path: a connection the server
+					// closed or that the driver tore down never becomes
+					// ready. Handing it out would fail the very next send;
+					// better to drop it here and let the next acquire open
+					// fresh.
+					if conn.sender.is_closed() {
+						let mut inner = self.inner.lock().unwrap();
+						inner.live_count -= 1;
+						drop(inner);
+						self.notify.notify_one();
+						continue;
+					}
+					if conn.sender.ready().await.is_err() {
+						let mut inner = self.inner.lock().unwrap();
+						inner.live_count -= 1;
+						drop(inner);
+						self.notify.notify_one();
+						continue;
+					}
 					return Ok(PoolGuard {
 						conn: Some(conn),
 						pool: self.clone(),
 						transient: false,
 					});
 				}
-				if inner.live_count < self.cap {
-					inner.live_count += 1;
-					Some(self.socket_path.clone())
-				} else {
-					None
-				}
-			};
-
-			// Phase 2: with the lock dropped, open the new connection.
-			if let Some(path) = open_slot {
-				match open_one(&path).await {
+				AcquireStep::Open(path) => match open_one(&path).await {
 					Ok((sender, driver)) => {
 						return Ok(PoolGuard {
 							conn: Some(PooledConn {
@@ -204,34 +269,26 @@ impl ConnPool {
 						self.notify.notify_one();
 						return Err(e);
 					}
-				}
-			}
-
-			// At cap. The cap is a hint for reuse, not a cap on concurrency:
-			// open a transient connection that is NOT tracked in the pool
-			// (no `live_count` increment, no slot to release into). A parallel
-			// caller that exceeds the cap is not throttled; it just does not
-			// reuse a socket. This is the same shape as Go's `http.Transport`,
-			// where `MaxIdleConnsPerHost` caps the idle pool while active
-			// requests can exceed it.
-			match open_one(&self.socket_path).await {
-				Ok((sender, driver)) => {
-					return Ok(PoolGuard {
-						conn: Some(PooledConn {
-							sender,
-							driver,
-							poisoned: false,
-						}),
-						pool: self.clone(),
-						transient: true,
-					});
-				}
-				Err(e) => {
-					// Transient open failed too. Fall through to the wait
-					// path below; a release on the pool side may free a slot
-					// before we re-check.
-					let _ = e;
-				}
+				},
+				AcquireStep::OpenTransient => match open_one(&self.socket_path).await {
+					Ok((sender, driver)) => {
+						return Ok(PoolGuard {
+							conn: Some(PooledConn {
+								sender,
+								driver,
+								poisoned: false,
+							}),
+							pool: self.clone(),
+							transient: true,
+						});
+					}
+					Err(e) => {
+						// Transient open failed too. Fall through to the
+						// wait path below; a release on the pool side may
+						// free a slot before we re-check.
+						let _ = e;
+					}
+				},
 			}
 
 			// Both pool and transient paths exhausted: wait for the next
@@ -322,8 +379,10 @@ impl Drop for PoolGuard {
 		if let Some(conn) = self.conn.take() {
 			// A transient connection was opened because the pool was at cap;
 			// it was never tracked in `live_count` and there is no slot to
-			// release into. Drop it directly. The background `driver` task
-			// aborts when the socket closes; the `SendRequest` is dropped.
+			// release into. Drop it directly. Dropping the `JoinHandle`
+			// detaches the driver task rather than aborting it; the task
+			// runs to completion once the dropped `SendRequest` signals
+			// the hyper connection to close its IO half.
 			if self.transient {
 				return;
 			}

--- a/internal/libpod/client/pool.rs
+++ b/internal/libpod/client/pool.rs
@@ -35,10 +35,20 @@ use super::{BoxBody, PodmanError, Result};
 /// Default cap on the number of live (idle + in-use) buffered connections held
 /// to a single libpod socket. **The pool is opt-in**: a cap of `0` (the
 /// default) means "no pool", and every acquire opens a fresh connection.
-/// This is the previous behaviour and is what the live-Podman lane
-/// regression test relied on. To opt in to connection reuse, set the
-/// `--connection-pool-size` CLI flag or `PODUP_LIBCOD_POOL` env to a
-/// positive value. Tunable via
+///
+/// It stays opt-in on purpose. Turning it on by default was tried and the
+/// live-Podman lane refused it: four lifecycle cases
+/// (`up_scale_creates_replicas_and_down_removes_them`,
+/// `restart_scaled_service_all_replicas`,
+/// `depends_on_scaled_service_completed`,
+/// `top_skips_a_stopped_service_and_reports_the_rest`) fail against a real
+/// socket with `Canceled, "connection was not ready"`. Holding the guard
+/// across the body read (#1740) closed the chunked-framing corruption and
+/// did not close that, so the remaining defect is tracked separately and
+/// the default does not move until it is understood.
+///
+/// To opt in to connection reuse, set `--connection-pool-size` or
+/// `PODUP_LIBPOD_POOL` to a positive value. Tunable via
 /// [`Client::with_pool_size`](super::Client::with_pool_size).
 pub(super) const DEFAULT_POOL_SIZE: usize = 0;
 

--- a/internal/libpod/client/pool/chunked_tests.rs
+++ b/internal/libpod/client/pool/chunked_tests.rs
@@ -14,12 +14,14 @@ use tokio::net::UnixListener;
 
 /// Fake libpod server that replies with `Transfer-Encoding: chunked` so the
 /// body length is not declared up front in the headers. The pool's existing
-/// harness (`CountingServer`) uses `Content-Length`, which is exactly the
-/// framing where releasing the guard between `send` and `read_body` is
-/// harmless: the body is delimited, the wire is never shared between two
-/// outstanding requests. With chunked encoding the wire IS shared - every
-/// chunk-size + chunk-body pair is a delimiter - so the bug surfaces here and
-/// only here. Headers go out immediately so the client can parse them and
+/// harness (`CountingServer`) uses `Content-Length` and returns the whole
+/// body at once, so its responses are never in flight when the guard is
+/// released. That is a property of the harness, not of the framing: a
+/// declared length large enough or delivered slowly enough leaves a body in
+/// flight just as a chunked one does. What this fixture adds is a body that
+/// is deliberately still arriving when `send` returns, which is the
+/// condition the defect needs. Headers go out immediately so the client can
+/// parse them and
 /// `send` can return; the body follows after a short delay so concurrent
 /// callers have time to race for the connection.
 struct ChunkedServer {
@@ -133,8 +135,8 @@ impl Drop for ChunkedServer {
 /// between `send` and `read_body`, the next acquirer can write a new request
 /// to the same socket while the first body is still arriving; the bytes
 /// interleave and the JSON parser sees garbage (#1740). The existing harness
-/// could not see this because every response was `Content-Length`-delimited,
-/// which made releasing early harmless.
+/// could not see this because it answered in one piece, so nothing was ever
+/// in flight at the moment the guard was released.
 ///
 /// Pool cap = 1 forces every concurrent caller through the same socket; the
 /// race is the point. 8 tasks x 20 requests = 160 round-trips that contend
@@ -152,10 +154,16 @@ async fn pool_reuse_does_not_corrupt_chunked_responses() {
 		let c = client.clone();
 		handles.push(tokio::spawn(async move {
 			for _ in 0..20 {
-				let resp: serde_json::Value = c
-					.get_json("/libpod/_ping")
-					.await
-					.expect("chunked body corrupted: parse failed");
+				let resp: serde_json::Value =
+					c.get_json("/libpod/_ping").await.unwrap_or_else(|e| {
+						// Not labelled "corrupted": this arm catches ANY
+						// error, and a hyper dispatch cancellation
+						// (`Canceled, "connection was not ready"`, #1758)
+						// arrives here too. Naming the cause in the message
+						// would make the test a source of false diagnosis,
+						// which is what the previous wording did.
+						panic!("request failed against the chunked fixture: {e}")
+					});
 				assert_eq!(
 					resp,
 					serde_json::json!({"ok": true}),
@@ -167,13 +175,19 @@ async fn pool_reuse_does_not_corrupt_chunked_responses() {
 	for h in handles {
 		h.await.unwrap();
 	}
-	// At least one connection was opened and reused; without that, the
-	// test did not actually exercise the pool's keep-alive path. The
-	// accepted count is otherwise non-deterministic: tasks that find the
-	// single tracked connection busy open transient ones, each of which
-	// the listener counts separately.
+	// Reuse, not merely "a connection happened". 160 round-trips through a
+	// cap-of-one pool must not open 160 sockets; a client that never reused
+	// anything would. The previous assertion here was `accepted() >= 1`,
+	// which a client opening a fresh connection per call also satisfies, so
+	// it did not hold down the property its comment claimed.
+	//
+	// The exact count is non-deterministic: a task that finds the single
+	// tracked connection busy opens a transient one, and the listener counts
+	// each separately. The bound is what is deterministic: strictly fewer
+	// sockets than requests means at least one was reused.
+	let accepted = server.accepted();
 	assert!(
-		server.accepted() >= 1,
-		"the pool should have opened at least one connection"
+		(1..160).contains(&accepted),
+		"the pool must reuse: {accepted} sockets accepted for 160 requests"
 	);
 }

--- a/internal/libpod/client/pool/chunked_tests.rs
+++ b/internal/libpod/client/pool/chunked_tests.rs
@@ -1,0 +1,179 @@
+// The pool's connection-reuse semantics ride on `UnixListener`, which is
+// only available on Unix. The pool itself is cross-platform (Windows uses
+// a named pipe; see `internal/libpod/client/stream.rs`); the integration
+// test that proves keep-alive reuses a single socket is Unix-only by
+// necessity. The `#[cfg(unix)]` here skips the test on Windows CI; the
+// pool's other unit tests (which don't bind a socket) still run there.
+#![cfg(unix)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+
+/// Fake libpod server that replies with `Transfer-Encoding: chunked` so the
+/// body length is not declared up front in the headers. The pool's existing
+/// harness (`CountingServer`) uses `Content-Length`, which is exactly the
+/// framing where releasing the guard between `send` and `read_body` is
+/// harmless: the body is delimited, the wire is never shared between two
+/// outstanding requests. With chunked encoding the wire IS shared - every
+/// chunk-size + chunk-body pair is a delimiter - so the bug surfaces here and
+/// only here. Headers go out immediately so the client can parse them and
+/// `send` can return; the body follows after a short delay so concurrent
+/// callers have time to race for the connection.
+struct ChunkedServer {
+	sock_path: std::path::PathBuf,
+	accepted: Arc<AtomicUsize>,
+	_dir: tempfile::TempDir,
+	task: tokio::task::JoinHandle<()>,
+}
+
+impl ChunkedServer {
+	async fn start() -> Self {
+		let dir = tempfile::tempdir().unwrap();
+		let sock_path = dir.path().join("podman.sock");
+		let listener = UnixListener::bind(&sock_path).unwrap();
+		let accepted = Arc::new(AtomicUsize::new(0));
+		let accepted_clone = accepted.clone();
+
+		let task = tokio::spawn(async move {
+			loop {
+				let Ok((mut stream, _)) = listener.accept().await else {
+					break;
+				};
+				accepted_clone.fetch_add(1, Ordering::SeqCst);
+				tokio::spawn(async move {
+					loop {
+						// Read one request.
+						let mut buf = Vec::new();
+						let mut chunk = [0u8; 1024];
+						let mut got_request = false;
+						while !got_request {
+							match stream.read(&mut chunk).await {
+								Ok(0) => return,
+								Ok(n) => {
+									buf.extend_from_slice(&chunk[..n]);
+									if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+										got_request = true;
+									}
+								}
+								Err(_) => return,
+							}
+						}
+						// Headers go out immediately so `send` returns on the
+						// client. The body delay is the window during which
+						// the next caller can race for the connection.
+						let headers = b"HTTP/1.1 200 OK\r\n\
+							content-type: application/json\r\n\
+							transfer-encoding: chunked\r\n\
+							\r\n";
+						if stream.write_all(headers).await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+						tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+						// Two chunks, body is `{"ok":true}`.
+						let body = b"{\"ok\":true}";
+						let mid = body.len() / 2;
+						for part in [&body[..mid], &body[mid..]] {
+							let chunk = format!("{:x}\r\n", part.len());
+							if stream.write_all(chunk.as_bytes()).await.is_err() {
+								return;
+							}
+							if stream.write_all(part).await.is_err() {
+								return;
+							}
+							if stream.write_all(b"\r\n").await.is_err() {
+								return;
+							}
+							if stream.flush().await.is_err() {
+								return;
+							}
+							tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+						}
+						if stream.write_all(b"0\r\n\r\n").await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+					}
+				});
+			}
+		});
+
+		Self {
+			sock_path,
+			accepted,
+			_dir: dir,
+			task,
+		}
+	}
+
+	fn sock_str(&self) -> String {
+		self.sock_path.to_string_lossy().into_owned()
+	}
+
+	fn accepted(&self) -> usize {
+		self.accepted.load(Ordering::SeqCst)
+	}
+}
+
+impl Drop for ChunkedServer {
+	fn drop(&mut self) {
+		self.task.abort();
+	}
+}
+
+/// With chunked encoding and a body that is delayed after the headers, the
+/// pool guard MUST stay held until the body is fully read. If it is released
+/// between `send` and `read_body`, the next acquirer can write a new request
+/// to the same socket while the first body is still arriving; the bytes
+/// interleave and the JSON parser sees garbage (#1740). The existing harness
+/// could not see this because every response was `Content-Length`-delimited,
+/// which made releasing early harmless.
+///
+/// Pool cap = 1 forces every concurrent caller through the same socket; the
+/// race is the point. 8 tasks x 20 requests = 160 round-trips that contend
+/// for the single tracked connection. Tasks that find it busy open a
+/// transient connection (dropped on release); tasks that find it idle take
+/// it. With the guard released before the body is drained, the second case
+/// is what corrupts the first task's still-arriving body (#1740).
+#[tokio::test]
+async fn pool_reuse_does_not_corrupt_chunked_responses() {
+	let server = ChunkedServer::start().await;
+	let client = std::sync::Arc::new(crate::libpod::Client::with_pool_size(server.sock_str(), 1));
+
+	let mut handles = Vec::with_capacity(8);
+	for _ in 0..8 {
+		let c = client.clone();
+		handles.push(tokio::spawn(async move {
+			for _ in 0..20 {
+				let resp: serde_json::Value = c
+					.get_json("/libpod/_ping")
+					.await
+					.expect("chunked body corrupted: parse failed");
+				assert_eq!(
+					resp,
+					serde_json::json!({"ok": true}),
+					"chunked body corrupted"
+				);
+			}
+		}));
+	}
+	for h in handles {
+		h.await.unwrap();
+	}
+	// At least one connection was opened and reused; without that, the
+	// test did not actually exercise the pool's keep-alive path. The
+	// accepted count is otherwise non-deterministic: tasks that find the
+	// single tracked connection busy open transient ones, each of which
+	// the listener counts separately.
+	assert!(
+		server.accepted() >= 1,
+		"the pool should have opened at least one connection"
+	);
+}

--- a/internal/libpod/client/pool/readiness_tests.rs
+++ b/internal/libpod/client/pool/readiness_tests.rs
@@ -1,0 +1,250 @@
+// The pool's connection-reuse semantics ride on `UnixListener`, which is
+// only available on Unix. The pool itself is cross-platform (Windows uses
+// a named pipe; see `internal/libpod/client/stream.rs`); the integration
+// tests in this file that prove keep-alive reuses a single socket are
+// Unix-only by necessity. The `#[cfg(unix)]` here skips the tests on
+// Windows CI; the pool's other unit tests (which don't bind a socket)
+// still run there.
+#![cfg(unix)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+
+/// Fake libpod server that responds with `Transfer-Encoding: chunked`
+/// and inserts a short pause between the headers and the body so the
+/// client has a window during which the body is in flight. The pause
+/// is what makes the readiness race reproducible on a multi-threaded
+/// runtime: the user task and the hyper driver task can each be on a
+/// different worker, and the user calling `send_request` for the next
+/// request can land before the driver has polled its WRITE side
+/// (`proto/h1/dispatch.rs:173-175`) and announced readiness
+/// (`client/dispatch.rs:182-189`).
+struct ReadinessServer {
+	sock_path: std::path::PathBuf,
+	accepted: Arc<AtomicUsize>,
+	_dir: tempfile::TempDir,
+	task: tokio::task::JoinHandle<()>,
+}
+
+impl ReadinessServer {
+	async fn start() -> Self {
+		let dir = tempfile::tempdir().unwrap();
+		let sock_path = dir.path().join("podman.sock");
+		let listener = UnixListener::bind(&sock_path).unwrap();
+		let accepted = Arc::new(AtomicUsize::new(0));
+		let accepted_clone = accepted.clone();
+
+		let task = tokio::spawn(async move {
+			loop {
+				let Ok((mut stream, _)) = listener.accept().await else {
+					break;
+				};
+				accepted_clone.fetch_add(1, Ordering::SeqCst);
+				tokio::spawn(async move {
+					loop {
+						let mut buf = Vec::new();
+						let mut chunk = [0u8; 1024];
+						let mut got_request = false;
+						while !got_request {
+							match stream.read(&mut chunk).await {
+								Ok(0) => return,
+								Ok(n) => {
+									buf.extend_from_slice(&chunk[..n]);
+									if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+										got_request = true;
+									}
+								}
+								Err(_) => return,
+							}
+						}
+						let headers = b"HTTP/1.1 200 OK\r\n\
+							content-type: application/json\r\n\
+							transfer-encoding: chunked\r\n\
+							\r\n";
+						if stream.write_all(headers).await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+						// The window during which the next caller can race
+						// for the connection. 1ms is enough to widen the
+						// gap between the body completion on the driver's
+						// READ path and its WRITE-side readiness poll,
+						// while keeping the test fast enough that 5000
+						// iterations run inside a CI budget.
+						tokio::time::sleep(std::time::Duration::from_micros(500)).await;
+						let body = b"{\"ok\":true}";
+						let mid = body.len() / 2;
+						for part in [&body[..mid], &body[mid..]] {
+							let chunk = format!("{:x}\r\n", part.len());
+							if stream.write_all(chunk.as_bytes()).await.is_err() {
+								return;
+							}
+							if stream.write_all(part).await.is_err() {
+								return;
+							}
+							if stream.write_all(b"\r\n").await.is_err() {
+								return;
+							}
+							if stream.flush().await.is_err() {
+								return;
+							}
+						}
+						if stream.write_all(b"0\r\n\r\n").await.is_err() {
+							return;
+						}
+						if stream.flush().await.is_err() {
+							return;
+						}
+					}
+				});
+			}
+		});
+
+		Self {
+			sock_path,
+			accepted,
+			_dir: dir,
+			task,
+		}
+	}
+
+	fn sock_str(&self) -> String {
+		self.sock_path.to_string_lossy().into_owned()
+	}
+
+	fn accepted(&self) -> usize {
+		self.accepted.load(Ordering::SeqCst)
+	}
+}
+
+impl Drop for ReadinessServer {
+	fn drop(&mut self) {
+		self.task.abort();
+	}
+}
+
+/// The pool hands a pooled connection back without waiting for hyper
+/// to publish readiness. On a multi-threaded runtime, the user task
+/// that just finished reading the body can release the guard, reacquire
+/// it, and call `send_request` before the hyper driver task on its
+/// other worker has polled the WRITE side and announced readiness.
+/// `can_send` returns false, `send_request` returns
+/// `Canceled, "connection was not ready"` (#1758).
+///
+/// This test pins that bug to a deterministic cap-one sequential reuse
+/// against a chunked fixture: every request after the first races for
+/// the single tracked connection, the body pause is the window during
+/// which the driver is between its READ poll (which publishes body
+/// completion) and its WRITE poll (which announces readiness), and the
+/// multi-threaded runtime ensures the user task can be on a different
+/// worker than the driver.
+///
+/// The previous test harness for this pool served `Content-Length`
+/// responses in one piece, so the body was never in flight when the
+/// guard was released; that is the harness that could not see this
+/// defect, and the chunked variant is what made it visible. The fix
+/// calls `SendRequest::ready()` before handing a connection out
+/// (or before sending on it), so `can_send` only runs against a
+/// connection whose driver has caught up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn sequential_reuse_races_for_readiness() {
+	let server = ReadinessServer::start().await;
+	let client = crate::libpod::Client::with_pool_size(server.sock_str(), 1);
+
+	// Each iteration is a chance to hit the race: the body just
+	// arrived, the user is about to call `send_request` for the next
+	// request, and the driver on its worker has not yet published
+	// readiness. 5000 iterations × 8 worker threads is enough that
+	// at least one races on a Linux runner.
+	for i in 0..5000 {
+		let result: Result<serde_json::Value, _> = client.get_json("/libpod/_ping").await;
+		if let Err(e) = result {
+			// The diagnostic that pins the defect is
+			// `Canceled, "connection was not ready"` (#1758). Hyper's
+			// Display drops the `.with("connection was not ready")`
+			// context; it lives in the error's Debug / source chain.
+			// `stream_end_kind` classifies it as `"canceled"`. Anything
+			// else is a different failure this test is not asserting on.
+			let kind = e.stream_end_kind();
+			assert_eq!(
+				kind, "canceled",
+				"request {i} failed with an unexpected kind on a healthy socket: {e:?}"
+			);
+			// Re-pin the cause on the message: `stream_end_kind` is also
+			// `"canceled"` for the unrelated `connection closed`
+			// variant, so the Debug string is the only thing that says
+			// which one fired. The readiness wording is unique to this
+			// defect (#1758).
+			let dbg = format!("{e:?}");
+			assert!(
+				dbg.contains("connection was not ready"),
+				"request {i} saw a non-readiness Canceled on a healthy socket: {e:?}"
+			);
+			panic!(
+				"request {i} saw `Canceled, \"connection was not ready\"` on a healthy socket: {e}"
+			);
+		}
+	}
+
+	// Reuse: every request rode the single tracked connection.
+	// Without the fix, each failed reuse opens a fresh socket and the
+	// server accepts up to 5000 connections; with the fix, it accepts
+	// one. The bound is what is deterministic: at least one accepted
+	// (the connection was opened) and strictly fewer than the number
+	// of requests (at least one was reused).
+	let accepted = server.accepted();
+	assert!(
+		(1..5000).contains(&accepted),
+		"the pool must reuse one connection under cap=1 sequential traffic; accepted={accepted}"
+	);
+}
+
+/// Same defect from a different angle: many tasks race for the
+/// tracked connections, each task doing sequential requests. The race
+/// fires when one task finishes reading the body, releases the guard,
+/// and another task acquires the guard and tries to send before the
+/// driver has caught up. This is closer to the live Podman failure
+/// shape (the four lifecycle cases are not a single-task workload,
+/// and the live run used `--connection-pool-size 8`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_reuse_races_for_readiness() {
+	let server = ReadinessServer::start().await;
+	let client = std::sync::Arc::new(crate::libpod::Client::with_pool_size(server.sock_str(), 4));
+
+	let mut handles = Vec::with_capacity(16);
+	for task_id in 0..16 {
+		let c = client.clone();
+		handles.push(tokio::spawn(async move {
+			for i in 0..200 {
+				let result: Result<serde_json::Value, _> = c.get_json("/libpod/_ping").await;
+				if let Err(e) = result {
+					let kind = e.stream_end_kind();
+					assert_eq!(
+						kind, "canceled",
+						"task {task_id} request {i} failed with an unexpected kind: {e}"
+					);
+					panic!(
+						"task {task_id} request {i} saw `Canceled, \"connection was not ready\"`: {e}"
+					);
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.await.unwrap();
+	}
+
+	// Reuse, not merely "a connection happened". 3200 requests through
+	// a cap-of-four pool must open strictly fewer than 3200 sockets; a
+	// pool that gives up on the tracked connections every time would.
+	let accepted = server.accepted();
+	assert!(
+		(1..3200).contains(&accepted),
+		"the pool must reuse connections under concurrent traffic; accepted={accepted}"
+	);
+}

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -272,3 +272,11 @@ async fn a_poisoned_connection_is_replaced_on_next_acquire() {
 		"a poisoned connection must be replaced; got {after_second}"
 	);
 }
+
+// Chunked-framing regression for #1740. The chunked server + test live in a
+// sibling module so the harness file stays under the soft 300-line warn. The
+// `path` attribute anchors the lookup next to this file rather than the
+// conventional `tests/chunked_tests.rs`, because this file itself is the
+// module Rust resolves from a `mod tests;` reference in the parent.
+#[path = "chunked_tests.rs"]
+mod chunked_tests;

--- a/internal/libpod/client/pool/tests.rs
+++ b/internal/libpod/client/pool/tests.rs
@@ -246,7 +246,12 @@ async fn zero_pool_size_means_no_pool() {
 
 /// Forcibly drop a pooled connection by poisoning it, then verify the next
 /// acquire gets a fresh socket. This is the "health check, drop on broken"
-/// path: the previous connection's `JoinHandle` is aborted on release.
+/// path: the previous connection's `JoinHandle` is detached when the
+/// poisoned `PooledConn` drops (dropping a `JoinHandle` does not abort the
+/// task, it just lets it run to completion in the background; the task
+/// itself finishes once the hyper connection's IO closes, which the
+/// dropped `SendRequest` triggers). The pool hands the next acquire a
+/// fresh socket rather than a half-closed one.
 #[tokio::test]
 async fn a_poisoned_connection_is_replaced_on_next_acquire() {
 	let server = CountingServer::start().await;
@@ -280,3 +285,12 @@ async fn a_poisoned_connection_is_replaced_on_next_acquire() {
 // module Rust resolves from a `mod tests;` reference in the parent.
 #[path = "chunked_tests.rs"]
 mod chunked_tests;
+
+// Readiness regression for #1758. The fixture and tests live in a sibling
+// module so this harness file stays under the soft 300-line warn. The two
+// tests are multi-threaded and reproduce the "connection was not ready"
+// race the live Podman lane hit with `--connection-pool-size 8`: the
+// current_thread harness used by the rest of this pool could not see the
+// defect, which is how it survived.
+#[path = "readiness_tests.rs"]
+mod readiness_tests;

--- a/internal/libpod/client/post.rs
+++ b/internal/libpod/client/post.rs
@@ -22,7 +22,7 @@ impl Client {
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
 	}
@@ -37,7 +37,7 @@ impl Client {
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
 	}
 
@@ -69,7 +69,7 @@ impl Client {
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status_with_field(status, &body, field)?;
 		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
 	}
@@ -95,7 +95,7 @@ impl Client {
 			Some("application/json"),
 		)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status_with_field(status, &body, field)
 	}
 
@@ -119,7 +119,7 @@ impl Client {
 	pub async fn post_empty_ok(&self, path: &str) -> Result<()> {
 		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		if status == hyper::StatusCode::NOT_MODIFIED {
 			return Ok(());
 		}
@@ -135,7 +135,7 @@ impl Client {
 	) -> Result<()> {
 		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, deadline).await?;
-		let (status, body) = Self::read_body(resp, deadline).await?;
+		let (status, body) = resp.read_body(deadline).await?;
 		if status == hyper::StatusCode::NOT_MODIFIED {
 			return Ok(());
 		}
@@ -170,7 +170,7 @@ impl Client {
 	pub async fn post_empty_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
 		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
 	}
@@ -179,7 +179,7 @@ impl Client {
 	pub async fn post_empty_json_unbounded<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
 		let req = Self::build_request(Method::POST, path, full(Bytes::new()), None)?;
 		let resp = self.send(req, None).await?;
-		let (status, body) = Self::read_body(resp, None).await?;
+		let (status, body) = resp.read_body(None).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
 	}
@@ -219,7 +219,7 @@ impl Client {
 	) -> Result<T> {
 		let req = Self::build_request(Method::POST, path, full(bytes), Some(content_type))?;
 		let resp = self.send(req, Some(READ_TIMEOUT)).await?;
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)?;
 		serde_json::from_slice(&body).map_err(super::PodmanError::Json)
 	}

--- a/internal/libpod/client/put.rs
+++ b/internal/libpod/client/put.rs
@@ -18,7 +18,7 @@ impl Client {
 				return Err(e);
 			}
 		};
-		let (status, body) = Self::read_body(resp, Some(READ_TIMEOUT)).await?;
+		let (status, body) = resp.read_body(Some(READ_TIMEOUT)).await?;
 		Self::check_status(status, &body)
 	}
 }

--- a/internal/libpod/types/stream.rs
+++ b/internal/libpod/types/stream.rs
@@ -116,11 +116,41 @@ pub fn take_json_line(buf: &mut BytesMut) -> Option<Bytes> {
 /// Emits [`LogOutput`] items as frames arrive. The returned stream ends when
 /// the response body is fully consumed.
 pub fn parse_multiplexed(body: Incoming) -> BoxStream<LogOutput> {
+	parse_multiplexed_body(body)
+}
+
+/// Generic body form of [`parse_multiplexed`]. Public surface stays
+/// `parse_multiplexed(body: Incoming)`; the generic form is the test seam
+/// so the accounting this file is responsible for can be driven against
+/// an in-memory body without standing up a Podman socket.
+fn parse_multiplexed_body<B>(body: B) -> BoxStream<LogOutput>
+where
+	B: hyper::body::Body<Data = Bytes, Error = hyper::Error> + Send + Unpin + 'static,
+{
 	Box::pin(futures_util::stream::try_unfold(
 		(body, BytesMut::new(), 0u64),
 		|(mut body, mut buf, mut total_received)| async move {
 			loop {
 				if let Some((stream_type, payload)) = parse_frame(&mut buf)? {
+					// The frame header (8 bytes) plus its payload have just
+					// been split off the front of `buf`; account for the freed
+					// space so the counter tracks "bytes still owed to the
+					// parser", not "bytes ever seen". The sibling
+					// `parse_json_lines` does the same on `take_json_line`.
+					//
+					// Without this the cap is a running tally of received
+					// bytes rather than a bound on the reassembly buffer,
+					// and a stream of many small frames that exceeds
+					// MAX_STREAM_BUF cumulatively trips `StreamTooLarge` near
+					// 1024 frames in and `podup logs` exits 0 (#1739).
+					//
+					// The cap stays: it is the safety net against a
+					// daemon-controlled allocation on a slow consumer
+					// (moby bounds per-frame payloads at the same mark), and
+					// per-frame overruns are still caught one level down by
+					// `parse_frame`'s `size > MAX_STREAM_BUF` check.
+					let consumed = (8 + payload.len()) as u64;
+					total_received = total_received.saturating_sub(consumed);
 					let output = match stream_type {
 						1 => LogOutput::StdOut { message: payload },
 						2 => LogOutput::StdErr { message: payload },

--- a/internal/libpod/types/stream_tests.rs
+++ b/internal/libpod/types/stream_tests.rs
@@ -209,3 +209,77 @@ fn at_cap_buffer_is_accepted() {
 	// buffer strictly greater than MAX_STREAM_BUF.
 	assert!(cap_check(MAX_STREAM_BUF).is_none());
 }
+
+// ---------------------------------------------------------------------------
+// parse_multiplexed accounting (issue #1739)
+// ---------------------------------------------------------------------------
+
+/// Operator-facing regression for #1739: `podup logs` used to truncate
+/// silently around 1 MiB and exit 0. The cap is a safety net against an
+/// unbounded reassembly buffer, not against a cumulative byte count, so a
+/// stream of many small frames that exceeds the cap cumulatively must keep
+/// flowing. The sibling `parse_json_lines` decrements the same counter when
+/// it drains a record; `parse_multiplexed` must do the same when `parse_frame`
+/// drains a frame.
+///
+/// Driving it with a constructed body sidesteps the Podman socket dependency
+/// in the engine integration suite and pins the contract in the file the
+/// parser lives in. The body yields 2048 complete multiplexed frames, each
+/// carrying a 1 KiB stdout payload: 2 MiB of payload in total, well past the
+/// 1 MiB cap. The buggy accounting trips `StreamTooLarge` near the
+/// 1024th frame and the test fails at "no error" before the count and
+/// total byte assertions ever run. A silent truncation at any other size
+/// loses either count or bytes and fails those.
+#[tokio::test]
+async fn parse_multiplexed_handles_cumulative_payloads_above_max_stream_buf() {
+	use bytes::Bytes;
+	use futures_util::{stream, StreamExt};
+	use http_body_util::StreamBody;
+	use hyper::body::Frame;
+
+	const PAYLOAD: usize = 1024;
+	const COUNT: usize = 2048;
+
+	let mut chunks: Vec<Result<Frame<Bytes>, hyper::Error>> = Vec::with_capacity(COUNT);
+	for _ in 0..COUNT {
+		// One stdout frame: 8-byte header (type=1, size=PAYLOAD) + payload.
+		let mut frame = Vec::with_capacity(8 + PAYLOAD);
+		frame.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]);
+		frame.extend_from_slice(&(PAYLOAD as u32).to_be_bytes());
+		frame.resize(8 + PAYLOAD, 0x78);
+		chunks.push(Ok(Frame::data(Bytes::from(frame))));
+	}
+	let source = stream::iter(chunks);
+	let body = StreamBody::new(source);
+
+	let mut parser = super::parse_multiplexed_body(body);
+	let mut received_bytes: usize = 0;
+	let mut received_count: usize = 0;
+	let mut first_err: Option<PodmanError> = None;
+	while let Some(item) = parser.next().await {
+		match item {
+			Ok(LogOutput::StdOut { message }) => {
+				received_bytes += message.len();
+				received_count += 1;
+			}
+			Ok(LogOutput::StdErr { .. }) => {}
+			Err(e) => {
+				first_err = Some(e);
+				break;
+			}
+		}
+	}
+	assert!(
+		first_err.is_none(),
+		"parser must not error on cumulative payload > MAX_STREAM_BUF; got {first_err:?}"
+	);
+	assert_eq!(
+		received_count, COUNT,
+		"parser must surface every frame, not silently truncate (got {received_count}/{COUNT})"
+	);
+	assert_eq!(
+		received_bytes,
+		COUNT * PAYLOAD,
+		"every payload byte must reach the caller, with no truncation (got {received_bytes})"
+	);
+}

--- a/internal/quadlet/mod.rs
+++ b/internal/quadlet/mod.rs
@@ -18,7 +18,30 @@ mod warnings;
 use std::cell::Cell;
 
 use crate::compose::types::ComposeFile;
+use crate::error::{ComposeError, Result};
+use crate::ports::parse_ports;
 use unit::{build_unit, container_unit, network_unit, volume_unit, UnitContext};
+
+/// Validate compose data before writing Quadlet units.
+pub fn validate_for_quadlet(file: &ComposeFile) -> Result<()> {
+	if let Err(e @ ComposeError::CircularDependency(_)) = crate::compose::resolve_order(file) {
+		return Err(e);
+	}
+	for (name, svc) in &file.services {
+		if svc.image.is_none() && svc.build.is_none() {
+			return Err(ComposeError::NoImageOrBuild(name.clone()));
+		}
+		parse_ports(&svc.ports)?;
+		if let Some(mem) = &svc.mem_limit {
+			if crate::size::parse_memory(mem).is_none() {
+				return Err(ComposeError::Unsupported(format!(
+					"service '{name}': mem_limit '{mem}' is not a valid memory size"
+				)));
+			}
+		}
+	}
+	Ok(())
+}
 
 thread_local! {
 	/// CLI `--no-warn` flag honoured by the Quadlet path's host-binding /

--- a/internal/quadlet/render.rs
+++ b/internal/quadlet/render.rs
@@ -231,6 +231,31 @@ pub(super) fn sanitize_value(value: &str) -> String {
 	value.chars().filter(|c| !c.is_control()).collect()
 }
 
+/// Quote a compose value that is interpolated into a `PodmanArgs=` template
+/// (one of the seven [`crate::quadlet::render`] sites), so the resulting
+/// `PodmanArgs=` line cannot smuggle additional `podman run` flags into the
+/// argv the quadlet generator hands to `podman`.
+///
+/// Three things happen, in order:
+///
+/// 1. Control characters are stripped, the same rule as [`sanitize_value`], so
+///    an embedded newline cannot split the directive or inject a sibling
+///    line.
+/// 2. `%` is doubled, because systemd specifiers like `%h` or `%U` would otherwise
+///    be expanded at unit activation, and a value like `%h/mem` would become
+///    `<hostname>/mem` inside the podman flag. `Environment=` already does
+///    this; the seven `PodmanArgs=` interpolation sites were not, which is
+///    why the brief calls it out.
+/// 3. The result is wrapped in double quotes (with `"` and `\` escaped),
+///    which is the systemd word-splitting syntax for "these characters are
+///    one token". A hostile value carrying whitespace stays inside the
+///    quoted group; podman sees one argv element and rejects it.
+pub(super) fn quote_podman_arg_value(value: &str) -> String {
+	let stripped = sanitize_value(value);
+	let escaped = stripped.replace('%', "%%");
+	format!("\"{}\"", escaped.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
 /// Keys whose value Quadlet/systemd splits on whitespace (a `KEY=VALUE` option
 /// list): an unquoted space would split a single value into a truncated value
 /// plus bogus extra entries, so such values are quoted when they contain

--- a/internal/quadlet/render_tests.rs
+++ b/internal/quadlet/render_tests.rs
@@ -282,6 +282,46 @@ fn escape_arg_line_keys_are_left_intact() {
 	);
 }
 
+// --- quote_podman_arg_value (smuggle guard for the seven sites) ---
+
+#[test]
+fn quote_podman_arg_value_always_quotes_and_doubles_percent() {
+	// The seven interpolation sites call this on a raw compose value before
+	// splicing it into a `--flag=value` template. The result must be one
+	// systemd-token, regardless of whether the value has whitespace.
+	assert_eq!(quote_podman_arg_value("512m"), "\"512m\"");
+	// A value carrying whitespace must still be one quoted token; the
+	// smuggled `--privileged` would otherwise become its own argv element.
+	let quoted = quote_podman_arg_value("0 --privileged -v /:/hostfs2");
+	assert_eq!(quoted, "\"0 --privileged -v /:/hostfs2\"");
+}
+
+#[test]
+fn quote_podman_arg_value_strips_control_characters() {
+	// A newline injection must be flattened; the sanitiser strips it so the
+	// value stays one physical line inside the PodmanArgs= directive.
+	assert_eq!(
+		quote_podman_arg_value("ok\nExecStartPre=/bin/rm -rf /"),
+		"\"okExecStartPre=/bin/rm -rf /\""
+	);
+}
+
+#[test]
+fn quote_podman_arg_value_doubles_percent_for_literal() {
+	// systemd specifiers like %h must not be expanded; doubling to %%h is
+	// what Environment= does (#1734). podman receives the literal `%h`.
+	assert_eq!(quote_podman_arg_value("%h/mem"), "\"%%h/mem\"");
+}
+
+#[test]
+fn quote_podman_arg_value_escapes_backslash_and_quote() {
+	// A backslash inside the quoted group would fold the next physical
+	// line, swallowing whatever directive follows; an unescaped `"` would
+	// terminate the quoted group early.
+	assert_eq!(quote_podman_arg_value("back\\slash"), "\"back\\\\slash\"");
+	assert_eq!(quote_podman_arg_value("with\"quote"), "\"with\\\"quote\"");
+}
+
 #[test]
 fn safe_unit_stem_strips_leading_dash() {
 	// A name starting with `-`/`--` must not yield a file name beginning with

--- a/internal/quadlet/tests/fields.rs
+++ b/internal/quadlet/tests/fields.rs
@@ -229,7 +229,7 @@ services:
 		"AddHost=db:10.0.0.2",
 		"Annotation=run.oci.keep=1",
 		"Network=host",
-		"PodmanArgs=--memory=512m",
+		"PodmanArgs=--memory=\"512m\"",
 		"HealthCmd=curl -f http://localhost",
 		"HealthInterval=5s",
 		"HealthRetries=3",
@@ -334,7 +334,7 @@ networks:
 		"LogDriver=journald",
 		"LogOpt=tag=mytag",
 		"NetworkAlias=web-alias",
-		"PodmanArgs=--memory=256m",
+		"PodmanArgs=--memory=\"256m\"",
 	] {
 		assert!(c.contains(needle), "missing `{needle}` in:\n{c}");
 	}

--- a/internal/quadlet/tests/fields_resources.rs
+++ b/internal/quadlet/tests/fields_resources.rs
@@ -226,6 +226,78 @@ services:
 }
 
 #[test]
+fn volume_driver_opt_cannot_smuggle_extra_flags() {
+	// The `.volume` unit routes unrecognised driver options through
+	// `PodmanArgs=` too, and that site was missed when the container ones
+	// were fixed for #1734: the sweep stopped at the `.container` unit.
+	// These are `podman volume create` flags rather than `podman run`
+	// flags, so the blast radius differs, but the mechanism is identical.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    volumes:
+      - data:/data
+volumes:
+  data:
+    driver_opts:
+      arbitrary: "value --label injected=yes"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let v = &unit_named(&out, "p-data.volume").contents;
+	assert_argv_has_no_token(v, "--label");
+	assert_argv_has_no_token(v, "injected=yes");
+}
+
+#[test]
+fn volume_driver_opt_key_cannot_smuggle_extra_flags() {
+	// Quoting only the value leaves the same hole on the other side of the
+	// `=`. The key is attacker-controlled too: it is a YAML mapping key the
+	// compose file chooses.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    volumes:
+      - data:/data
+volumes:
+  data:
+    driver_opts:
+      "k --label injected=yes": v
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let v = &unit_named(&out, "p-data.volume").contents;
+	assert_argv_has_no_token(v, "--label");
+}
+
+#[test]
+fn volume_driver_opt_doubles_the_systemd_specifier() {
+	// `PodmanArgs=` skips `escape_unit_value`, which is what doubles `%`.
+	// An undoubled `%h` is expanded by systemd into the operator's home,
+	// so the quoting helper has to do it on this path too, on both halves.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    volumes:
+      - data:/data
+volumes:
+  data:
+    driver_opts:
+      "pcent%h": "%h/evil"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let v = &unit_named(&out, "p-data.volume").contents;
+	assert!(
+		v.contains("%%h") && !v.contains("=\"%h"),
+		"the specifier must be doubled on both halves, in:\n{v}"
+	);
+}
+
+#[test]
 fn apparmor_profile_cannot_smuggle_extra_flags() {
 	// The apparmor arm routes through PodmanArgs too (`AppArmor=` would be
 	// dropped by Quadlet). A hostile profile like

--- a/internal/quadlet/tests/fields_resources.rs
+++ b/internal/quadlet/tests/fields_resources.rs
@@ -10,6 +10,7 @@
 //! or a `deploy:` key into a Podman argument or a systemd directive, which is
 //! one question; the rest of `fields.rs` maps compose fields to Quadlet keys.
 
+use super::assert_argv_has_no_token;
 use super::unit_named;
 use crate::parse_str;
 use crate::quadlet::generate_at;
@@ -32,11 +33,11 @@ services:
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("PodmanArgs=--memory=512m"),
+		c.contains("PodmanArgs=--memory=\"512m\""),
 		"mem_limit must route through PodmanArgs in:\n{c}"
 	);
 	assert!(
-		c.contains("PodmanArgs=--security-opt apparmor=my-profile"),
+		c.contains("PodmanArgs=--security-opt apparmor=\"my-profile\""),
 		"apparmor must route through PodmanArgs in:\n{c}"
 	);
 	for forbidden in ["Memory=512m", "AppArmor=my-profile"] {
@@ -65,8 +66,8 @@ services:
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	for expected in [
-		"PodmanArgs=--cpus=1.5",
-		"PodmanArgs=--cpuset-cpus=0,1",
+		"PodmanArgs=--cpus=\"1.5\"",
+		"PodmanArgs=--cpuset-cpus=\"0,1\"",
 		"PodmanArgs=--cpu-shares=512",
 		"PodmanArgs=--cpu-quota=50000",
 		"PodmanArgs=--cpu-period=100000",
@@ -92,7 +93,7 @@ services:
 	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
 	let c = &unit_named(&out, "p-s.container").contents;
 	assert!(
-		c.contains("PodmanArgs=--cpus=2"),
+		c.contains("PodmanArgs=--cpus=\"2\""),
 		"missing deploy cpus PodmanArgs in:\n{c}"
 	);
 }
@@ -142,4 +143,169 @@ fn deploy_restart_condition_none_maps_to_no() {
 	assert!(unit_named(&out, "p-s.container")
 		.contents
 		.contains("Restart=no"));
+}
+
+// ---------------------------------------------------------------------------
+// #1734: PodmanArgs= argv safety at the seven interpolation sites
+//
+// `escape_unit_value` returns early for `PodmanArgs` (treating it like
+// `Exec`/`Entrypoint`), so the seven `format!()` sites that interpolate a
+// compose value into a podman-flag template were emitting raw bytes. A
+// hostile compose value containing whitespace would smuggle additional
+// `podman run` flags onto the same `PodmanArgs=` line; the unit text reads as
+// one innocent line, but systemd's word-splitter and podman's parser see two
+// argv elements. The only assertion worth pinning is the argv podman would
+// actually build, not the line that produced it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mem_limit_cannot_smuggle_extra_flags() {
+	// `mem_limit: "512m --privileged -v /:/hostfs"` is the canonical case
+	// from the issue. The smuggled `--privileged` and `-v /:/hostfs` must
+	// land inside ONE argv element via quoting, not become separate podman
+	// arguments.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    mem_limit: "512m --privileged -v /:/hostfs"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+	assert_argv_has_no_token(c, "-v");
+}
+
+#[test]
+fn cpus_cannot_smuggle_extra_flags() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    cpus: "1.5 --privileged"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+}
+
+#[test]
+fn cpuset_cannot_smuggle_extra_flags() {
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    cpuset: "0 --privileged -v /:/hostfs2"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+	assert_argv_has_no_token(c, "-v");
+}
+
+#[test]
+fn deploy_memory_cannot_smuggle_extra_flags() {
+	// `deploy.resources.limits.memory` is the modern equivalent of
+	// `mem_limit`; both interpolation sites need the same protection.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    deploy:
+      resources:
+        limits:
+          memory: "256m --privileged"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+}
+
+#[test]
+fn apparmor_profile_cannot_smuggle_extra_flags() {
+	// The apparmor arm routes through PodmanArgs too (`AppArmor=` would be
+	// dropped by Quadlet). A hostile profile like
+	// "my-profile --privileged -v /:/hostfs" must stay one argv element.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    security_opt:
+      - "apparmor=my-profile --privileged"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	assert_argv_has_no_token(c, "--privileged");
+}
+
+#[test]
+fn build_arg_value_cannot_smuggle_extra_flags() {
+	// The smoke-test from the issue: a build service with a `build:` block
+	// emits a `.build` unit that carries `--build-arg` through PodmanArgs.
+	// A value with whitespace must not become two podman args.
+	let yaml = r#"
+services:
+  app:
+    build:
+      context: .
+      args:
+        EVIL: "v --privileged -v /:/hostfs"
+    image: app:1.0
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let b = &unit_named(&out, "p-app.build").contents;
+	assert_argv_has_no_token(b, "--privileged");
+	assert_argv_has_no_token(b, "-v");
+}
+
+#[test]
+fn build_arg_bare_key_cannot_smuggle_extra_flags() {
+	// A `--build-arg` with no value is just the key. Smuggling still has to
+	// be impossible: a hostile key like `BAD --privileged` must end up as
+	// one argv element, not the literal "--privileged" plus the key.
+	let yaml = r#"
+services:
+  app:
+    build:
+      context: .
+      args:
+        - "BAD --privileged"
+    image: app:1.0
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let b = &unit_named(&out, "p-app.build").contents;
+	assert_argv_has_no_token(b, "--privileged");
+}
+
+#[test]
+fn podman_args_doubles_percent_specifiers() {
+	// systemd specifiers like `%h` would otherwise be expanded at unit
+	// activation time (the same behaviour `Environment=` already escapes).
+	// After the fix a value carrying `%h` is doubled to `%%h` in the
+	// interpolated podman arg, so podman receives `%h` literally and systemd
+	// does not substitute it for the unit's hostname.
+	let yaml = r#"
+services:
+  web:
+    image: alpine:3.20
+    mem_limit: "%h/mem"
+"#;
+	let file = parse_str(yaml).unwrap();
+	let out = generate_at(&file, "p", std::path::Path::new("/srv/app"));
+	let c = &unit_named(&out, "p-web.container").contents;
+	// After systemd unescapes `%%` to `%`, podman would receive the
+	// literal `%h/mem` from the quoted value, which is harmless; before
+	// the fix, podman would receive `mem` with `%h` expanded to the host's
+	// hostname.
+	assert!(
+		c.contains("PodmanArgs=--memory=\"%%h/mem\""),
+		"`%%h` must be doubled on the PodmanArgs path; got:\n{c}"
+	);
 }

--- a/internal/quadlet/tests/mod.rs
+++ b/internal/quadlet/tests/mod.rs
@@ -5,7 +5,10 @@ mod fields_logging;
 mod fields_resources;
 mod health;
 mod network_volume;
+mod podman_argv;
 mod units;
+
+pub(super) use podman_argv::assert_argv_has_no_token;
 
 fn unit_named<'a>(out: &'a QuadletOutput, filename: &str) -> &'a QuadletUnit {
 	out.units

--- a/internal/quadlet/tests/network_volume.rs
+++ b/internal/quadlet/tests/network_volume.rs
@@ -153,8 +153,17 @@ volumes:
 	assert!(vol.contains("Type=nfs"), "in:\n{vol}");
 	assert!(vol.contains("Device=:/exports"), "in:\n{vol}");
 	assert!(vol.contains("Options=addr=10.0.0.1,rw"), "in:\n{vol}");
-	// An option with no dedicated key falls back to PodmanArgs=--opt.
-	assert!(vol.contains("PodmanArgs=--opt custom=extra"), "in:\n{vol}");
+	// An option with no dedicated key falls back to PodmanArgs=--opt. The
+	// value is quoted (#1734): systemd consumes the quotes, so Podman's own
+	// generator still builds `--opt custom=extra`, and a value carrying
+	// whitespace stays one argv element instead of becoming extra flags.
+	// The assertion is on the argv rather than the unit text for that
+	// reason: the unit text is what looked correct while the bug was live.
+	assert_eq!(
+		crate::quadlet::tests::podman_argv::podman_argv_from_unit(vol),
+		vec!["--opt", "custom=extra"],
+		"in:\n{vol}"
+	);
 }
 
 #[test]

--- a/internal/quadlet/tests/podman_argv.rs
+++ b/internal/quadlet/tests/podman_argv.rs
@@ -1,0 +1,129 @@
+//! Argv-tokenisation helpers used by tests to assert that a generated unit's
+//! `PodmanArgs=` value cannot smuggle an extra `podman run` flag into the argv
+//! quadlet's generator would build from it.
+//!
+//! The unit text alone is not enough: `PodmanArgs=--memory=512m --privileged`
+//! is what `escape_unit_value` produced on the unfixed tree for a hostile
+//! `mem_limit: "512m --privileged"`, and it reads as one innocent-looking
+//! line. Podman, however, would receive `--memory=512m` and `--privileged` as
+//! two separate argv elements. That is the security property the bug breaks,
+//! and the only one worth asserting.
+//!
+//! systemd's `systemd.syntax(7)` word-splitter is the authoritative divider:
+//! the directive value after `PodmanArgs=` is tokenised on whitespace while
+//! honouring `"`-quoted groups (single quotes and C-style escapes are also
+//! honoured by systemd, but the seven interpolation sites have no reason to
+//! emit those, so a faithful `PodmanArgs=-side only needs the double-quote
+//! form to be tested).
+
+/// Tokenise one `PodmanArgs=` value the way systemd does.
+///
+/// Returns the argv podman would receive. Tokens coming out of a `"..."`
+/// group have their quotes stripped, the way systemd does (the consumed
+/// double quotes are not preserved as characters).
+pub fn tokenise_podman_argv(value: &str) -> Vec<String> {
+	let mut out = Vec::new();
+	let mut current = String::new();
+	let mut in_quotes = false;
+	let mut chars = value.chars().peekable();
+	while let Some(c) = chars.next() {
+		if in_quotes {
+			match c {
+				'"' => in_quotes = false,
+				'\\' if chars.peek() == Some(&'"') => {
+					current.push('"');
+					chars.next();
+				}
+				_ => current.push(c),
+			}
+			continue;
+		}
+		match c {
+			'"' => in_quotes = true,
+			c if c.is_whitespace() => {
+				if !current.is_empty() {
+					out.push(std::mem::take(&mut current));
+				}
+			}
+			_ => current.push(c),
+		}
+	}
+	if !current.is_empty() {
+		out.push(current);
+	}
+	out
+}
+
+/// Parse every `PodmanArgs=` line out of a unit body, concatenate the values
+/// the way systemd does (`PodmanArgs=` is multi-valued by design), and
+/// tokenise the combined string. Returns the argv podman would receive when
+/// the generator feeds it to `podman run`.
+///
+/// Comment lines (`#`) are skipped so a unit file's ownership marker does not
+/// confuse the parser; the `# podup-owner: <project>` line lives at the top
+/// of every generated unit and would otherwise contribute empty tokens.
+pub fn podman_argv_from_unit(unit_contents: &str) -> Vec<String> {
+	let mut combined = String::new();
+	for raw in unit_contents.lines() {
+		let line = raw.trim_end();
+		if line.starts_with('#') {
+			continue;
+		}
+		if let Some(rest) = line.strip_prefix("PodmanArgs=") {
+			if !combined.is_empty() {
+				combined.push('\n');
+			}
+			combined.push_str(rest);
+		}
+	}
+	tokenise_podman_argv(&combined)
+}
+
+/// Assert that no `PodmanArgs=` line in `unit_contents` produces `needle` as
+/// its own argv element after systemd tokenisation. Used by the seven
+/// per-site tests to pin the property the bug breaks.
+pub fn assert_argv_has_no_token(unit_contents: &str, needle: &str) {
+	let argv = podman_argv_from_unit(unit_contents);
+	assert!(
+		!argv.iter().any(|tok| tok == needle),
+		"unit produces {needle:?} as its own argv element; argv = {argv:#?}; unit:\n{unit_contents}"
+	);
+}
+
+#[test]
+fn tokenise_splits_on_whitespace() {
+	assert_eq!(
+		tokenise_podman_argv("--memory=512m --privileged"),
+		vec!["--memory=512m", "--privileged"]
+	);
+}
+
+#[test]
+fn tokenise_respects_double_quotes() {
+	// `--cpuset-cpus="0 --privileged"` is ONE argv element. That is what
+	// the seven-site fix must produce, and what this helper proves.
+	assert_eq!(
+		tokenise_podman_argv(r#"--cpuset-cpus="0 --privileged""#),
+		vec!["--cpuset-cpus=0 --privileged"]
+	);
+}
+
+#[test]
+fn multiple_podman_args_lines_concatenate() {
+	// systemd accepts multiple `PodmanArgs=` lines; their values merge.
+	let unit = "\
+PodmanArgs=--memory=512m
+PodmanArgs=--cpuset-cpus=0,1
+";
+	assert_eq!(
+		podman_argv_from_unit(unit),
+		vec!["--memory=512m", "--cpuset-cpus=0,1"]
+	);
+}
+
+#[test]
+fn comments_are_ignored() {
+	// The podup ownership marker is the first line of every unit.
+	let unit = "# podup-owner: p\nPodmanArgs=--privileged\n";
+	assert_eq!(podman_argv_from_unit(unit), vec!["--privileged"]);
+}

--- a/internal/quadlet/unit/build.rs
+++ b/internal/quadlet/unit/build.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 
 use crate::compose::types::{BuildConfig, Service};
 
-use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{
+	owner_marker, quote_podman_arg_value, sorted_label_pairs, unit_stem, QuadletUnit, Section,
+};
 
 /// Resolve a compose build `context` to an absolute `SetWorkingDirectory` value.
 ///
@@ -112,8 +114,18 @@ pub(crate) fn build_unit(
 				// drop the whole unit at daemon-reload), so route build args through
 				// PodmanArgs= as `--build-arg`, like the container CPU/memory limits.
 				match val {
-					Some(v) => section.add("PodmanArgs", format!("--build-arg {key}={v}")),
-					None => section.add("PodmanArgs", format!("--build-arg {key}")),
+					Some(v) => section.add(
+						"PodmanArgs",
+						format!(
+							"--build-arg {}={}",
+							quote_podman_arg_value(&key),
+							quote_podman_arg_value(&v)
+						),
+					),
+					None => section.add(
+						"PodmanArgs",
+						format!("--build-arg {}", quote_podman_arg_value(&key)),
+					),
 				}
 			}
 			for (key, val) in sorted_label_pairs(labels.to_map()) {

--- a/internal/quadlet/unit/container.rs
+++ b/internal/quadlet/unit/container.rs
@@ -10,9 +10,9 @@ use crate::size::parse_duration_secs;
 use super::health::render_healthcheck;
 use super::security::{is_inline_secret, map_security_opt, render_secret};
 use super::{
-	abs_against, collect_warnings, owner_marker, render_command, render_publish_port,
-	render_restart, render_tmpfs_mount, render_volume, safe_unit_stem, sorted_label_pairs,
-	sorted_pairs, unit_stem, QuadletUnit, Section,
+	abs_against, collect_warnings, owner_marker, quote_podman_arg_value, render_command,
+	render_publish_port, render_restart, render_tmpfs_mount, render_volume, safe_unit_stem,
+	sorted_label_pairs, sorted_pairs, unit_stem, QuadletUnit, Section,
 };
 use crate::quadlet::is_no_warn_set;
 
@@ -282,11 +282,17 @@ pub(crate) fn container_unit(
 		// `Memory=` is not a recognised [Container] Quadlet key (Quadlet would drop
 		// the whole unit at daemon-reload), so route the limit through PodmanArgs=
 		// as `--memory`, like the CPU limits. The value is validated as a size
-		// before generation, so it is a well-formed limit here.
-		container.add("PodmanArgs", format!("--memory={mem}"));
+		// before generation, so it is a well-formed limit here. The value is
+		// still quoted (and `%`-doubled) so an interpolation site cannot smuggle
+		// additional podman args into the same argv (#1734).
+		container.add(
+			"PodmanArgs",
+			format!("--memory={}", quote_podman_arg_value(mem)),
+		);
 	}
 	// CPU limits have no native [Container] Quadlet key (unlike Memory=/
-	// PidsLimit=), so they go through PodmanArgs=.
+	// PidsLimit=), so they go through PodmanArgs=. Quoted per #1734, same
+	// reason as `mem_limit` above.
 	// `cpus` falls back to the modern `deploy.resources.limits.cpus`.
 	let deploy_cpus = service
 		.deploy
@@ -295,10 +301,16 @@ pub(crate) fn container_unit(
 		.and_then(|r| r.limits.as_ref())
 		.and_then(|l| l.cpus.as_deref());
 	if let Some(c) = service.cpus.as_deref().or(deploy_cpus) {
-		container.add("PodmanArgs", format!("--cpus={c}"));
+		container.add(
+			"PodmanArgs",
+			format!("--cpus={}", quote_podman_arg_value(c)),
+		);
 	}
 	if let Some(cs) = &service.cpuset {
-		container.add("PodmanArgs", format!("--cpuset-cpus={cs}"));
+		container.add(
+			"PodmanArgs",
+			format!("--cpuset-cpus={}", quote_podman_arg_value(cs)),
+		);
 	}
 	if let Some(sh) = service.cpu_shares {
 		container.add("PodmanArgs", format!("--cpu-shares={sh}"));
@@ -450,7 +462,10 @@ pub(crate) fn container_unit(
 			.and_then(|r| r.limits.as_ref())
 			.and_then(|l| l.memory.as_ref())
 		{
-			container.add("PodmanArgs", format!("--memory={mem}"));
+			container.add(
+				"PodmanArgs",
+				format!("--memory={}", quote_podman_arg_value(mem)),
+			);
 		}
 	}
 	for secret in &service.secrets {

--- a/internal/quadlet/unit/mod.rs
+++ b/internal/quadlet/unit/mod.rs
@@ -16,6 +16,7 @@ pub(super) use volume::volume_unit;
 
 // Shared helpers from the sibling `render`/`warnings` modules and the parent
 // `QuadletUnit` type, re-exported so the unit submodules import them from here.
+pub(super) use super::render::quote_podman_arg_value;
 use super::render::{
 	render_command, render_publish_port, render_restart, render_tmpfs_mount, render_volume,
 	safe_unit_stem, sorted_label_pairs, sorted_pairs, unit_stem, Section,

--- a/internal/quadlet/unit/security.rs
+++ b/internal/quadlet/unit/security.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 
 use crate::compose::types::{SecretConfig, ServiceSecretRef};
 
-use super::Section;
+use super::{quote_podman_arg_value, Section};
 
 /// Sanitize one `Secret=` option-list field: drop control characters and the
 /// `,`/`=` separators so a hostile compose value cannot inject extra options.
@@ -102,7 +102,16 @@ pub(super) fn map_security_opt(
 		// `AppArmor=` is not a recognised [Container] Quadlet key (Quadlet would
 		// drop the whole unit at daemon-reload), so route it through PodmanArgs= as
 		// `--security-opt apparmor=<profile>`, like the other escape-hatch flags.
-		container.add("PodmanArgs", format!("--security-opt apparmor={profile}"));
+		// `profile` is composed input; a value like `my-profile --privileged`
+		// must stay one argv element rather than two podman args: `escape_unit_value`
+		// short-circuits on `PodmanArgs` (#1734), so the quote happens here.
+		container.add(
+			"PodmanArgs",
+			format!(
+				"--security-opt apparmor={}",
+				quote_podman_arg_value(profile)
+			),
+		);
 	} else if let Some(label) = opt.strip_prefix("label=") {
 		if label == "disable" {
 			container.add("SecurityLabelDisable", "true".to_string());

--- a/internal/quadlet/unit/security_tests.rs
+++ b/internal/quadlet/unit/security_tests.rs
@@ -88,10 +88,10 @@ fn maps_seccomp_and_apparmor() {
 	// `apparmor:` route through PodmanArgs= as a `--security-opt` flag.
 	assert!(map_one("apparmor=docker-default")
 		.0
-		.contains("PodmanArgs=--security-opt apparmor=docker-default"));
+		.contains("PodmanArgs=--security-opt apparmor=\"docker-default\""));
 	assert!(map_one("apparmor:unconfined")
 		.0
-		.contains("PodmanArgs=--security-opt apparmor=unconfined"));
+		.contains("PodmanArgs=--security-opt apparmor=\"unconfined\""));
 }
 
 #[test]

--- a/internal/quadlet/unit/volume.rs
+++ b/internal/quadlet/unit/volume.rs
@@ -2,7 +2,9 @@
 
 use crate::compose::types::VolumeConfig;
 
-use super::{owner_marker, sorted_label_pairs, unit_stem, QuadletUnit, Section};
+use super::{
+	owner_marker, quote_podman_arg_value, sorted_label_pairs, unit_stem, QuadletUnit, Section,
+};
 
 /// Build the `.volume` unit for one declared named volume. Emits a single
 /// `[Volume]` section (VolumeName, then driver/driver-opts/labels), always
@@ -30,7 +32,23 @@ pub(crate) fn volume_unit(name: &str, project: &str, config: Option<&VolumeConfi
 				"type" => vol.add("Type", val),
 				"device" => vol.add("Device", val),
 				"o" => vol.add("Options", val),
-				_ => vol.add("PodmanArgs", format!("--opt {key}={val}")),
+				// Quoted for the same reason the container sites are (#1734):
+				// `PodmanArgs=` is exempt from `escape_unit_value`, so an
+				// unquoted value here smuggles extra `podman volume create`
+				// flags. This site was missed when the container sites were
+				// fixed, because the search stopped at the `.container` unit.
+				// Both halves. Quoting only the value leaves the same hole on
+				// the other side of the `=`: a key carrying whitespace splits
+				// into extra flags, and a key carrying `%` is expanded by
+				// systemd. `--opt "k"="v"` is one argv element either way.
+				_ => vol.add(
+					"PodmanArgs",
+					format!(
+						"--opt {}={}",
+						quote_podman_arg_value(&key),
+						quote_podman_arg_value(&val)
+					),
+				),
 			}
 		}
 		for (key, val) in sorted_label_pairs(cfg.labels.to_map()) {

--- a/internal/startup/bridge_tests.rs
+++ b/internal/startup/bridge_tests.rs
@@ -1,0 +1,62 @@
+//! Tests for the legacy `PODUP_LIBCOD_POOL` -> `PODUP_LIBPOD_POOL` env
+//! bridge. Kept in its own file so `tests.rs` stays near its existing size;
+//! `tests.rs` was already past the 300-line soft warn when this branch
+//! forked, and the bridge is the only new suite being added.
+
+// Helper: run `bridge_legacy_pool_env` with `PODUP_LIBPOD_POOL` and
+// `PODUP_LIBCOD_POOL` set to the given `(Option<&str>, Option<&str>)`
+// and return what the new var reads after. The new var is captured in
+// and out: the helper both removes it before and inspects it after, so
+// a test asserts on the post-call observation only.
+fn run_bridge(new: Option<&str>, legacy: Option<&str>) -> Option<String> {
+	// Clear both to start. A leftover `PODUP_LIBPOD_POOL` from a
+	// parent process would otherwise leak into the test.
+	std::env::remove_var("PODUP_LIBPOD_POOL");
+	std::env::remove_var("PODUP_LIBCOD_POOL");
+	if let Some(v) = new {
+		std::env::set_var("PODUP_LIBPOD_POOL", v);
+	}
+	if let Some(v) = legacy {
+		std::env::set_var("PODUP_LIBCOD_POOL", v);
+	}
+	super::bridge_legacy_pool_env();
+	let after = std::env::var("PODUP_LIBPOD_POOL").ok();
+	std::env::remove_var("PODUP_LIBPOD_POOL");
+	std::env::remove_var("PODUP_LIBCOD_POOL");
+	after
+}
+
+// The three cases live in ONE test on purpose. They mutate the process
+// environment, and `cargo test` runs test functions on parallel threads
+// inside a single process, so as separate tests they race for
+// `PODUP_LIBPOD_POOL` and the loser reads the winner's value. That is
+// what `rust / Test (windows-latest)` caught here: the same three passed
+// on Linux, where the scheduling happened to interleave differently. One
+// test function is one thread, and the shared resource is then not
+// shared.
+#[test]
+fn the_bridge_honours_precedence_across_the_three_env_shapes() {
+	// The early-return path: with neither env present the helper is
+	// a no-op and `PODUP_LIBPOD_POOL` stays unset after the call.
+	assert_eq!(
+		run_bridge(None, None),
+		None,
+		"neither var set must leave the new name unset",
+	);
+
+	// The contract a script that exports only `PODUP_LIBCOD_POOL`
+	// depends on: after the call the new var reads the old value.
+	assert_eq!(
+		run_bridge(None, Some("4")),
+		Some("4".to_string()),
+		"legacy value must be visible to clap under the new name",
+	);
+
+	// Set precedence: a script that exports BOTH wins when its new-var
+	// value is the explicit one; the legacy value must not overwrite.
+	assert_eq!(
+		run_bridge(Some("8"), Some("0")),
+		Some("8".to_string()),
+		"new var must not be overwritten when explicitly exported",
+	);
+}

--- a/internal/startup/config_render.rs
+++ b/internal/startup/config_render.rs
@@ -3,6 +3,7 @@
 //! file in YAML/JSON with unset keys pruned and inline secrets redacted. Split
 //! out of `startup` so each file stays within the source line limit.
 
+use std::io::{self, Write};
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
@@ -41,6 +42,26 @@ pub(crate) fn render_config(
 	project: &str,
 	base_dir: &Path,
 ) -> podup::Result<()> {
+	let mut stdout = io::stdout().lock();
+	render_config_to(&mut stdout, file, format, out, project, base_dir)
+}
+
+/// [`render_config`] writing to `w`. The list-projection branches
+/// (`--services`, `--volumes`, `--images`, `--profiles`) print user-controlled
+/// compose values directly; those lines route the value through `sanitize_cell`
+/// so a malicious compose file cannot inject raw terminal escapes into the
+/// operator's output, and the bytes do not survive a pipe. The `--hash` and
+/// resolved-YAML/JSON branches escape differently: the hash branch is a hard
+/// `SERVICE HEX` shape with the service name sanitized; the YAML/JSON branches
+/// go through serde which already escapes every control character.
+pub(crate) fn render_config_to<W: Write>(
+	w: &mut W,
+	file: &podup::compose::types::ComposeFile,
+	format: &ConfigFormat,
+	out: &ConfigOutput,
+	project: &str,
+	base_dir: &Path,
+) -> podup::Result<()> {
 	// Reaching here means the file parsed and merged cleanly. Run the full
 	// config-time validation (non-empty services, image-or-build, service-name
 	// charset, port ranges, undefined volume/network references, and an acyclic
@@ -59,13 +80,13 @@ pub(crate) fn render_config(
 	}
 	if out.services {
 		for name in file.services.keys() {
-			println!("{name}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(name))?;
 		}
 		return Ok(());
 	}
 	if out.volumes {
 		for name in file.volumes.keys() {
-			println!("{name}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(name))?;
 		}
 		return Ok(());
 	}
@@ -75,7 +96,7 @@ pub(crate) fn render_config(
 				.image
 				.clone()
 				.unwrap_or_else(|| format!("{name}:latest"));
-			println!("{image}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(&image))?;
 		}
 		return Ok(());
 	}
@@ -87,12 +108,12 @@ pub(crate) fn render_config(
 			}
 		}
 		for p in profiles {
-			println!("{p}");
+			writeln!(w, "{}", podup::ui::sanitize_cell(p))?;
 		}
 		return Ok(());
 	}
 	if let Some(selector) = &out.hash {
-		return render_config_hash(file, selector);
+		return render_config_hash_to(w, file, selector);
 	}
 	let mut redacted = file.clone();
 	// Surface the resolved project name in the rendered output, like
@@ -136,7 +157,7 @@ pub(crate) fn render_config(
 			quote_yaml11_booleans(&yaml)
 		}
 	};
-	println!("{rendered}");
+	writeln!(w, "{rendered}")?;
 	Ok(())
 }
 
@@ -157,8 +178,11 @@ fn service_config_hash(svc: &podup::compose::types::Service) -> podup::Result<St
 }
 
 /// `config --hash`: print `SERVICE HASH` for all services ("*") or the given
-/// comma-separated subset (an unknown service name is an error).
-fn render_config_hash(
+/// comma-separated subset (an unknown service name is an error). Writing
+/// only the service name is sanitized; the hash is a 64-character hex
+/// string we control and needs no escaping.
+fn render_config_hash_to<W: Write>(
+	w: &mut W,
 	file: &podup::compose::types::ComposeFile,
 	selector: &str,
 ) -> podup::Result<()> {
@@ -176,7 +200,12 @@ fn render_config_hash(
 			.services
 			.get(&name)
 			.ok_or_else(|| podup::ComposeError::ServiceNotFound(name.clone()))?;
-		println!("{name} {}", service_config_hash(svc)?);
+		writeln!(
+			w,
+			"{} {}",
+			podup::ui::sanitize_cell(&name),
+			service_config_hash(svc)?
+		)?;
 	}
 	Ok(())
 }

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -212,6 +212,22 @@ pub(crate) fn run_labels_for(command: &Commands) -> Vec<String> {
 	}
 }
 
+/// Bridge the legacy `PODUP_LIBCOD_POOL` env to the corrected
+/// `PODUP_LIBPOD_POOL` before clap parses the CLI. The new var is the one
+/// clap reads (`#[arg(env = "PODUP_LIBPOD_POOL")]` on
+/// `Cli::connection_pool_size`); this helper exists purely so a script that
+/// already exports the old typo'd name keeps taking effect after the rename.
+/// Only set when the new var is unset; an explicit new-var export is left
+/// untouched. Pure on the env at the moment it runs.
+fn bridge_legacy_pool_env() {
+	if std::env::var_os("PODUP_LIBPOD_POOL").is_some() {
+		return;
+	}
+	if let Some(legacy) = std::env::var_os("PODUP_LIBCOD_POOL") {
+		std::env::set_var("PODUP_LIBPOD_POOL", legacy);
+	}
+}
+
 /// Parse the CLI, framing `--help`/`--version` output with a blank line top and
 /// bottom (clap trims template edges, so wrap the rendered text here).
 /// Render a clap help/usage screen, with or without its styling.
@@ -299,6 +315,14 @@ fn takes_a_value(cmd: &clap::Command, token: &str) -> bool {
 }
 
 pub(crate) fn parse_cli() -> Cli {
+	// Bridge the legacy `PODUP_LIBCOD_POOL` env var before clap reads the new
+	// `PODUP_LIBPOD_POOL`. The earlier name was a typo for `LIBPOD`; renaming
+	// the env var keeps the docs and the rest of the codebase consistent,
+	// but the rename is non-breaking only if an existing script that exports
+	// the old name still takes effect. We only set the new var when the old
+	// one is set AND the new one is not, so a script that explicitly
+	// overrides with the new name is unaffected.
+	bridge_legacy_pool_env();
 	// Apply `--ansi` before clap renders anything: `--help` and clap's own
 	// errors are produced inside the parse call below, so a choice applied
 	// afterwards arrives too late for them.
@@ -395,5 +419,8 @@ fn format_clap_error(err: &clap::error::Error) -> String {
 	format!("{prefix}{body}")
 }
 
+#[cfg(test)]
+#[path = "bridge_tests.rs"]
+mod bridge_tests;
 #[cfg(test)]
 mod tests;

--- a/internal/startup/mod.rs
+++ b/internal/startup/mod.rs
@@ -14,6 +14,8 @@ use crate::cli::{Cli, Commands};
 
 mod config_normalize;
 mod config_render;
+#[cfg(test)]
+pub(crate) use config_render::render_config_to;
 pub(crate) use config_render::{render_config, ConfigOutput};
 
 /// Whether a command creates, destroys, or changes the state of containers and

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -18,6 +18,16 @@ use parse::{collect_var_name, is_var_start, parse_braced_var, resolve_modifier};
 /// cap turns a pathological chain into a clean error instead of a stack overflow.
 const MAX_INTERP_DEPTH: usize = 64;
 
+/// Upper bound on the cumulative size of the output of a single [`substitute`]
+/// pass. The output grows by `count(refs_in_input) × len(value_of_VAR)`, with
+/// no natural ceiling: a few hundred kilobytes of input where one variable
+/// repeats many times reaches gigabytes before anything else has a chance to
+/// fire (#1738). The bound is checked as `out` grows (before each `push_str`)
+/// so the refusal happens before the offending allocation, and the message
+/// names the variable and the size so a legitimate large payload (a long
+/// secret, a multi-line config blob) can be told apart from a hostile one.
+const MAX_INTERP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -63,7 +73,8 @@ pub(super) fn substitute_depth(
 			Some('{') => {
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
-				let value = resolve_modifier(var, modifier, vars, depth)?;
+				let value = resolve_modifier(var.clone(), modifier, vars, depth)?;
+				check_output_cap(&out, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
@@ -78,6 +89,7 @@ pub(super) fn substitute_depth(
 						String::new()
 					}
 				};
+				check_output_cap(&out, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(_) => {
@@ -87,6 +99,22 @@ pub(super) fn substitute_depth(
 	}
 
 	Ok(out)
+}
+
+/// Refuse a variable expansion that would push the cumulative interpolation
+/// output past [`MAX_INTERP_OUTPUT_BYTES`]. Called before the `push_str` so the
+/// refusal fires before the offending allocation, with a message naming the
+/// variable and the size it had reached.
+fn check_output_cap(out: &str, value: &str, var: &str) -> Result<()> {
+	let new_len = out.len().saturating_add(value.len());
+	if new_len > MAX_INTERP_OUTPUT_BYTES {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"variable '{var}' would expand to {new_len} bytes of output; at most \
+			 {MAX_INTERP_OUTPUT_BYTES} bytes of interpolated output are allowed; the value \
+			 may repeat too many times in the document"
+		)));
+	}
+	Ok(())
 }
 
 /// Load a `.env` file from `dir`.

--- a/internal/substitute/mod.rs
+++ b/internal/substitute/mod.rs
@@ -28,6 +28,27 @@ const MAX_INTERP_DEPTH: usize = 64;
 /// secret, a multi-line config blob) can be told apart from a hostile one.
 const MAX_INTERP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 
+/// Upper bound on the total interpolated output of one document.
+///
+/// [`MAX_INTERP_OUTPUT_BYTES`] bounds a single scalar, which is the wrong
+/// unit on its own: repetition split across scalars is unbounded while every
+/// individual substitution stays legal. Measured on the tree before this
+/// bound existed, with a 1 MiB `.env` value and one service whose
+/// environment carries N entries all reading it: 256 entries reached 1.6 GB,
+/// 512 reached 3.2 GB, and 1024 aborted at 5.27 GB. No single substitution
+/// exceeded 1 MiB, so the per-scalar cap never fired once.
+///
+/// 16 MiB, the same number the per-file cap already uses, so a reader meets
+/// one size rather than two. It was picked by measurement rather than taste:
+/// at 64 MiB a document of 64 one-mebibyte entries is accepted and costs
+/// 419 MB resident, which is not a bound worth having. At 16 MiB the same
+/// shape is refused and a document that is legitimately large, a long secret
+/// or a config blob across a handful of services, still parses.
+///
+/// The per-scalar cap stays as the cheaper first line: it refuses a single
+/// runaway value without walking the rest of the document.
+pub(crate) const MAX_INTERP_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -37,7 +58,18 @@ const MAX_INTERP_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 /// `vars` should contain both the process environment and the `.env` file
 /// entries (process environment takes precedence).
 pub fn substitute(input: &str, vars: &HashMap<String, String>) -> Result<String> {
-	substitute_depth(input, vars, 0)
+	let mut spent = 0usize;
+	substitute_depth(input, vars, 0, &mut spent)
+}
+
+/// [`substitute`] with a budget that outlives the call, so a caller
+/// interpolating many scalars bounds their total rather than each one.
+pub(crate) fn substitute_budgeted(
+	input: &str,
+	vars: &HashMap<String, String>,
+	spent: &mut usize,
+) -> Result<String> {
+	substitute_depth(input, vars, 0, spent)
 }
 
 /// Inner substitution carrying the current nesting `depth` so recursive
@@ -46,6 +78,7 @@ pub(super) fn substitute_depth(
 	input: &str,
 	vars: &HashMap<String, String>,
 	depth: usize,
+	spent: &mut usize,
 ) -> Result<String> {
 	if depth > MAX_INTERP_DEPTH {
 		return Err(ComposeError::InvalidSubstitution(format!(
@@ -73,8 +106,9 @@ pub(super) fn substitute_depth(
 			Some('{') => {
 				chars.next();
 				let (var, modifier) = parse_braced_var(&mut chars)?;
-				let value = resolve_modifier(var.clone(), modifier, vars, depth)?;
+				let value = resolve_modifier(var.clone(), modifier, vars, depth, spent)?;
 				check_output_cap(&out, &value, &var)?;
+				check_document_budget(spent, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(c) if is_var_start(*c) => {
@@ -90,6 +124,7 @@ pub(super) fn substitute_depth(
 					}
 				};
 				check_output_cap(&out, &value, &var)?;
+				check_document_budget(spent, &value, &var)?;
 				out.push_str(&value);
 			}
 			Some(_) => {
@@ -105,6 +140,18 @@ pub(super) fn substitute_depth(
 /// output past [`MAX_INTERP_OUTPUT_BYTES`]. Called before the `push_str` so the
 /// refusal fires before the offending allocation, with a message naming the
 /// variable and the size it had reached.
+fn check_document_budget(spent: &mut usize, value: &str, var: &str) -> Result<()> {
+	*spent = spent.saturating_add(value.len());
+	if *spent > MAX_INTERP_DOCUMENT_BYTES {
+		return Err(ComposeError::InvalidSubstitution(format!(
+			"interpolating '{var}' pushes this document past {MAX_INTERP_DOCUMENT_BYTES} \
+			 bytes of substituted output; at most that much is allowed across the whole \
+			 file; the value may repeat across many fields"
+		)));
+	}
+	Ok(())
+}
+
 fn check_output_cap(out: &str, value: &str, var: &str) -> Result<()> {
 	let new_len = out.len().saturating_add(value.len());
 	if new_len > MAX_INTERP_OUTPUT_BYTES {

--- a/internal/substitute/parse.rs
+++ b/internal/substitute/parse.rs
@@ -154,6 +154,7 @@ pub(super) fn resolve_modifier(
 	modifier: Modifier,
 	vars: &HashMap<String, String>,
 	depth: usize,
+	spent: &mut usize,
 ) -> Result<String> {
 	let value = vars.get(&var);
 
@@ -174,21 +175,21 @@ pub(super) fn resolve_modifier(
 		// than overflowing the stack.
 		Modifier::DefaultIfUnsetOrEmpty(default) => match value {
 			Some(v) if !v.is_empty() => Ok(v.clone()),
-			_ => super::substitute_depth(&default, vars, depth + 1),
+			_ => super::substitute_depth(&default, vars, depth + 1, spent),
 		},
 
 		Modifier::DefaultIfUnset(default) => match value {
 			Some(v) => Ok(v.clone()),
-			None => super::substitute_depth(&default, vars, depth + 1),
+			None => super::substitute_depth(&default, vars, depth + 1, spent),
 		},
 
 		Modifier::AltIfSetAndNonEmpty(alt) => match value {
-			Some(v) if !v.is_empty() => super::substitute_depth(&alt, vars, depth + 1),
+			Some(v) if !v.is_empty() => super::substitute_depth(&alt, vars, depth + 1, spent),
 			_ => Ok(String::new()),
 		},
 
 		Modifier::AltIfSet(alt) => match value {
-			Some(_) => super::substitute_depth(&alt, vars, depth + 1),
+			Some(_) => super::substitute_depth(&alt, vars, depth + 1, spent),
 			None => Ok(String::new()),
 		},
 

--- a/internal/substitute/parse_tests.rs
+++ b/internal/substitute/parse_tests.rs
@@ -182,11 +182,11 @@ fn parse_unterminated_modifier_is_error() {
 fn resolve_none_uses_value_or_empty() {
 	let v = vars(&[("A", "1")]);
 	assert_eq!(
-		resolve_modifier("A".into(), Modifier::None, &v, 0).unwrap(),
+		resolve_modifier("A".into(), Modifier::None, &v, 0, &mut 0usize).unwrap(),
 		"1"
 	);
 	assert_eq!(
-		resolve_modifier("MISSING".into(), Modifier::None, &v, 0).unwrap(),
+		resolve_modifier("MISSING".into(), Modifier::None, &v, 0, &mut 0usize).unwrap(),
 		""
 	);
 }
@@ -195,12 +195,18 @@ fn resolve_none_uses_value_or_empty() {
 fn resolve_default_if_unset_or_empty() {
 	let v = vars(&[("EMPTY", ""), ("SET", "x")]);
 	let m = || Modifier::DefaultIfUnsetOrEmpty("def".into());
-	assert_eq!(resolve_modifier("EMPTY".into(), m(), &v, 0).unwrap(), "def");
 	assert_eq!(
-		resolve_modifier("MISSING".into(), m(), &v, 0).unwrap(),
+		resolve_modifier("EMPTY".into(), m(), &v, 0, &mut 0usize).unwrap(),
 		"def"
 	);
-	assert_eq!(resolve_modifier("SET".into(), m(), &v, 0).unwrap(), "x");
+	assert_eq!(
+		resolve_modifier("MISSING".into(), m(), &v, 0, &mut 0usize).unwrap(),
+		"def"
+	);
+	assert_eq!(
+		resolve_modifier("SET".into(), m(), &v, 0, &mut 0usize).unwrap(),
+		"x"
+	);
 }
 
 #[test]
@@ -211,7 +217,8 @@ fn resolve_default_if_unset_keeps_empty_value() {
 			"EMPTY".into(),
 			Modifier::DefaultIfUnset("def".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		""
@@ -221,7 +228,8 @@ fn resolve_default_if_unset_keeps_empty_value() {
 			"MISSING".into(),
 			Modifier::DefaultIfUnset("def".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		"def"
@@ -236,7 +244,8 @@ fn resolve_alt_forms() {
 			"SET".into(),
 			Modifier::AltIfSetAndNonEmpty("a".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		"a"
@@ -246,17 +255,32 @@ fn resolve_alt_forms() {
 			"EMPTY".into(),
 			Modifier::AltIfSetAndNonEmpty("a".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		""
 	);
 	assert_eq!(
-		resolve_modifier("EMPTY".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
+		resolve_modifier(
+			"EMPTY".into(),
+			Modifier::AltIfSet("a".into()),
+			&v,
+			0,
+			&mut 0usize
+		)
+		.unwrap(),
 		"a"
 	);
 	assert_eq!(
-		resolve_modifier("MISSING".into(), Modifier::AltIfSet("a".into()), &v, 0).unwrap(),
+		resolve_modifier(
+			"MISSING".into(),
+			Modifier::AltIfSet("a".into()),
+			&v,
+			0,
+			&mut 0usize
+		)
+		.unwrap(),
 		""
 	);
 }
@@ -268,7 +292,8 @@ fn resolve_error_forms() {
 		"EMPTY".into(),
 		Modifier::ErrorIfUnsetOrEmpty("e".into()),
 		&v,
-		0
+		0,
+		&mut 0usize
 	)
 	.is_err());
 	assert_eq!(
@@ -276,14 +301,29 @@ fn resolve_error_forms() {
 			"SET".into(),
 			Modifier::ErrorIfUnsetOrEmpty("e".into()),
 			&v,
-			0
+			0,
+			&mut 0usize
 		)
 		.unwrap(),
 		"x"
 	);
-	assert!(resolve_modifier("MISSING".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).is_err());
+	assert!(resolve_modifier(
+		"MISSING".into(),
+		Modifier::ErrorIfUnset("e".into()),
+		&v,
+		0,
+		&mut 0usize
+	)
+	.is_err());
 	assert_eq!(
-		resolve_modifier("EMPTY".into(), Modifier::ErrorIfUnset("e".into()), &v, 0).unwrap(),
+		resolve_modifier(
+			"EMPTY".into(),
+			Modifier::ErrorIfUnset("e".into()),
+			&v,
+			0,
+			&mut 0usize
+		)
+		.unwrap(),
 		""
 	);
 }

--- a/internal/substitute/tests.rs
+++ b/internal/substitute/tests.rs
@@ -480,3 +480,44 @@ fn strict_build_vars_allows_multiline_and_tab_values() {
 	);
 	assert_eq!(vars.get("TABBED").map(String::as_str), Some("a\tb"));
 }
+
+// variable-repetition cap (#1738)
+
+#[test]
+fn interpolation_cap_refuses_variable_repetition_in_one_scalar() {
+	// 300 KB of `${PAYLOAD}` references in one scalar with a moderately sized
+	// PAYLOAD value would otherwise produce hundreds of MB of output and
+	// (on the host from the issue) SIGABRT in under a second. The cap is
+	// checked as `out` grows inside `substitute_depth`, so the refusal
+	// fires before the offending allocation is committed, and names both
+	// the variable and the size so a legitimate large value can be told
+	// apart from a hostile one (#1738).
+	let payload = "x".repeat(2 * 1024);
+	let mut input = String::new();
+	while input.len() < 300 * 1024 {
+		input.push_str("${PAYLOAD}");
+	}
+	let v = vars(&[("PAYLOAD", &payload)]);
+	let err = substitute(&input, &v)
+		.expect_err("expected the interpolation cap to refuse variable repetition");
+	let msg = format!("{err}");
+	assert!(
+		matches!(err, crate::error::ComposeError::InvalidSubstitution(_)),
+		"refusal should be InvalidSubstitution; got: {msg}"
+	);
+	assert!(
+		msg.contains("PAYLOAD"),
+		"refusal should name the variable; got: {msg}"
+	);
+	assert!(
+		msg.contains("bytes"),
+		"refusal should name the size reached; got: {msg}"
+	);
+}
+
+#[test]
+fn interpolation_cap_allows_legitimate_repetition() {
+	// A handful of repetitions of a small value stay well under the cap.
+	let v = vars(&[("TAG", "v1")]);
+	assert_eq!(substitute("${TAG}-${TAG}-${TAG}", &v).unwrap(), "v1-v1-v1");
+}

--- a/internal/substitute/tests.rs
+++ b/internal/substitute/tests.rs
@@ -521,3 +521,39 @@ fn interpolation_cap_allows_legitimate_repetition() {
 	let v = vars(&[("TAG", "v1")]);
 	assert_eq!(substitute("${TAG}-${TAG}-${TAG}", &v).unwrap(), "v1-v1-v1");
 }
+
+#[test]
+fn the_document_budget_bounds_repetition_spread_across_scalars() {
+	// The per-scalar cap is the wrong unit on its own: repetition split
+	// across scalars is unbounded while every single substitution stays
+	// legal. Measured before this budget existed, with a 1 MiB value and
+	// one service reading it from N environment entries: 256 reached
+	// 1.6 GB, 512 reached 3.2 GB, 1024 aborted at 5.27 GB, and no single
+	// substitution passed 1 MiB, so the per-scalar cap never fired.
+	//
+	// The value is built here rather than committed as a fixture.
+	let big = "y".repeat(1024 * 1024);
+	let mut vars = std::collections::HashMap::new();
+	vars.insert("BIG".to_string(), big);
+
+	// Under the budget: still accepted, because a long secret across a
+	// handful of fields is a legitimate document.
+	let mut spent = 0usize;
+	for _ in 0..8 {
+		super::substitute_budgeted("${BIG}", &vars, &mut spent)
+			.expect("eight one-mebibyte substitutions stay under the budget");
+	}
+
+	// Over it: refused, and the message names the variable so a large
+	// legitimate file can be told apart from a hostile one.
+	let mut spent = 0usize;
+	let err = (0..64)
+		.map(|_| super::substitute_budgeted("${BIG}", &vars, &mut spent))
+		.find_map(|r| r.err())
+		.expect("sixty-four must cross the document budget");
+	let msg = format!("{err}");
+	assert!(
+		msg.contains("BIG") && msg.contains("past"),
+		"the refusal must name the variable and the budget, got: {msg}"
+	);
+}

--- a/internal/ui/mod.rs
+++ b/internal/ui/mod.rs
@@ -435,14 +435,19 @@ pub fn bold() -> Style {
 /// is stripped automatically when colour is off. The single place every list
 /// command renders its header, keeping them consistent.
 pub fn print_bold_header(cols: &str) {
-	use std::io::Write;
+	let stdout = std::io::stdout();
+	let mut out = stdout.lock();
+	let _ = write_bold_header(&mut out, cols);
+}
+
+/// [`print_bold_header`] writing to `w`, factored out so the renderer can be
+/// driven against an in-memory buffer. The bold styling is rendered as the
+/// raw ANSI codes regardless of the global colour choice: tests read the
+/// bytes verbatim, and `Table::print_to` (the only caller here) writes plain
+/// columns alongside the header.
+pub fn write_bold_header<W: std::io::Write>(w: &mut W, cols: &str) -> std::io::Result<()> {
 	let s = bold();
-	let _ = writeln!(
-		anstream::stdout(),
-		"{}{cols}{}",
-		s.render(),
-		s.render_reset()
-	);
+	writeln!(w, "{}{cols}{}", s.render(), s.render_reset())
 }
 
 /// Print a bold header tinted with its identity colour, used where a block is

--- a/internal/ui/progress/mod.rs
+++ b/internal/ui/progress/mod.rs
@@ -227,6 +227,31 @@ pub fn start_anchored(
 	emit(sink, kind, name, verb);
 }
 
+/// The lines one stream chunk contributes to a row's tail.
+///
+/// A builder writes several lines in one chunk, and the repaint arithmetic
+/// counts entries: a note holding `\n` is drawn as several terminal rows and
+/// counted as one, so `cursor_up(painted)` lands short and every later
+/// repaint erases too few lines (#1733). Splitting here keeps the invariant
+/// `Region` documents, that one entry is one row.
+///
+/// `split('\n')` rather than `lines()` on purpose: `lines()` also swallows a
+/// trailing `\r`, and the `trim()` here handles `\r\n` anyway, so the two
+/// responsibilities stay apart. Empty parts are dropped, matching what a
+/// single blank line already did.
+fn note_lines(line: &str) -> impl Iterator<Item = &str> {
+	line.split('\n')
+		.map(str::trim)
+		.filter(|part| !part.is_empty())
+}
+
+/// Test hook for [`note_lines`], which is otherwise only reachable through a
+/// live region the cargo-test runner cannot give us.
+#[cfg(test)]
+pub(crate) fn note_lines_for_tests(line: &str) -> Vec<&str> {
+	note_lines(line).collect()
+}
+
 /// Hand one line of a row's stream output to the renderer.
 ///
 /// On a live terminal the line is appended to the per-row tail kept under the
@@ -250,34 +275,49 @@ pub fn note_for(kind: &str, name: &str, line: &str) {
 	let Some(kind) = Kind::from_noun(kind) else {
 		return;
 	};
-	let trimmed = line.trim();
-	if trimmed.is_empty() {
-		return;
-	}
-	let sink = {
-		let Ok(mut slot) = SESSION.lock() else {
-			return;
-		};
-		match slot.as_mut() {
-			Some(session) => {
-				if session.region.is_some() {
-					push_note_live(&mut session.notes, kind, name, trimmed);
-					Sink::Live
-				} else {
-					Sink::Plain
-				}
-			}
-			None => Sink::None,
-		}
-	};
-	match sink {
-		Sink::Live => repaint(),
-		Sink::Plain | Sink::None => {
-			if !super::progress_enabled() {
+	// One entry per line. A builder stream chunk can carry several lines in a
+	// single write, and the repaint arithmetic counts entries: a note holding
+	// `\n` is drawn as several terminal rows but counted as one, so from that
+	// frame on `cursor_up(painted)` lands short and every repaint erases too
+	// few lines. That is the eighty-times-scrolled board in #1733, and
+	// `Region`'s own doc comment predicts it: it says a line that wraps makes
+	// the terminal count two rows where this counted one. An embedded newline
+	// breaks the same invariant by a different route, and the width fit does
+	// not cover it because `chars().take(width)` counts `\n` as an ordinary
+	// character.
+	//
+	// It also restores `MAX_NOTES_PER_ROW`, which a single arbitrarily tall
+	// entry defeats.
+	//
+	// `split('\n')` rather than `lines()` on purpose: `lines()` also swallows
+	// a trailing `\r`, and the `trim()` below handles `\r\n` anyway, so this
+	// keeps the two responsibilities apart.
+	for trimmed in note_lines(line) {
+		let sink = {
+			let Ok(mut slot) = SESSION.lock() else {
 				return;
+			};
+			match slot.as_mut() {
+				Some(session) => {
+					if session.region.is_some() {
+						push_note_live(&mut session.notes, kind, name, trimmed);
+						Sink::Live
+					} else {
+						Sink::Plain
+					}
+				}
+				None => Sink::None,
 			}
-			use std::io::Write;
-			let _ = writeln!(anstream::stderr(), "{name} | {trimmed}");
+		};
+		match sink {
+			Sink::Live => repaint(),
+			Sink::Plain | Sink::None => {
+				if !super::progress_enabled() {
+					return;
+				}
+				use std::io::Write;
+				let _ = writeln!(anstream::stderr(), "{name} | {trimmed}");
+			}
 		}
 	}
 }

--- a/internal/ui/progress/mod_tests.rs
+++ b/internal/ui/progress/mod_tests.rs
@@ -335,3 +335,68 @@ fn a_row_added_after_begin_widens_the_name_column() {
 	reset_plain_buffer();
 	super::super::set_progress(prev_progress);
 }
+
+/// #1733: a builder stream chunk carrying several lines in one write was one
+/// tail entry. The board counted it as one row and the terminal drew it as
+/// several, so `cursor_up(painted)` landed short and every later repaint
+/// erased too few lines. One build scrolled the same block down the terminal
+/// about eighty times.
+#[test]
+fn a_multi_line_chunk_becomes_one_entry_per_line() {
+	assert_eq!(
+		super::super::progress::note_lines_for_tests("a\nb\nc"),
+		vec!["a", "b", "c"],
+		"a chunk with newlines must not stay one entry"
+	);
+}
+
+#[test]
+fn a_crlf_chunk_leaves_no_stray_carriage_return() {
+	// `split('\n')` leaves the `\r` on each part and the `trim()` removes it.
+	// `lines()` would swallow it too, but it would also make the split and
+	// the trimming one decision instead of two.
+	assert_eq!(
+		super::super::progress::note_lines_for_tests("a\r\nb\r\n"),
+		vec!["a", "b"],
+		"a CRLF chunk must produce clean entries"
+	);
+}
+
+#[test]
+fn empty_lines_inside_a_chunk_are_dropped() {
+	// Matches what a single blank line already did before the split.
+	assert_eq!(
+		super::super::progress::note_lines_for_tests("a\n\n   \nb"),
+		vec!["a", "b"],
+		"blank parts must be dropped, as a lone blank line already was"
+	);
+}
+
+#[test]
+fn the_note_cap_still_holds_when_the_input_arrives_as_one_chunk() {
+	// A single arbitrarily tall entry defeated MAX_NOTES_PER_ROW: the cap
+	// counts entries, so one entry of seven lines was one line as far as it
+	// was concerned.
+	let mut notes = std::collections::HashMap::new();
+	for line in super::super::progress::note_lines_for_tests("1\n2\n3\n4\n5\n6\n7") {
+		super::super::progress::push_note_live_for_tests(
+			&mut notes,
+			Kind::Image,
+			"localhost/img:1",
+			line,
+		);
+	}
+	let tail = notes
+		.get(&(Kind::Image, "localhost/img:1".to_string()))
+		.expect("the row's tail is populated");
+	assert_eq!(
+		tail.iter().cloned().collect::<Vec<_>>(),
+		vec![
+			"4".to_string(),
+			"5".to_string(),
+			"6".to_string(),
+			"7".to_string()
+		],
+		"the cap must see one entry per line"
+	);
+}

--- a/internal/ui/progress/row.rs
+++ b/internal/ui/progress/row.rs
@@ -212,6 +212,12 @@ pub fn summary(done: usize, total: usize, width: usize) -> String {
 /// Truncated by character, not by escape sequence, the same way [`render`]
 /// does it.
 pub fn render_note(line: &str, width: usize) -> String {
+	// The invariant this function relies on, asserted where it is relied on
+	// rather than only where it is produced. A note carrying `\n` is drawn as
+	// several rows and counted as one, and the repaint arithmetic then erases
+	// the wrong lines (#1733). `note_for` splits at ingestion; this catches a
+	// future path that does not.
+	debug_assert!(!line.contains('\n'), "a note must be one line: {line:?}");
 	let indented = format!(" {line}");
 	let trimmed = if width > 0 && indented.chars().count() > width {
 		indented.chars().take(width).collect::<String>()

--- a/internal/ui/table.rs
+++ b/internal/ui/table.rs
@@ -273,8 +273,21 @@ impl Table {
 	/// Print the table to stdout: a bold header followed by the rows, with the
 	/// status column (if any) colourised when stdout is a colour sink.
 	pub fn print(&self) {
+		let stdout = std::io::stdout();
+		let mut out = stdout.lock();
+		if self.print_to(&mut out).is_err() {
+			// The terminal is gone; nothing to do. The CLI's own stdout writer
+			// also swallows broken-pipe exits, so the live behaviour matches.
+		}
+	}
+
+	/// [`Table::print`] writing to `w`, factored out so tests can capture the
+	/// rendered bytes without redirecting the process's stdout. The header is
+	/// written as plain (uncoloured) text: tests inspect the bytes verbatim,
+	/// and any colour escape is noise against that signal.
+	pub fn print_to<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
 		let widths = self.widths();
-		crate::ui::print_bold_header(&self.format_row(&self.headers, &widths, false));
+		crate::ui::write_bold_header(w, &self.format_row(&self.headers, &widths, false))?;
 		// Every column marker that can tint a cell has to appear here, or a table
 		// that uses only that marker renders plain. `caution_col` was added
 		// without being listed, and it went unnoticed because its first caller,
@@ -282,8 +295,9 @@ impl Table {
 		let colour = self.colours_any_column() && super::stdout_colored();
 		for (i, row) in self.rows.iter().enumerate() {
 			let key = self.keys.get(i).and_then(Option::as_deref);
-			println!("{}", self.format_row_keyed(row, &widths, colour, key));
+			writeln!(w, "{}", self.format_row_keyed(row, &widths, colour, key))?;
 		}
+		Ok(())
 	}
 
 	/// Whether the table has any data rows. Callers can use this to print an

--- a/internal/update/install.rs
+++ b/internal/update/install.rs
@@ -331,7 +331,35 @@ pub(crate) fn write_temp(tmp: &Path, new_bytes: &[u8], target: &Path) -> crate::
 				ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
 			})?
 	};
-	#[cfg(not(unix))]
+	#[cfg(windows)]
+	let mut f = {
+		use std::os::windows::fs::OpenOptionsExt;
+		// Mirror the Unix branch's invariants on Windows. `create_new(true)`
+		// is the Windows analogue of `O_CREAT|O_EXCL`: after the unlink
+		// below, the open fails if anything reappeared at `tmp` rather
+		// than truncating it, so a
+		// planted junction cannot redirect the verified bytes into a host
+		// path the operator did not name. `custom_flags(0x0020_0000)` is
+		// `FILE_FLAG_OPEN_REPARSE_POINT`: the open is given a handle to
+		// the reparse point itself rather than the target it points at,
+		// failing the call rather than silently traversing the link.
+		// Together with the `remove_file` above (which unlinks a planted
+		// symlink rather than following it) the verified bytes can only
+		// land in a freshly created file at `tmp`. The constants are
+		// intentionally inlined rather than imported from `windows-sys`
+		// to keep this branch buildable on hosts that only have the
+		// `Console` features wired up.
+		let _ = std::fs::remove_file(tmp);
+		std::fs::OpenOptions::new()
+			.write(true)
+			.create_new(true)
+			.custom_flags(0x0020_0000)
+			.open(tmp)
+			.map_err(|e| {
+				ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
+			})?
+	};
+	#[cfg(not(any(unix, windows)))]
 	let mut f = std::fs::File::create(tmp).map_err(|e| {
 		ComposeError::Update(format!("cannot write update to {}: {e}", tmp.display()))
 	})?;

--- a/internal/update/install/tests.rs
+++ b/internal/update/install/tests.rs
@@ -411,3 +411,32 @@ fn cleanup_stale_backup_is_a_no_op_without_a_leftover() {
 	cleanup_stale_backup();
 	assert!(!backup.exists());
 }
+/// The Windows branch must not let a planted reparse point redirect the
+/// verified bytes, which is the invariant `FILE_FLAG_OPEN_REPARSE_POINT`
+/// buys. It is NOT that a pre-existing `tmp` is refused: both branches
+/// unlink `tmp` first on purpose, so a leftover from an interrupted
+/// update does not wedge every later one. An earlier version of this
+/// test asserted the refusal and failed on the Windows runner for that
+/// reason, which is the useful kind of failure: the assertion and the
+/// code disagreed and the code was right.
+///
+/// Windows-only: the call sits behind `#[cfg(windows)]` and cannot be
+/// exercised from a Linux host. `write_temp_never_propagates_a_special_bit_from_the_target`
+/// pins the sibling shape for the Unix branch.
+#[cfg(windows)]
+#[test]
+fn write_temp_lands_the_bytes_at_tmp_over_a_leftover_on_windows() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let target = dir.path().join("podup");
+	std::fs::write(&target, b"old").expect("write target");
+	// A leftover from an interrupted update. The contract is that it is
+	// replaced, not that it wedges the update.
+	let tmp = dir.path().join("podup.update-1234");
+	std::fs::write(&tmp, b"planted leftover").expect("write tmp");
+	write_temp(&tmp, b"verified bytes", &target).expect("write_temp must replace a leftover tmp");
+	assert_eq!(
+		std::fs::read(&tmp).expect("read tmp"),
+		b"verified bytes",
+		"the verified bytes must land at tmp, not the leftover"
+	);
+}

--- a/internal/update/verify_key_copies_agree.rs
+++ b/internal/update/verify_key_copies_agree.rs
@@ -6,38 +6,104 @@ use std::path::Path;
 /// takes there. A new one is a line here.
 const COPIES: [&str; 3] = ["install.sh", "install.ps1", "docs/self-update.md"];
 
-/// The unpadded base64 of the key the binary trusts first.
-fn binary_key() -> String {
-	base64::engine::general_purpose::STANDARD_NO_PAD.encode(RELEASE_PUBKEYS[0])
+/// The unpadded-base64 view of every non-empty slot in `keys`, in the same
+/// shape the embedded copies are stored as. Slot 0 is the live key; slot 1
+/// starts zeroed (the steady-state shape) and is populated during the next
+/// rotation. Iterating over the full array (with the empty-slot filter)
+/// means a rotation that adds a second live key to the constant also adds
+/// it to the check (#1747), so the "every copy carries the key"
+/// guarantee that has always held for slot 0 picks up the new slot on
+/// the same day.
+fn encoded_keys(keys: &[[u8; 32]]) -> Vec<String> {
+	keys.iter()
+		.filter(|raw| **raw != [0u8; 32])
+		.map(|raw| base64::engine::general_purpose::STANDARD_NO_PAD.encode(raw))
+		.collect()
+}
+
+/// The view `every_embedded_copy_matches_every_configured_release_key`
+/// checks against; reads the production constant. Wrapping the constant
+/// pass keeps the public test asserting against the live build and lets
+/// the unit test exercise the filter directly with a hand-built fixture.
+fn binary_keys() -> Vec<String> {
+	encoded_keys(&RELEASE_PUBKEYS)
 }
 
 #[test]
-fn every_embedded_copy_matches_the_key_the_binary_uses() {
+fn every_embedded_copy_matches_every_configured_release_key() {
 	let root = Path::new(env!("CARGO_MANIFEST_DIR"));
-	let want = binary_key();
+	let wants = binary_keys();
+	assert!(
+		!wants.is_empty(),
+		"the binary must verify against at least one release key"
+	);
 
 	for name in COPIES {
 		let body = std::fs::read_to_string(root.join(name))
 			.unwrap_or_else(|e| panic!("{name} is readable: {e}"));
-		assert!(
-			body.contains(&want),
-			"{name} does not carry the key this binary verifies with ({want}). \
-			 A rotation that updates the constant and misses a file fails on a \
-			 user's machine, not here."
-		);
+		for want in &wants {
+			assert!(
+				body.contains(want),
+				"{name} does not carry the key this binary verifies with \
+                 ({want}). A rotation that populates a second slot and \
+                 misses a file fails on a user's machine, not here."
+			);
+		}
 	}
 }
 
-/// The check above only means something if the key is a specific string.
-/// Were `binary_key` to return something every file trivially contains,
-/// it would pass while proving nothing.
+/// The check above only means something if the keys are specific strings.
+/// Were `binary_keys` to return something every file trivially contains,
+/// it would pass while proving nothing. Every configured key is the
+/// unpadded base64 of a 32-byte Ed25519 public key.
 #[test]
-fn the_key_is_a_full_length_ed25519_public_key() {
-	let key = binary_key();
-	assert_eq!(
-		key.len(),
-		43,
-		"unpadded base64 of 32 bytes is 43 chars: {key}"
+fn every_configured_key_is_a_full_length_ed25519_public_key() {
+	let keys = binary_keys();
+	assert!(!keys.is_empty(), "at least one configured release key");
+	for key in &keys {
+		assert_eq!(
+			key.len(),
+			43,
+			"unpadded base64 of 32 bytes is 43 chars: {key}"
+		);
+		assert!(!key.contains('='), "the copies are stored unpadded: {key}");
+	}
+}
+
+/// #1747 (L9): `encoded_keys` used to take `keys[0]` only. Today
+/// `RELEASE_PUBKEYS[1]` is `[0u8; 32]` (the empty rotation slot), so
+/// both old and new code see only one key and the test passes either
+/// way; the difference is the day `RELEASE_PUBKEYS[1]` is populated.
+/// This fixture exercises that path by passing two non-empty slots to
+/// the helper and checking it returns both. Slot 0 alone is what the
+/// pre-fix code returned; slot 1 alone is the rotation-day shape; both
+/// together is steady-state mid-rotation.
+#[test]
+fn encoded_keys_includes_every_non_empty_slot_not_just_the_first() {
+	use base64::engine::general_purpose::STANDARD_NO_PAD;
+	let a = [42u8; 32];
+	let b = [7u8; 32];
+	let a_str = STANDARD_NO_PAD.encode(a);
+	let b_str = STANDARD_NO_PAD.encode(b);
+	// Old code (had it returned just `keys[0]`): `[a_str]`.
+	// New code: `[a_str, b_str]`.
+	let out = encoded_keys(&[a, b]);
+	assert!(
+		out.contains(&a_str) && out.contains(&b_str),
+		"both slots must be returned; got {out:?}"
 	);
-	assert!(!key.contains('='), "the copies are stored unpadded: {key}");
+	assert_eq!(
+		out.len(),
+		2,
+		"the empty-slot filter must keep both live slots"
+	);
+}
+
+/// An empty (all-zero) slot is the steady-state shape for `RELEASE_PUBKEYS`
+/// before rotation. The filter rejects it so a binary built with the
+/// constant in its rotation-day shape still surfaces the configured key.
+#[test]
+fn encoded_keys_skips_all_zero_slots() {
+	let out = encoded_keys(&[[0u8; 32], [0u8; 32]]);
+	assert!(out.is_empty(), "no live key, no rows: {out:?}");
 }

--- a/tests/audit_exit_codes.rs
+++ b/tests/audit_exit_codes.rs
@@ -41,6 +41,11 @@ fn run(args: &[&str]) -> Output {
 	// treats as global configuration; `PATH` and the locale stay so the
 	// process can locate shared libraries and render messages.
 	for key in [
+		"PODUP_LIBPOD_POOL",
+		// `PODUP_LIBCOD_POOL` is the legacy typo'd spelling; the runtime
+		// still reads it as a fallback so a developer's exported value
+		// would otherwise leak into the spawned binary and silently
+		// override its default pool size.
 		"PODUP_LIBCOD_POOL",
 		"PODMAN_SOCKET",
 		"DOCKER_HOST",

--- a/tests/fixtures/releases/proto-redir-test.sh
+++ b/tests/fixtures/releases/proto-redir-test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Regression test for --proto-redir in install.sh (issue #1722).
+#
+# install.sh pins the protocol across redirects with
+#
+#     curl --proto '=https' --proto-redir '=https' --tlsv1.2 ...
+#
+# The comment above the call explains why both flags are needed:
+# --proto only restricts the initial URL, and a CDN redirect (the
+# second hop) is governed by --proto-redir. Without that pin, an
+# actor who could answer the first request and redirect the download
+# to plain http would hand the installer bytes fetched in cleartext.
+#
+# Nothing exercised the flag. This fixture serves a 302 from an https
+# origin to an http:// URL and requires the installer to refuse at
+# the download step. The refusal has to be attributed: an installer
+# that fails for an unrelated reason would still exit non-zero, and a
+# case that only checked the exit code would pass with --proto-redir
+# deleted - the signature check would catch a bad payload and produce
+# a non-zero exit anyway.
+#
+# The redirect target serves a VALID payload - the real fixture
+# artifact. If the flag were removed, curl would follow the redirect
+# and the download would succeed; the case would then fail because the
+# install did NOT refuse at the download step (and did install, if it
+# got that far). That is the trap the valid payload closes.
+#
+# Run from the repo root:
+#   bash tests/fixtures/releases/proto-redir-test.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+FIXTURE_DIR="$REPO_ROOT/tests/fixtures/releases"
+
+# Pre-flight: the test spins up local HTTP/HTTPS listeners and needs
+# python3 (stdlib http.server + ssl) and openssl (self-signed cert).
+# A missing tool here is a missing fixture, not a passing test.
+command -v python3 >/dev/null 2>&1 || {
+	echo "SKIP: python3 is not installed"
+	exit 0
+}
+command -v openssl >/dev/null 2>&1 || {
+	echo "SKIP: openssl is not installed"
+	exit 0
+}
+
+# Source install.sh's helpers (everything before the "# --- Dispatch"
+# section). Same pattern version-self-test.sh uses: the helpers are
+# pure function definitions and constants; sourcing them does not
+# touch the network or write to the filesystem.
+TMP_HELPERS="$(mktemp)"
+sed '/^# --- Dispatch /,$d' "$INSTALL_SH" > "$TMP_HELPERS"
+# shellcheck disable=SC1090
+source "$TMP_HELPERS"
+
+# Work directory: self-signed cert, server logs, captured output. The
+# install.sh source installed a trap of its own (rm -rf "$TMP_DIR")
+# on EXIT; we override both TMP_DIR and the trap so cleanup runs in
+# one place and the listener's life cycle is bounded.
+WORK="$(mktemp -d)"
+SRV_PID=""
+cleanup() {
+	if [[ -n "$SRV_PID" ]]; then
+		kill "$SRV_PID" 2>/dev/null || true
+		wait "$SRV_PID" 2>/dev/null || true
+	fi
+	rm -f "$TMP_HELPERS"
+	rm -rf "$WORK"
+}
+trap cleanup EXIT
+TMP_DIR="$WORK/dl"
+mkdir -p "$TMP_DIR"
+
+# Free ports on 127.0.0.1 for the HTTPS (302) and HTTP (payload)
+# listeners. Picking at runtime avoids colliding with anything the
+# runner already has open.
+HTTPS_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+HTTP_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+
+# Self-signed cert with SAN=127.0.0.1 so curl accepts it once
+# CURL_CA_BUNDLE points at it. Without that env var curl would refuse
+# the cert before reaching the redirect, and the case would fail at
+# the TLS handshake rather than at the redirect - the protection
+# under test would be invisible.
+openssl req -x509 -newkey rsa:2048 \
+	-keyout "$WORK/cert.key" -out "$WORK/cert.pem" -days 1 -nodes \
+	-subj "/CN=localhost" \
+	-addext "subjectAltName = IP:127.0.0.1" >/dev/null 2>&1
+
+# HTTPS origin (the URL install.sh will hit) and HTTP target (where
+# the 302 redirects to). Both listeners bind 127.0.0.1; nothing here
+# is reachable from off-host.
+HTTPS_URL="https://127.0.0.1:$HTTPS_PORT/asset"
+HTTP_TARGET="http://127.0.0.1:$HTTP_PORT/asset"
+
+# One Python process, two listeners: HTTPS returns 302 to the HTTP
+# port, HTTP serves the fixture artifact bytes. Daemon threads do the
+# serving; the main thread blocks on a signal so SIGTERM stops the
+# process promptly instead of waiting out a sleep.
+# `env` rather than a bare assignment prefix: with the prefix form, a later
+# assignment on the same line expands the OUTER value, which shellcheck flags
+# (SC2097/SC2098) and which is a real trap the day these stop being equal.
+env WORK="$WORK" HTTPS_PORT="$HTTPS_PORT" HTTP_PORT="$HTTP_PORT" \
+	HTTP_TARGET="$HTTP_TARGET" FIXTURE_DIR="$FIXTURE_DIR" \
+	python3 - >"$WORK/srv.log" 2>&1 <<'PYEOF' &
+import http.server, ssl, socketserver, threading, signal, os
+
+WORK = os.environ['WORK']
+HTTPS_PORT = int(os.environ['HTTPS_PORT'])
+HTTP_PORT = int(os.environ['HTTP_PORT'])
+HTTP_TARGET = os.environ['HTTP_TARGET']
+FIXTURE_DIR = os.environ['FIXTURE_DIR']
+
+
+class RedirHandler(http.server.BaseHTTPRequestHandler):
+	def do_GET(self):
+		try:
+			self.send_response(302)
+			self.send_header('Location', HTTP_TARGET)
+			self.end_headers()
+		except (BrokenPipeError, ConnectionResetError):
+			pass
+
+	def log_message(self, *a, **k):
+		pass
+
+
+class AssetHandler(http.server.BaseHTTPRequestHandler):
+	def do_GET(self):
+		try:
+			# Serve the real fixture artifact: a download that
+			# arrives here is a valid binary by definition. If
+			# --proto-redir were removed, curl would follow the
+			# 302 and get bytes - and the install would NOT
+			# refuse at the download step.
+			with open(os.path.join(FIXTURE_DIR, 'podup-linux-x86_64'), 'rb') as f:
+				data = f.read()
+			self.send_response(200)
+			self.send_header('Content-Type', 'application/octet-stream')
+			self.send_header('Content-Length', str(len(data)))
+			self.end_headers()
+			self.wfile.write(data)
+		except (BrokenPipeError, ConnectionResetError):
+			pass
+
+	def log_message(self, *a, **k):
+		pass
+
+
+ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+ctx.load_cert_chain(f'{WORK}/cert.pem', f'{WORK}/cert.key')
+
+httpd = socketserver.TCPServer(('127.0.0.1', HTTPS_PORT), RedirHandler)
+httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+httpd2 = socketserver.TCPServer(('127.0.0.1', HTTP_PORT), AssetHandler)
+threading.Thread(target=httpd2.serve_forever, daemon=True).start()
+
+stop = threading.Event()
+signal.signal(signal.SIGTERM, lambda *_: stop.set())
+signal.signal(signal.SIGINT, lambda *_: stop.set())
+with open(f'{WORK}/srv.ready', 'w') as f:
+	f.write('ok')
+stop.wait()
+PYEOF
+SRV_PID=$!
+
+# Poll for readiness rather than sleeping a guessed interval, so the
+# suite is deterministic on a slow runner. A server that never came
+# up is a missing fixture, not a passing test.
+for _ in $(seq 1 50); do
+	[[ -f "$WORK/srv.ready" ]] && break
+	sleep 0.1
+done
+if [[ ! -f "$WORK/srv.ready" ]]; then
+	echo "FAIL: the local redirect server never came up"
+	echo "      server log:"
+	sed 's/^/        /' "$WORK/srv.log"
+	exit 1
+fi
+
+# Point BASE_URL at the HTTPS origin so install.sh's download
+# function hits the 302 listener. CURL_CA_BUNDLE trusts the cert.
+BASE_URL="$HTTPS_URL"
+export CURL_CA_BUNDLE="$WORK/cert.pem"
+
+# Call install.sh's download function with the redirect URL. The
+# function passes --proto-redir '=https' to curl, which refuses the
+# 302 to http:// and makes the function fall through to
+# `fail "Download failed: ..."`. We run inside a subshell so the
+# function's `exit 1` only kills the subshell; the test then reads
+# the exit status and the captured output.
+set +e
+(download "${BASE_URL}/asset" "${TMP_DIR}/asset") >"$WORK/out" 2>&1
+rc=$?
+set -e
+
+# Three assertions, all of them needed:
+#
+#   1. non-zero exit: the install refused.
+#   2. "Download failed" in stderr: the refusal is at the download
+#      step, not at some later check. Without this attribution, an
+#      installer that refuses for any other reason would satisfy the
+#      exit-code check alone.
+#   3. nothing written to TMP_DIR: the refused download produced no
+#      artifact, so a half-written binary cannot be left on disk.
+#
+# All three must hold. Removing --proto-redir flips all three at once:
+# curl follows the 302 to the HTTP listener, the download succeeds,
+# and the install would proceed past the download step.
+fail=0
+if [[ "$rc" -eq 0 ]]; then
+	echo "FAIL: download should have refused the redirect, but succeeded"
+	echo "      output:"
+	sed 's/^/        /' "$WORK/out"
+	fail=$((fail + 1))
+fi
+if ! grep -q "Download failed" "$WORK/out"; then
+	echo "FAIL: download should have failed with 'Download failed', got:"
+	sed 's/^/        /' "$WORK/out"
+	fail=$((fail + 1))
+fi
+if [[ -e "${TMP_DIR}/asset" ]]; then
+	echo "FAIL: nothing should have been written on download refusal,"
+	echo "      but ${TMP_DIR}/asset exists ($(stat -c '%s' "${TMP_DIR}/asset") bytes)"
+	fail=$((fail + 1))
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+	exit 1
+fi
+
+echo "All parts passed."

--- a/tests/shell/branch-health-conclusion.test.sh
+++ b/tests/shell/branch-health-conclusion.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# `check-branch-conclusion.sh` decides whether the newest completed run of a
+# workflow on a branch is a pass. It is the only piece of behaviour in the
+# branch-health guard, and the rest of it is a YAML wiring the shell script
+# is fed by `gh api`. A test that exercises the wiring but not the decision
+# proves nothing about the decision.
+#
+# The harness here plants API answers on stdin and asserts exit code plus
+# the matching summary line. Three states the brief calls out by name --
+# `success` passes, `failure` fails, an empty list reports "no run on
+# record" -- are covered with the same JSON the GitHub API returns today,
+# plus `cancelled` and `skipped`, which the reusable's comment says it
+# treats as failures (the comment above the script's `case` is the
+# contract this test pins).
+#
+# Each plant is a complete `repos/.../runs` response, not just the array,
+# because the script reads `.workflow_runs[0]` and would behave differently
+# against a bare array vs. an envelope. Building plants out of the envelope
+# is the cheapest way to read what the script reads.
+#
+# Requires: bash, jq, the script under test, nothing else.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+script=.github/scripts/check-branch-conclusion.sh
+[ -x "$script" ] || { echo "FAIL  $script is not executable in git"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "FAIL  jq is required to run this test"; exit 1; }
+
+pass=0; fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Run the script under test against a planted API answer. The script
+# reads WORKFLOW and BRANCH from the environment, so the harness passes
+# them in.
+run_with() { # <workflow> <branch> <json-on-stdin>
+	WORKFLOW="$1" BRANCH="$2" bash "$script" <<<"$3"
+}
+
+# Each plant is a complete response from the workflow-runs endpoint, with
+# exactly one entry under `.workflow_runs`. The shape comes from the
+# GitHub docs and the value the script reads is `.workflow_runs[0].conclusion`.
+
+plant_success='{"workflow_runs":[{"id":1,"conclusion":"success","html_url":"https://x/r/1"}]}'
+plant_failure='{"workflow_runs":[{"id":2,"conclusion":"failure","html_url":"https://x/r/2"}]}'
+plant_cancelled='{"workflow_runs":[{"id":3,"conclusion":"cancelled","html_url":"https://x/r/3"}]}'
+plant_skipped='{"workflow_runs":[{"id":4,"conclusion":"skipped","html_url":"https://x/r/4"}]}'
+plant_empty='{"workflow_runs":[],"total_count":0}'
+
+# --- success passes ---
+out=$(run_with "ci.yml" "main" "$plant_success"); rc=$?
+check "success on main exits 0" "0" "$rc"
+check "success on main prints the url" "https://x/r/1" \
+	"$(printf '%s\n' "$out" | grep -oE 'https://x/r/[0-9]+' || true)"
+
+# --- failure fails ---
+out=$(run_with "ci.yml" "main" "$plant_failure"); rc=$?
+check "failure on main exits 1" "1" "$rc"
+check "failure on main names the conclusion" "failure" \
+	"$(printf '%s\n' "$out" | grep -oE 'conclusion=f[a-z]+' | head -1 | cut -d= -f2)"
+
+# --- cancelled fails and explains why ---
+out=$(run_with "ci.yml" "main" "$plant_cancelled"); rc=$?
+check "cancelled on main exits 1" "1" "$rc"
+case "$out" in
+	*cancelled*) check "cancelled on main is named" "yes" "yes" ;;
+	*) check "cancelled on main is named" "cancelled-named" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+# --- skipped fails and explains why ---
+out=$(run_with "ci.yml" "main" "$plant_skipped"); rc=$?
+check "skipped on main exits 1" "1" "$rc"
+case "$out" in
+	*skipped*) check "skipped on main is named" "yes" "yes" ;;
+	*) check "skipped on main is named" "skipped-named" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+# --- empty history fails with "no completed run on record" ---
+out=$(run_with "ci.yml" "main" "$plant_empty"); rc=$?
+check "empty history on main exits 1" "1" "$rc"
+case "$out" in
+	*"No completed run"*) check "empty history says no run on record" "yes" "yes" ;;
+	*) check "empty history says no run on record" "no-run-on-record" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+# --- the script's branch parameter actually surfaces in the message ---
+# Same input, different branch argument: the failure message names the
+# branch the caller asked about, not whichever the harness happens to use.
+out_main=$(run_with "ci.yml" "main" "$plant_failure")
+out_develop=$(run_with "ci.yml" "develop" "$plant_failure")
+case "$out_main" in
+	*"on main"*) check "failure message names branch=main" "yes" "yes" ;;
+	*) check "failure message names branch=main" "branch=main" "$(printf '%s\n' "$out_main" | head -1)" ;;
+esac
+case "$out_develop" in
+	*"on develop"*) check "failure message names branch=develop" "yes" "yes" ;;
+	*) check "failure message names branch=develop" "branch=develop" "$(printf '%s\n' "$out_develop" | head -1)" ;;
+esac
+
+# --- the script refuses to run without WORKFLOW or BRANCH ---
+out=$(WORKFLOW='' BRANCH=main bash "$script" <<<"$plant_success" 2>/dev/null); rc=$?
+check "missing WORKFLOW is fatal" "1" "$rc"
+out=$(WORKFLOW=ci.yml BRANCH='' bash "$script" <<<"$plant_success" 2>/dev/null); rc=$?
+check "missing BRANCH is fatal" "1" "$rc"
+
+# --- the negative control: a planted response the parser is asked to
+# reject, with a conclusion that does not exist in the API. The script
+# falls through to the default branch, which is "not success" rather
+# than silently passing. ---
+plant_unknown='{"workflow_runs":[{"id":5,"conclusion":"made_up","html_url":"https://x/r/5"}]}'
+out=$(run_with "ci.yml" "main" "$plant_unknown"); rc=$?
+check "unknown conclusion exits 1" "1" "$rc"
+case "$out" in
+	*"unexpected conclusion made_up"*) check "unknown conclusion is named" "yes" "yes" ;;
+	*) check "unknown conclusion is named" "unexpected-made_up" "$(printf '%s\n' "$out" | head -1)" ;;
+esac
+
+echo
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/branch-health-conclusion.test.sh
+++ b/tests/shell/branch-health-conclusion.test.sh
@@ -128,4 +128,5 @@ esac
 
 echo
 echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/check-hardening-macos.test.sh
+++ b/tests/shell/check-hardening-macos.test.sh
@@ -18,6 +18,8 @@ script=.github/scripts/check-hardening-macos.sh
 
 if ! command -v clang >/dev/null 2>&1 || ! command -v otool >/dev/null 2>&1 || ! command -v nm >/dev/null 2>&1; then
 	echo "SKIP: clang/otool/nm are not all on PATH; this test runs on the macOS CI runner only."
+	pass=0; fail=0
+	printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 	exit 0
 fi
 
@@ -102,4 +104,5 @@ check "no arguments is a usage error, exit 2" "2" "$rc"
 
 echo
 echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/check-hardening.test.sh
+++ b/tests/shell/check-hardening.test.sh
@@ -85,4 +85,5 @@ check "no arguments is a usage error, exit 2" "2" "$rc"
 
 echo
 echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/check-suite-completeness.test.sh
+++ b/tests/shell/check-suite-completeness.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Run every test file the workflow invokes and require each one to print its
+# sentinel. The sentinel is the last line every test file writes:
+#
+#     printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+#
+# It sits between the count line and `[ "$fail" -eq 0 ]`, so it is reached
+# only after the last `check` runs. A test that exits early -- because
+# someone planted `exit 0`, because `set -e` killed it on an unexpected
+# error, or because anything else cut the run short -- never produces the
+# sentinel, and this file names it.
+#
+# Why this shape, not a trap on EXIT: a trap fires on the truncated path
+# too, so it would print the sentinel exactly when the file stopped early,
+# which is the defect, not the fix. The sentinel is a plain `printf` that
+# runs only when control reaches it.
+#
+# Why this shape, not a sidecar file: every test would have to know the
+# sidecar path and append to it, and a non-writable sidecar is a new
+# failure mode unrelated to what this catches.
+#
+# Why this shape, not parsing lint-shell.yml inside this file: the list
+# of files is right there in the workflow, but a runner that parses YAML
+# to find its own input couples itself to the workflow's shape. The
+# workflow lists the tests as this file's arguments, and
+# `tests/shell/ci-runs-every-test.test.sh` already keeps that list
+# honest (every file invoked must exist, every file must be invoked).
+#
+# The macOS fixture skips cleanly where clang/otool/nm are absent; the
+# skip path prints the sentinel before exiting 0, so the Linux job still
+# sees it.
+#
+# Usage: check-suite-completeness.test.sh <test-file> [<test-file> ...]
+
+set -u
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <test-file> [<test-file> ...]" >&2
+	exit 2
+fi
+
+self="${BASH_SOURCE[0]##*/}"
+
+# Every test file must end with a sentinel of the form
+# `DONE <basename> <pass-count> <fail-count>`. The basename is what the
+# file itself sees in BASH_SOURCE, so the check is by basename rather than
+# the path the runner was given: a file invoked as `./tests/foo.test.sh`
+# and as `tests/foo.test.sh` both report `foo.test.sh` in their sentinel,
+# and either way the runner reaches the same answer.
+sentinel_re='^DONE [A-Za-z0-9_.-]+\.test\.sh [0-9]+ [0-9]+$'
+
+for f in "$@"; do
+	basename="${f##*/}"
+
+	# Skip self if invoked recursively (it would not terminate).
+	[ "$basename" = "$self" ] && continue
+
+	output="$("$f" 2>&1)"
+	rc=$?
+
+	# The test's own output is the diagnosis: the FAIL line it printed
+	# when one of its checks failed, or the `ok` line that was its last
+	# printed word before a planted `exit 0`. Print it so the operator
+	# who comes after the runner has the same picture.
+	printf '%s\n' "$output"
+
+	# The sentinel, if the test reached it, is the last line of output.
+	# Command substitution strips trailing newlines, so the sentinel's
+	# terminating \n is not in $output; the last line is the sentinel's
+	# body.
+	last_line="$(printf '%s' "$output" | tail -n 1)"
+	has_sentinel=0
+	if [ -n "$last_line" ] && [[ "$last_line" =~ $sentinel_re ]]; then
+		has_sentinel=1
+	fi
+
+	check "$basename reached its end" "1" "$has_sentinel"
+	if [ "$has_sentinel" -eq 0 ]; then
+		echo "        last line was: $last_line"
+	fi
+
+	if [ "$rc" -ne 0 ]; then
+		check "$basename exited 0" "1" "0"
+	else
+		check "$basename exited 0" "1" "1"
+	fi
+done
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "$self" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/ci-runs-every-test.test.sh
+++ b/tests/shell/ci-runs-every-test.test.sh
@@ -91,4 +91,5 @@ check "every test a workflow invokes exists" "" \
 
 echo
 echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/install-help.test.sh
+++ b/tests/shell/install-help.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# `install.sh --help` works under the documented pipe.
+#
+# The header carries the help text. The old `usage()` body read it via
+# `sed -n '3,21p' "$0"`. That works for `./install.sh --help` and
+# `bash install.sh --help`, where $0 is the script path. The script
+# also documents the use `curl -fsSL .../install/unix | bash`, where
+# the bytes arrive on stdin and $0 is the program name "bash": there
+# is no file named "bash" and the old code failed with `sed: can't read
+# bash`. Test that path here, plus the file-invocation path, plus a
+# header/heredoc drift guard so a future hand-edit that touches one and
+# not the other fails loudly.
+#
+# Requires: bash, sed, the script under test, nothing else.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 1
+script=install.sh
+[ -f "$script" ] || { echo "FAIL  $script is missing"; exit 1; }
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Pin the help text the function emits. These are the lines the heredoc
+# produces after `cat <<'USAGE'`. A reviewer editing one but not the
+# other should see a diff here, not a silent divergence.
+case "$(bash "$script" --help)" in
+	*"podup installer."*) help_marker=1 ;; *) help_marker=0 ;;
+esac
+check "file invocation prints the help header" "1" "$help_marker"
+
+case "$(bash "$script" --help)" in
+	*"PODUP_VERSION"*) env_marker=1 ;; *) env_marker=0 ;;
+esac
+check "file invocation prints the env-var block" "1" "$env_marker"
+
+# The documented pipe: `curl ... | bash`. `cat install.sh | bash -s --
+# --help` reproduces it locally. The old `usage` body tried to read a
+# file literally named "bash"; on the unfixed tree this exits with
+# `sed: can't read bash: No such file or directory` and the help
+# output never reaches the user. `cat | bash` is the shape we want to
+# drive, even though `bash < file` would be a one-liner; shellcheck's
+# SC2002 suggestion would change what we are testing.
+# shellcheck disable=SC2002
+pipe_out="$(cat "$script" | bash -s -- --help 2>&1)"
+pipe_rc=$?
+check "pipe invocation exits 0" "0" "$pipe_rc"
+
+# On the unfixed tree the pipe produces `sed: can't read bash ...` (or
+# an empty body) rather than the help. On the fixed tree the help header
+# is in the output.
+case "$pipe_out" in
+	*"podup installer."*) pipe_marker=1 ;; *) pipe_marker=0 ;;
+esac
+check "pipe invocation prints the help header" "1" "$pipe_marker"
+
+case "$pipe_out" in
+	*"PODUP_VERSION"*) pipe_env_marker=1 ;; *) pipe_env_marker=0 ;;
+esac
+check "pipe invocation prints the env-var block" "1" "$pipe_env_marker"
+
+case "$pipe_out" in
+	*"sed:"*"can't read"*)
+		check "pipe invocation does not surface a sed read error" "0" "1" ;;
+	*)
+		check "pipe invocation does not surface a sed read error" "0" "0" ;;
+esac
+
+# The two help bodies must match. The file-invocation path already
+# worked (it was the curl|bash path that broke); this guard catches a
+# future mutation that drops the heredoc and goes back to the broken
+# sed-from-header on either side.
+file_body="$(bash "$script" --help)"
+# shellcheck disable=SC2002
+pipe_body="$(cat "$script" | bash -s -- --help)"
+if [ "$file_body" = "$pipe_body" ]; then
+	check "help body is identical across invocation shapes" "1" "1"
+else
+	check "help body is identical across invocation shapes" "1" "0"
+	echo "--- file invocation body ---"
+	printf '%s\n' "$file_body"
+	echo "--- pipe invocation body ---"
+	printf '%s\n' "$pipe_body"
+fi
+
+# Header/heredoc drift guard: every line of the help heredoc must still
+# appear in the file invocation output, and conversely, no body line
+# surfaced only by the file path. The heredoc is duplicated against the
+# header by design; this is the test that fails when one side moves
+# and the other doesn't. The `case` shell-pattern matches avoid the
+# grep-vs-flag-name pitfall that `grep -qxF` hits when a heredoc line
+# starts with a dash.
+file_lines="$(printf '%s\n' "$file_body" | sed -n '/^podup installer\./,/^  PODUP_INSTALL_DIR/p' | sed '/^$/d')"
+missing=""
+while IFS= read -r line; do
+	[ -z "$line" ] && continue
+	if ! grep -qxF -- "$line" <<<"$file_body"; then
+		missing="${missing}${line}\n"
+	fi
+done <<<"$file_lines"
+if [ -z "$missing" ]; then
+	check "help body fully matches the heredoc" "1" "1"
+else
+	check "help body fully matches the heredoc" "1" "0"
+	echo "        missing: $(printf '%b' "$missing" | head -3)"
+fi
+
+echo
+echo "passed: $pass  failed: $fail"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/install-rollback-cleans-staged.test.sh
+++ b/tests/shell/install-rollback-cleans-staged.test.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Behaviour test for install.sh's refusal path (#1746 entry 1).
+#
+# When install.sh refuses a staged binary because its --version does not match
+# the resolved release tag, the staged file in INSTALL_DIR is supposed to be
+# removed. The original code calls `rm -f "$staged"` directly, which runs as
+# the calling user. In the realistic flow the staged file is owned by root
+# (because the copy was done through `sudo sh -c "... && chmod ..."`), so the
+# unprivileged `rm` fails silently. The user is then told "the staged file
+# has been removed" while the binary sits in /usr/local/bin owned by root.
+#
+# The fix is to route the cleanup through `run_root`, so the rm is elevated
+# the same way the install itself was.
+#
+# The assertion here is direct: the function's refusal path must invoke
+# `sudo rm -f` (or equivalent privilege elevation), not a bare `rm -f`. The
+# stubs below record calls without altering behaviour so the difference is
+# visible.
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL_SH="$HERE/install.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# --- stubs -------------------------------------------------------------------
+#
+# Stub `sudo` to record the call and then run the command as the caller. The
+# stub does not actually need elevated privileges for this assertion: the
+# point is that `sudo` was invoked at all. In the buggy version, `run_root`
+# is not in the call chain at all, so `sudo` is never recorded.
+STUB="$WORK/stub"
+mkdir -p "$STUB"
+
+cat > "$STUB/sudo" <<'EOF'
+#!/bin/sh
+printf 'SUDO %s\n' "$*" >> "$WORK/sudo.log"
+exec "$@"
+EOF
+chmod +x "$STUB/sudo"
+
+# Stub `rm` so the call is recorded even when the underlying rm would succeed.
+# Real `rm` would happily remove a file the test owns; this stub records the
+# call before delegating, so the test sees what was invoked.
+cat > "$STUB/rm" <<'EOF'
+#!/bin/sh
+printf 'RM %s\n' "$*" >> "$WORK/rm.log"
+exec /bin/rm "$@"
+EOF
+chmod +x "$STUB/rm"
+
+# --- fixture -----------------------------------------------------------------
+#
+# A staged binary whose --version reports something that does not match the
+# expected tag. The function under test compares each whitespace-delimited
+# token in the output against the tag, so `podup version 0.0.0` against an
+# expected `v9.9.9` is a mismatch and lands in the refusal branch.
+STAGED="$WORK/.podup.install-$$"
+cat > "$STAGED" <<'EOF'
+#!/bin/sh
+echo "podup version 0.0.0"
+EOF
+chmod +x "$STAGED"
+
+# --- run ---------------------------------------------------------------------
+#
+# Source the two relevant functions from install.sh. log_ok / log_error / fail
+# are overridden locally so the test captures the refusal message instead of
+# exiting the process. run_root is sourced as-is so the fix has to take effect
+# inside it; the bug is in verify_version_self_test not calling run_root, so
+# sourcing the real run_root is correct for both versions.
+# Both stdout and stderr are captured so the refusal message is observable,
+# and the exit code is preserved (no `|| true` so $? reflects the fail() exit).
+OUT="$(PATH="$STUB:$PATH" WORK="$WORK" STAGED="$STAGED" INSTALL_SH="$INSTALL_SH" \
+	bash 2>&1 <<'INNER'
+set +e
+
+log_ok() { :; }
+log_error() { :; }
+fail() { printf 'REFUSAL %s\n' "$1"; exit 1; }
+
+eval "$(awk '/^verify_version_self_test\(\) {/,/^}$/' "$INSTALL_SH")"
+eval "$(awk '/^run_root\(\) {/,/^}$/' "$INSTALL_SH")"
+
+verify_version_self_test "$STAGED" "v9.9.9"
+INNER
+)"
+RC=$?
+
+REFUSAL="$(printf '%s\n' "$OUT" | grep -E '^REFUSAL ' | head -n 1 | sed 's/^REFUSAL //')"
+
+# --- assertions --------------------------------------------------------------
+
+check 'verify_version_self_test refuses a wrong version (non-zero exit)' "1" "$RC"
+check 'and the refusal message names the rollback cause' "1" \
+	"$([ -n "$REFUSAL" ] && echo 1 || echo 0)"
+check 'and the refusal message says the staged file has been removed' "1" \
+	"$([ -n "$REFUSAL" ] && printf '%s' "$REFUSAL" | grep -q -F 'the staged file has been removed' && echo 1 || echo 0)"
+
+# The substantive assertion: the cleanup of the staged file must go through
+# `run_root`, which prefixes `sudo` when running as a non-root user. The bug
+# is that the original code calls `rm -f "$staged"` directly, with no `sudo`
+# in front, so a non-root caller running install.sh with the default
+# /usr/local/bin target leaves the file behind.
+SUDO_RM_COUNT=0
+if [ -f "$WORK/sudo.log" ]; then
+	SUDO_RM_COUNT="$(grep -c '^SUDO rm -f' "$WORK/sudo.log" || true)"
+	SUDO_RM_COUNT="${SUDO_RM_COUNT:-0}"
+fi
+check 'the refusal path invokes sudo rm -f on the staged file' "1" "$SUDO_RM_COUNT"
+
+# --- cleanup state -----------------------------------------------------------
+
+# After the function returns (refused or accepted), the staged file must not
+# exist on disk. With the stub `sudo` chaining to real `/bin/rm` this is the
+# same outcome whether the fix is in place or not, so this check is the
+# positive control rather than the bug detector.
+check 'the staged file is gone after refusal' "0" \
+	"$([ -e "$STAGED" ] && echo 1 || echo 0)"
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/locale-pinned.test.sh
+++ b/tests/shell/locale-pinned.test.sh
@@ -57,4 +57,5 @@ check "every sort runs under a pinned collation" "" "${unpinned%$'\n'}"
 
 echo
 echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-caller-if.test.sh
+++ b/tests/shell/reusable-workflow-lint-caller-if.test.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the caller-if assertion in
+# .github/workflows/reusable-workflow-lint.yml: a caller of a job that
+# emits a required check name must not carry a switchable job-level
+# 'if:'.
+#
+# Eleven status checks are required on 'main' and ten on 'develop'.
+# Every one of them is emitted either directly by a job in this tree or
+# by a reusable a job here calls. GitHub reports a SKIPPED required
+# check as Success, so a job-level 'if: false' (or anything else that
+# can evaluate false) switches the gate off without failing it. The
+# assertion refuses that, with one message naming the file, the job,
+# and the property being violated.
+#
+# 'if: always()' is the one allowed form. It can never evaluate false,
+# so the job always runs and the check is always reported. This is the
+# load-bearing pattern from #1552: a gate job summarises a matrix that
+# may fail, so it has to run on 'failure' too and reads 'needs.*.result'
+# to make its verdict. The podman-lane gate and the rust-ci gates are
+# the documented cases in this repository, and the assertion keeps them
+# passing while refusing every other value.
+#
+# 'if:' lines INSIDE a reusable are not in scope: they configure how
+# the reusable behaves ('if: inputs.msrv !=') and refusing them would
+# take down the repository by deleting controls. The assertion skips
+# files whose basename starts with 'reusable-', so it never reaches
+# them. One of the tests plants a switching 'if:' inside
+# reusable-rust-ci.yml-shaped content to prove the seam holds.
+#
+# Each step's 'run:' body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository. Every
+# refusal asserts WHICH message fired. Each refusal is paired with an
+# acceptance of the same shape just inside the line.
+#
+# Requires: python3 with PyYAML (the step under test imports it).
+# The fixtures below carry literal '${{ ... }}' expressions and
+# backticks: the assertion under test reads those characters, so they
+# must reach the file unexpanded. Single quotes are the point, not an
+# oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# All test descriptions are passed via this helper as single-quoted
+# strings. Backticks inside double quotes would be command substitution
+# in bash, so the helper takes its argument unquoted and the call sites
+# use single quotes throughout.
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Pull one step's 'run:' body out of a workflow, dedented, so it can be
+# run. Same helper as the other tests in this directory: the point is
+# to exercise the script as it ships rather than a copy of it that can
+# drift.
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A caller of a required check" > "$WORK/caller-if.sh"
+check 'the caller-if assertion was extracted from the workflow' "1" \
+	"$(grep -c 'REQUIRED_REUSABLES' "$WORK/caller-if.sh" | awk '{print ($1>0)}')"
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# A fresh empty tree with '.github/workflows/', and the real reusables
+# copied across. The reusables are needed because the assertion walks
+# them to learn which required check names they emit; without them the
+# caller scan has nothing to look at.
+new() {
+	rm -rf "$WORK/t"
+	mkdir -p "$WORK/t/.github/workflows"
+	for r in \
+		reusable-rust-ci.yml \
+		reusable-dco.yml \
+		reusable-line-limit.yml \
+		reusable-main-guard.yml \
+		reusable-workflow-lint.yml; do
+		cp "$HERE/.github/workflows/$r" "$WORK/t/.github/workflows/"
+	done
+	printf '%s' "$WORK/t"
+}
+run_in() { # $1=dir $2=script -> stdout+stderr, status in $?
+	( cd "$1" && bash "$2" 2>&1 )
+}
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+# A caller of a required-emitting reusable with a placeholder if-value
+# or no 'if:' at all (when $2 is empty). The reusable referenced here
+# is one whose required names are listed in REQUIRED_REUSABLES; any of
+# the five will do for the assertions.
+caller() { # $1=dir $2=if-value (or empty) $3=reusable basename
+	if [ -n "$2" ]; then
+		ifline="    if: $2"
+	else
+		ifline=""
+	fi
+	cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  caller:
+$ifline
+    uses: ./.github/workflows/$3
+EOF
+}
+
+# A direct-emitting job: 'name: Supported Podman majors' on the
+# 'podman-majors' job, matching DIRECT_EMITTER_NAMES. The optional
+# 'if:' value sits between the 'name:' and 'runs-on:'.
+direct() { # $1=dir $2=if-value (or empty)
+	if [ -n "$2" ]; then
+		ifline="    if: $2"
+	else
+		ifline=""
+	fi
+	cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  podman-majors:
+    name: Supported Podman majors
+$ifline
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo green
+EOF
+}
+
+# ===========================================================================
+# Positive control: the real tree passes (the load-bearing if: always()
+# on the podman-lane gate stays allowed).
+# ===========================================================================
+
+out="$(cd "$HERE" && bash "$WORK/caller-if.sh")"; rc=$?
+check 'the real repository tree passes the caller-if assertion' "0" "$rc"
+check 'and the step prints the OK summary, not a refusal' "1" \
+	"$(said "$out" 'caller-if: every caller of a required check')"
+
+# ===========================================================================
+# Negative fixtures: each refusal is paired with a same-shape positive
+# control so the acceptance is not implicit.
+# ===========================================================================
+
+# --- a job-level if: false on a caller is refused ------------------------
+d="$(new)"; caller "$d" 'false' 'reusable-rust-ci.yml'
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'a job-level if: false on a reusable caller is refused' "1" "$rc"
+check 'and the message names the offending job' "1" \
+	"$(said "$out" 'job `caller` in')"
+check 'and the message names the reusable required checks' "1" \
+	"$(said "$out" 'required checks')"
+check 'and the message names the value as a switch, not a filter' "1" \
+	"$(said "$out" 'switch, not a filter')"
+check 'and the message points at always() as the blessed form' "1" \
+	"$(said "$out" 'Only `if: always()` is allowed')"
+
+# --- a job-level if: ${{ ... }} over github.event_name is refused --------
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/reusable-rust-ci.yml
+EOF
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'a switching if: over github.event_name is refused' "1" "$rc"
+check 'and the offending job is named' "1" "$(said "$out" '`caller`')"
+
+# --- a job-level if: inputs.X on a reusable caller is refused ------------
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    if: inputs.coverage-threshold > 0
+    uses: ./.github/workflows/reusable-rust-ci.yml
+EOF
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an if: inputs.X on a reusable caller is refused' "1" "$rc"
+
+# --- a direct-emitting job (podman-majors) with if: false is refused ----
+d="$(new)"; direct "$d" 'false'
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an if: false on the direct podman-majors job is refused' "1" "$rc"
+check 'and the message names the required check, not just the job' "1" \
+	"$(said "$out" 'required check `Supported Podman majors`')"
+
+# --- a direct-emitting job with if: success() is refused -----------------
+d="$(new)"; direct "$d" 'success()'
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an if: success() on a direct emitter is refused' "1" "$rc"
+
+# ===========================================================================
+# Positive controls inside the negative fixtures: each shape above is
+# accepted when the conditional is removed or replaced with always().
+# ===========================================================================
+
+# --- a caller with no if: at all is allowed ------------------------------
+d="$(new)"; caller "$d" '' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'a caller with no job-level if: is allowed' "0" "$rc"
+
+# --- a caller with if: always() is the blessed form ---------------------
+d="$(new)"; caller "$d" 'always()' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: always() on a reusable caller is allowed' "0" "$rc"
+out="$(run_in "$d" "$WORK/caller-if.sh")"
+check 'and the step says every caller passes' "1" \
+	"$(said "$out" 'every caller of a required check')"
+
+# --- the wrapped spelling of always() means the same thing ---------------
+# A bare if: is evaluated as an expression either way, so refusing the
+# wrapped form would refuse valid code. Its tail-carrying cousin can still
+# evaluate false and stays refused, which is what makes this a real seam
+# rather than a substring match.
+d="$(new)"; caller "$d" '${{ always() }}' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'the wrapped spelling of always() is allowed too' "0" "$rc"
+
+d="$(new)"; caller "$d" 'always() && needs.build.result == "success"' 'reusable-rust-ci.yml'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'always() with a tail can still be false, so it is refused' "1" "$rc"
+
+# --- a direct-emitting job with if: always() is allowed -----------------
+d="$(new)"; direct "$d" 'always()'
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: always() on the direct podman-majors job is allowed' "0" "$rc"
+
+# --- a direct-emitting job with no if: is allowed ------------------------
+d="$(new)"; direct "$d" ''
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'the direct podman-majors job with no if: is allowed' "0" "$rc"
+
+# ===========================================================================
+# Inside a reusable, if: configs the reusable. Refusing it would break
+# the whole repository. The assertion skips reusable-* files, so a
+# switching 'if:' inside reusable-rust-ci.yml stays accepted.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/some-job.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/reusable-rust-ci.yml
+EOF
+# Replace the test-extra job's 'if: inputs.extra-test-os != ...' with a
+# switching expression that would be refused on a caller. The reusable's
+# own job must stay accepted, because refusing it would take the
+# repository down.
+python3 - "$d/.github/workflows/reusable-rust-ci.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+text = text.replace(
+    "  test-extra:\n    name: Test (${{ matrix.os }})\n    if: inputs.extra-test-os != '[]'",
+    "  test-extra:\n    name: Test (${{ matrix.os }})\n    if: ${{ github.event_name == 'pull_request' }}",
+    1,
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'a switching if: inside a reusable is still allowed' "0" "$rc"
+out="$(run_in "$d" "$WORK/caller-if.sh")"
+check 'and the step did not flag the reusable own job' "0" \
+	"$(said "$out" 'test-extra')"
+check 'and the step says every caller passes' "1" \
+	"$(said "$out" 'every caller of a required check')"
+
+# ===========================================================================
+# Edge: a non-required job carrying if: is not in scope. The assertion
+# only fires on jobs that emit a required check, so an if: on a
+# different job stays allowed. This is the seam that keeps the friction
+# local to the gate.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/some-job.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  unrelated:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo green
+EOF
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: on a non-required job is allowed' "0" "$rc"
+
+# ===========================================================================
+# Edge: a caller of a reusable that is NOT in REQUIRED_REUSABLES. The
+# callers of reusables not on the list are not gated, because the
+# assertion cannot prove their jobs are required.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/some-job.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    if: false
+    uses: ./.github/workflows/reusable-shell-ci.yml
+EOF
+rc=0; run_in "$d" "$WORK/caller-if.sh" >/dev/null || rc=$?
+check 'an if: false on a non-required reusable caller is allowed' "0" "$rc"
+
+# ===========================================================================
+# Edge: an unparseable caller is a warning, not a silent skip. The
+# previous form of a check here would fail-closed on a YAML parse
+# error; this form follows tooling-isolation and reports it as a
+# ::warning so the silence is visible.
+# ===========================================================================
+
+d="$(new)"; printf 'name: [\n' > "$d/.github/workflows/broken.yml"
+out="$(run_in "$d" "$WORK/caller-if.sh")"; rc=$?
+check 'an unparseable workflow does not fail the step' "0" "$rc"
+check 'but is reported as skipped' "1" "$(said "$out" '::warning')"
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-caller-with.test.sh
+++ b/tests/shell/reusable-workflow-lint-caller-with.test.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the caller's `with:` defaults check in
+# .github/workflows/reusable-workflow-lint.yml. The caller-if assertion
+# (#1731) refuses a job-level `if:` that can skip a required check.
+# This one refuses a job-level `with:` value that differs from the
+# reusable's declared `inputs.X.default`. Same outcome through a
+# different lever: the ruleset requires the check NAME, but the
+# underlying job runs differently when the input value is not the
+# one the ruleset was configured against. A pull request to
+# ci.yml:coverage-threshold: 76 -> 0, ci.yml:msrv: 1.85 -> '',
+# ci.yml:extra-test-os: '["macos-latest", ...]' -> '[]', or
+# ci.yml:doc-warnings: true -> false would all keep `rust / Coverage`,
+# `rust / MSRV`, `rust / MSRV (1.85)`, `rust / Extra platforms`,
+# `rust / Doc warnings` as the names the ruleset matches and silently
+# lower or remove the gate. The lint catches each.
+#
+# The rule is symmetric to caller-if: same named set of required checks,
+# same static map, same fixture shape. The comparison is not against
+# the ruleset (the ruleset sees check names, not inputs) but against
+# the reusable's declared `inputs.X.default`. The reusable is the
+# place where the value the ruleset assumes is canonicalised: a
+# change to the default is reviewed on the reusable's diff, where the
+# ruleset's check name stays stable.
+#
+# `if:` lines INSIDE a reusable are skipped the same way caller-if
+# skips them. The same `reusable-*` basename filter applies. This
+# step is wholly in the non-reusable scan path.
+#
+# Each step's `run:` body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository. Every
+# refusal asserts WHICH message fired. Each refusal is paired with a
+# same-shape acceptance so the rule is precise.
+#
+# Requires: python3 with PyYAML (the step under test imports it).
+# The fixtures below carry literal `${{ ... }}` expressions: the
+# assertion under test reads those characters, so they must reach
+# the file unexpanded. Single quotes are the point, not an oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+try:
+    start = next(i for i, l in enumerate(lines) if "name: " + sys.argv[2] in l)
+except StopIteration:
+    sys.exit(0)
+try:
+    run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+except StopIteration:
+    sys.exit(0)
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A caller of a required check must carry \`with:\`" \
+	> "$WORK/caller-with.sh"
+check "the caller-with assertion was extracted from the workflow" "1" \
+	"$(grep -c check-caller-with-defaults.py "$WORK/caller-with.sh" | awk '{print ($1>0)}')"
+
+check "the caller-with-defaults script lives next to the other GitHub scripts" "1" \
+	"$(test -f "$HERE/.github/scripts/check-caller-with-defaults.py" && echo 1 || echo 0)"
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# A fresh empty tree with '.github/workflows/' (and '.github/scripts/'
+# for the caller-with-defaults checker the step body shells out to),
+# and the real reusables copied across. The reusables declare the
+# inputs whose defaults the caller is compared against; a fixture
+# that does not include them cannot be checked.
+new() {
+	rm -rf "$WORK/t"
+	mkdir -p "$WORK/t/.github/workflows" "$WORK/t/.github/scripts"
+	for r in \
+		reusable-rust-ci.yml \
+		reusable-dco.yml \
+		reusable-line-limit.yml \
+		reusable-main-guard.yml \
+		reusable-workflow-lint.yml; do
+		cp "$HERE/.github/workflows/$r" "$WORK/t/.github/workflows/"
+	done
+	cp "$HERE/.github/scripts/check-caller-with-defaults.py" \
+		"$WORK/t/.github/scripts/"
+	printf '%s' "$WORK/t"
+}
+run_in() { ( cd "$1" && bash "$2" 2>&1 ); }
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+# A caller of a required-emitting reusable, with the supplied with:
+# block contents (already indented under the job). `with_text` may be
+# the empty string for "no with: block at all".
+caller_with() { # $1=dir $2=with-block text (or empty) $3=reusable basename
+	if [ -n "$2" ]; then
+		cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/$3
+    with:
+$2
+EOF
+	else
+		cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/$3
+EOF
+	fi
+}
+
+# ===========================================================================
+# Real-tree positive control: the loaded step body, run against the
+# real repository, exits 0 and prints the OK summary once the
+# reusable defaults carry the values the production callers set. With
+# the original defaults, ci.yml:coverage-threshold: 76 differs from
+# the reusable's declared default of 0 and the step exits 1; that is
+# the failure the defaults bump removes.
+# ===========================================================================
+
+out="$(cd "$HERE" && bash "$WORK/caller-with.sh")"; rc=$?
+check "the real repository tree passes the caller-with-defaults assertion" \
+	"0" "$rc"
+check "and the step prints the OK summary when the real tree is clean" "1" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# ===========================================================================
+# Each negative fixture plants a caller whose `with:` value differs
+# from the reusable's declared default. The seeded reusables carry
+# the same defaults the production reusables declare, so the step
+# catches each fixture the same way it would catch the same change
+# in production. Every refusal is paired with an acceptance (a
+# caller with the matching value, or no `with:` at all) so the rule
+# is precise.
+# ===========================================================================
+
+# --- coverage-threshold 76 -> 0 drops the coverage gate --------------
+d="$(new)"
+caller_with "$d" "      coverage-threshold: 0" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: coverage-threshold: 0 (default 76) is refused" "1" "$rc"
+check "and the message names the offending job" "1" \
+	"$(said "$out" 'job `caller` in')"
+check "and the message names the input key and the value" "1" \
+	"$(said "$out" 'coverage-threshold')"
+check "and the message names the declared default" "1" \
+	"$(said "$out" 'default')"
+check "and the message points at the reusable's declared default" "1" \
+	"$(said "$out" 'declared default')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# --- msrv 1.85 -> '' disables the MSRV job ---------------------------
+d="$(new)"
+caller_with "$d" "      msrv: ''" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: msrv: '' (default 1.85) is refused" "1" "$rc"
+check "and the message names the input key" "1" \
+	"$(said "$out" 'msrv')"
+
+# --- extra-test-os "[...]" -> '[]' drops extra-platform gating -------
+d="$(new)"
+caller_with "$d" "      extra-test-os: '[]'" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: extra-test-os: '[]' (default array) is refused" "1" "$rc"
+
+# --- doc-warnings true -> false drops doc-warning gate ---------------
+d="$(new)"
+caller_with "$d" "      doc-warnings: false" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: doc-warnings: false (default true) is refused" "1" "$rc"
+
+# --- extensions trimmed to a subset of the default set --------------
+d="$(new)"
+caller_with "$d" "      extensions: 'rs go'" "reusable-line-limit.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: extensions: 'rs go' (full default) is refused" "1" "$rc"
+
+# --- working-directory: src is non-default, refused ----------------
+d="$(new)"
+caller_with "$d" "      working-directory: src" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "with: working-directory: src (default '.') is refused" "1" "$rc"
+
+# ===========================================================================
+# Each shape above is accepted when the value matches the default.
+# ===========================================================================
+
+# --- a caller with no with: block at all is fine --------------------
+d="$(new)"
+caller_with "$d" "" "reusable-rust-ci.yml"
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "a caller with no with: block is allowed" "0" "$rc"
+
+# --- a caller whose with: values equal the declared defaults --------
+d="$(new)"
+caller_with "$d" "      coverage-threshold: 76
+      msrv: '1.85'
+      extra-test-os: '[\"macos-latest\", \"windows-latest\"]'
+      doc-warnings: true
+      working-directory: '.'
+      toolchain: '1.98'
+      podman: false
+      package-check: false
+      semver-check: false
+      semver-checks-version: '0.50.0'
+      llvm-cov-version: '0.8.7'
+      coverage-ignore-regex: ''" "reusable-rust-ci.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "a caller whose with: values match the declared defaults is allowed" "0" "$rc"
+check "and the step prints the OK summary" "1" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# --- an input the reusable does not declare is ignored, not refused
+d="$(new)"
+caller_with "$d" "      not-a-real-input: anything" "reusable-rust-ci.yml"
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "an unknown input key is ignored, not refused" "0" "$rc"
+
+# ===========================================================================
+# Direct emitter (Supported Podman majors) is not gated: the rule
+# only catches callers of required-emitting REUSABLES. A direct job
+# named `Supported Podman majors` does not pass a `with:` to anyone,
+# and any `with:` on a step within it is not the same level as the
+# caller-if/caller-with scan.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  podman-majors:
+    name: Supported Podman majors
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo green
+EOF
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "a direct emitter job (no uses:, no with:) is allowed" "0" "$rc"
+
+# ===========================================================================
+# A caller of a non-required reusable is not in scope. Line-limit.yml
+# is a required-emitting reusable but for the `line-limit` check;
+# ASSET-CONTRACT uses reusable-installer-contract, which is not in
+# REQUIRED_REUSABLES. A caller of reusable-installer-contract with a
+# non-default `with:` must NOT be caught.
+# ===========================================================================
+
+d="$(new)"
+caller_with "$d" "      install-script: 'install.sh.bak'" \
+	"reusable-installer-contract.yml"
+rc=0; run_in "$d" "$WORK/caller-with.sh" >/dev/null || rc=$?
+check "a non-default with: on a non-required reusable is not in scope" \
+	"0" "$rc"
+
+# ===========================================================================
+# Inside a reusable, a `with:`-shaped dict is the reusable's own
+# inputs declaration, not a caller override. The rule skips the
+# reusable's own file (same seam as caller-if).
+# ===========================================================================
+
+d="$(new)"
+# Set up a workflow that calls reusable-rust-ci.yml AND modify the
+# reusable's own `inputs.X.default` to a different value. The
+# caller's with: matches the original default, so the assertion must
+# stay quiet: the rule compares to the reusable's CURRENT declared
+# default, which we just changed.
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  caller:
+    uses: ./.github/workflows/reusable-rust-ci.yml
+    with:
+      coverage-threshold: 76
+EOF
+python3 - "$d/.github/workflows/reusable-rust-ci.yml" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+# Bump the input's default; the caller's 76 no longer matches the
+# declared default (now 50).
+text = text.replace(
+    "coverage-threshold:\n        description: Minimum line coverage percentage (0 disables the gate)\n        type: number\n        default: 0",
+    "coverage-threshold:\n        description: Minimum line coverage percentage (0 disables the gate)\n        type: number\n        default: 50",
+    1,
+)
+with open(path, "w") as fh:
+    fh.write(text)
+PY
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "a caller whose with: matches what the reusable now declares is allowed" \
+	"0" "$rc"
+check "and the step did not flag the reuse-side default change" "1" \
+	"$(said "$out" 'caller-with-defaults: every caller')"
+
+# ===========================================================================
+# Edge: an unparseable caller is a warning, not a silent skip. The
+# previous step would fail-closed on a YAML parse error; this one
+# emits a warning so the silence is visible.
+# ===========================================================================
+
+d="$(new)"
+printf 'name: [\n' > "$d/.github/workflows/broken.yml"
+out="$(run_in "$d" "$WORK/caller-with.sh")"; rc=$?
+check "an unparseable workflow does not fail the step" "0" "$rc"
+check "but is reported as skipped" "1" "$(said "$out" '::warning')"
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-pin-length.test.sh
+++ b/tests/shell/reusable-workflow-lint-pin-length.test.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the pin-length assertion in
+# .github/workflows/reusable-workflow-lint.yml: every third-party
+# `uses:` reference must pin to exactly 40 hexadecimal characters.
+#
+# A commit SHA is 40 characters. GitHub answers 422 for any other
+# length, so a workflow carrying a 39-character pin never starts the
+# job that references it. In #1741 that cost the repository the only
+# coverage of install.sh's refusal of an https-to-http redirect: the
+# fixture was correct, the job named it, and the job had never run.
+#
+# The reason nothing caught it is the distinction this file exists to
+# hold open. check-suite-completeness.test.sh and
+# ci-runs-every-test.test.sh assert that every test is NAMED by a
+# workflow, and a broken pin leaves the naming intact. Being named is
+# not being run.
+#
+# Local reusable calls (`uses: ./.github/workflows/x.yml`) carry no
+# `@` and so carry no pin to measure; they are out of scope by shape
+# rather than by exception. An unpinned third-party reference
+# (`uses: owner/repo@v4`) is a separate defect with its own control,
+# and this assertion is about length only.
+#
+# The step's `run:` body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository, so the
+# test cannot drift from the thing it tests. Every refusal asserts
+# WHICH message fired, and each refusal is paired with an acceptance
+# of the same shape just inside the line.
+#
+# Requires: python3 (the step under test is a python3 heredoc).
+#
+# Several assertions match against text the step prints verbatim,
+# backticks and all. Those needles are single-quoted so the characters
+# reach `grep -F` unexpanded, which is the point rather than an
+# oversight; the sibling caller-if test carries the same waiver.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# Descriptions carry backticks, so they are passed single-quoted and
+# the helper takes its argument without re-quoting it.
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Pull one step's 'run:' body out of a workflow, dedented, so it can
+# be run. Same helper as the other two reusable-workflow-lint tests in
+# this directory: the point is to exercise the script as it ships
+# rather than a copy of it that can drift.
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "pin must be 40 hex" > "$WORK/pin-length.sh"
+check 'the pin-length assertion was extracted from the workflow' "1" \
+	"$(grep -c 'SHA1_RE' "$WORK/pin-length.sh" | awk '{print ($1>0)}')"
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# The real 40-character actions/checkout pin this repository uses
+# everywhere, and the 39-character truncation of it that #1741 shipped
+# (the second 'a' of 'e5aac' dropped).
+GOOD_PIN="3d3c42e5aac5ba805825da76410c181273ba90b1"
+BAD_PIN="3d3c42e5ac5ba805825da76410c181273ba90b1"
+
+new() {
+	rm -rf "$WORK/t"
+	mkdir -p "$WORK/t/.github/workflows"
+	printf '%s' "$WORK/t"
+}
+run_in() { # $1=dir $2=script -> stdout+stderr, status in $?
+	( cd "$1" && bash "$2" 2>&1 )
+}
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+# A one-job workflow whose single step pins actions/checkout to $2.
+pinned() { # $1=dir $2=pin
+	cat > "$1/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@$2 # v7.0.1
+        with:
+          persist-credentials: false
+EOF
+}
+
+# ===========================================================================
+# Positive control: the real tree passes. This is the assertion that
+# went from red to green when line 194 of asset-contract.yml was
+# repaired, and it is what keeps the repair from silently regressing.
+# ===========================================================================
+
+out="$(cd "$HERE" && bash "$WORK/pin-length.sh")"; rc=$?
+check 'the real repository tree passes the pin-length assertion' "0" "$rc"
+check 'and the step prints the OK summary, not a refusal' "1" \
+	"$(said "$out" 'checkout-pin-length: every `uses:` pin')"
+
+# ===========================================================================
+# The defect of #1741, reproduced: a 39-character pin is refused, and
+# the message names the file and the pin.
+# ===========================================================================
+
+d="$(new)"; pinned "$d" "$BAD_PIN"
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+check 'a 39-character pin is refused' "1" "$rc"
+check 'and the message names the file' "1" \
+	"$(said "$out" 'file=.github/workflows/tests.yml')"
+check 'and the message names the line the pin sits on' "1" \
+	"$(said "$out" 'line 7:')"
+check 'and the message names the pin itself' "1" "$(said "$out" "$BAD_PIN")"
+check 'and the message names the length it found' "1" \
+	"$(said "$out" 'which is 39 characters')"
+check 'and the message says what the length must be' "1" \
+	"$(said "$out" 'exactly 40 hexadecimal')"
+check 'and the message says why it matters: the job never runs' "1" \
+	"$(said "$out" 'the job never runs')"
+
+# --- the paired acceptance: the same shape with the correct pin ----------
+d="$(new)"; pinned "$d" "$GOOD_PIN"
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'the same workflow with a 40-character pin is accepted' "0" "$rc"
+out="$(run_in "$d" "$WORK/pin-length.sh")"
+check 'and the step says every pin is 40 characters' "1" \
+	"$(said "$out" 'exactly 40 hexadecimal')"
+
+# ===========================================================================
+# Length on the other side, and the non-hex case. Both are rejected by
+# GitHub for the same reason, so both are refused here.
+# ===========================================================================
+
+d="$(new)"; pinned "$d" "${GOOD_PIN}f"
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'a 41-character pin is refused too' "1" "$rc"
+
+d="$(new)"; pinned "$d" "${GOOD_PIN:0:39}z"
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+check 'a 40-character pin with a non-hex character is refused' "1" "$rc"
+check 'and the refusal is about hexadecimal, not just length' "1" \
+	"$(said "$out" 'hexadecimal')"
+
+# ===========================================================================
+# Shapes with no pin to measure. Refusing these would take the
+# repository down, since every workflow here calls a local reusable.
+# ===========================================================================
+
+# --- a local reusable call carries no pin -------------------------------
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  shellcheck:
+    uses: ./.github/workflows/reusable-shell-ci.yml
+    with:
+      test-command: bash ./tests/shell/locale-pinned.test.sh
+EOF
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'a local reusable call is not in scope' "0" "$rc"
+
+# --- a tag reference is refused: a tag is not a pin ---------------------
+# `uses: owner/repo@v7` is a moving reference, not a pin, and no other
+# control in this repository refuses it. Nothing in the tree uses the
+# form today, so measuring it here costs nothing and closes the gap
+# rather than leaving it for a second check that does not exist.
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<'EOF'
+name: Tests
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+EOF
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+check 'a tag reference is refused: a tag is not a 40-character pin' "1" "$rc"
+check 'and the message names the tag it found' "1" "$(said "$out" '`v7`')"
+
+# --- a commented-out pin is prose, not wiring ---------------------------
+# reusable-dependabot-freshness.yml carries `uses: owner/repo@<sha>` in a
+# comment describing its own grep. A check that read comments would fail
+# the tree over documentation, which is the defect
+# ci-runs-every-test.test.sh already records about its first version.
+d="$(new)"; pinned "$d" "$GOOD_PIN"
+cat >> "$d/.github/workflows/tests.yml" <<EOF
+      # - uses: actions/checkout@$BAD_PIN # v7.0.1
+EOF
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'a commented-out short pin is not a violation' "0" "$rc"
+
+# ===========================================================================
+# Reach: the assertion must see every workflow file, and every pin
+# within one. A check that stopped at the first file, or the first pin
+# in a file, would have passed the tree of #1741 whenever the bad pin
+# was not the first one it met. It was the sixth.
+# ===========================================================================
+
+d="$(new)"; pinned "$d" "$GOOD_PIN"
+cat > "$d/.github/workflows/second.yml" <<EOF
+name: Second
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@$BAD_PIN # v7.0.1
+EOF
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+check 'a bad pin in the second workflow file is still found' "1" "$rc"
+check 'and the message names that file, not the first one' "1" \
+	"$(said "$out" 'file=.github/workflows/second.yml')"
+
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@$GOOD_PIN # v7.0.1
+      - uses: actions/setup-python@$GOOD_PIN # v6.0.0
+      - uses: actions/upload-artifact@$BAD_PIN # v7.0.1
+EOF
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+check 'the third pin in a file is reached, not just the first' "1" "$rc"
+check 'and the message names the offending action, not a sibling' "1" \
+	"$(said "$out" 'actions/upload-artifact')"
+check 'and the good siblings are not reported' "0" \
+	"$(said "$out" 'actions/setup-python')"
+
+# --- the `.yaml` spelling is a workflow too -----------------------------
+d="$(new)"
+cat > "$d/.github/workflows/tests.yaml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@$BAD_PIN # v7.0.1
+EOF
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'a bad pin in a .yaml workflow is found too' "1" "$rc"
+
+# ===========================================================================
+# Edge: the non-list `uses:` form. A reusable caller writes `uses:` as
+# a job property with no leading dash, and a third-party action can be
+# written the same way under `steps:` when other keys precede it. Both
+# spellings carry a pin, so both are measured.
+# ===========================================================================
+
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@$BAD_PIN # v7.0.1
+EOF
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+check 'the named-step spelling of uses: is measured too' "1" "$rc"
+check 'and it names the line the uses: sits on, not the name:' "1" \
+	"$(said "$out" 'line 8:')"
+
+d="$(new)"
+cat > "$d/.github/workflows/tests.yml" <<EOF
+name: Tests
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@$GOOD_PIN # v7.0.1
+EOF
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'and the same spelling with a good pin is accepted' "0" "$rc"
+
+# ===========================================================================
+# Edge: an empty workflow directory is not a violation. A check that
+# treated "no pins found" as a failure would go red on a repository
+# that had not written a workflow yet, which is noise rather than a
+# finding.
+# ===========================================================================
+
+d="$(new)"
+rc=0; run_in "$d" "$WORK/pin-length.sh" >/dev/null || rc=$?
+check 'a workflow directory with no files passes' "0" "$rc"
+
+# ===========================================================================
+# Edge: an unreadable workflow is a warning, not a silent skip. Same
+# shape as tooling-isolation and caller-if: the silence stays visible.
+# ===========================================================================
+
+d="$(new)"; pinned "$d" "$GOOD_PIN"
+printf 'name: Unreadable\n' > "$d/.github/workflows/locked.yml"
+chmod 000 "$d/.github/workflows/locked.yml"
+out="$(run_in "$d" "$WORK/pin-length.sh")"; rc=$?
+chmod 644 "$d/.github/workflows/locked.yml"
+# Running as root defeats the permission bit, so the warning only has
+# to appear where the read actually fails. The step must not fail
+# either way, which is the property under test.
+check 'an unreadable workflow does not fail the step' "0" "$rc"
+if [ "$(id -u)" -ne 0 ]; then
+	check 'but is reported as skipped' "1" "$(said "$out" '::warning')"
+else
+	echo "skip  but is reported as skipped (running as root)"
+fi
+
+echo
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-tooling-installers.test.sh
+++ b/tests/shell/reusable-workflow-lint-tooling-installers.test.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the broadened installer patterns in the
+# tooling-isolation step of reusable-workflow-lint.yml. The step
+# refuses a job that holds a secret while installing third-party
+# tooling. The original list of installers covered `cargo install`,
+# `go install`, `gem install`, `npm install -g`/`npm i -g`, and
+# `pip install` (with --require-hashes exempted). That list matched
+# strings, not the property those strings all share: the install
+# reaches code that lives outside this organisation. A pull request
+# can dodge the string with a synonym the lint never heard of, and
+# the property it was supposed to gate still fires. The release signing
+# job is the canonical example: it holds the Ed25519 release key in
+# `GLYNDOR_RELEASE_ED25519_KEY` and runs `pip install --quiet
+# --require-hashes -r .github/scripts/sign-requirements.txt`, which
+# executes the cryptography package's native build script. Hashed,
+# so it is exempt; the cryptography build script runs either way.
+#
+# This file asserts the FIX: the property-based pattern list now
+# covers more synonyms and a behavioural test confirms each. Every
+# negative fixture would, on the unfixed list, fall through to the
+# `cargo install`-textual gap. Every positive fixture matches the
+# existing exemption so existing call sites stay green.
+#
+# Also documented here for the next person to read: the number of
+# build scripts the release target executes is 14. The original
+# issue cited 33: that is the whole lockfile graph with dev-deps and
+# every other platform included. Filtered to
+# `cargo metadata --filter-platform x86_64-unknown-linux-gnu` it is
+# 14 (confirmed against 15 directories in `target/release/build/`,
+# one of which is the podup crate's own build script, the other 14
+# are deps). An acceptance built on 33 would exempt crates the
+# release never builds; 14 is the number that named the property in
+# the brief.
+#
+# Each step's `run:` body is extracted from the workflow and executed
+# as it ships, in a temporary tree shaped like a repository. Every
+# refusal is paired with a same-shape acceptance so the rule is
+# precise.
+#
+# Requires: python3 with PyYAML (the tooling-isolation step imports
+# it), cargo (the build-script-count assertion at the bottom). The
+# fixtures below carry literal `${{ secrets.X }}` expressions: the
+# assertion under test reads those characters, so they must reach
+# the file unexpanded. Single quotes are the point, not an oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if "name: " + sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A job holding a secret must not install" > "$WORK/tooling.sh"
+check "the tooling assertion was extracted from the workflow" "1" \
+	"$(grep -c 'INSTALL_PATTERNS' "$WORK/tooling.sh" | awk '{print ($1>0)}')"
+
+# The new patterns the broadened list is supposed to recognise. A
+# substring-match on the extracted step body ensures the fix is in
+# place (each name is a tuple entry in INSTALL_PATTERNS). An entry
+# that doesn't appear would itself be a regression, and would also
+# gate every negative fixture below.
+for needle in \
+	"cargo binstall" \
+	"pip3 install" \
+	"python -m pip install" \
+	"python3 -m pip install" \
+	"pipx install" \
+	"dotnet tool install"; do
+	check "INSTALL_PATTERNS names the property equivalent $needle" "1" \
+		"$(grep -F -c "$needle" "$WORK/tooling.sh" | awk '{print ($1>0)}')"
+done
+
+new() { rm -rf "$WORK/t"; mkdir -p "$WORK/t/.github/workflows"; printf '%s' "$WORK/t"; }
+run_in() { ( cd "$1" && bash "$2" 2>&1 ); }
+said() { printf '%s' "$1" | grep -q -F -- "$2" && echo 1 || echo 0; }
+
+tooling_case() { # $1=dir $2=env line $3=run line
+	cat > "$1/.github/workflows/job.yml" <<EOF
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      $2
+    steps:
+      - run: |
+          $3
+EOF
+}
+
+# ===========================================================================
+# Cargo binstall: same shape as cargo install but a different literal.
+# On the unfixed list it falls through and the lint passes. On the
+# broadened list the property that holds a secret while a third-party
+# build script would run is the one that fires.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'cargo binstall cargo-cyclonedx --version 0.5.9'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "cargo binstall while holding a secret is refused" "1" "$rc"
+check "and the message names the install and the line" "1" \
+	"$(said "$out" 'cargo binstall cargo-cyclonedx')"
+
+# ===========================================================================
+# pip3 install (alias for pip install): unfixed list does not name it,
+# so a job holding a secret and running `pip3 install requests`
+# falls through. The hash-pinned variant still passes; the property
+# is the same as pip install, so the exemption carries over.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip3 install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pip3 install without hashes while holding a secret is refused" "1" "$rc"
+check "and the message names the install and the line" "1" \
+	"$(said "$out" 'pip3 install requests')"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip3 install --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "pip3 install --require-hashes while holding a secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# python -m pip install: same property as pip install, different
+# invocation. The release signing jobs (release.yml) use exactly this
+# spelling; the broadened list catches both.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python -m pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "python -m pip install without hashes while holding a secret is refused" "1" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python -m pip install --quiet --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "python -m pip install --require-hashes while holding a secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# python3 -m pip install: another synonym the release signing job uses
+# when `python` is not on PATH (`command -v python >/dev/null 2>&1 ||
+# py=python3`). Same exemption applies.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python3 -m pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "python3 -m pip install without hashes while holding a secret is refused" "1" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'python3 -m pip install --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "python3 -m pip install --require-hashes while holding a secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# pipx install: isolated-venv pip. Does NOT support --require-hashes,
+# so the exemption cannot apply; the install is always refused.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pipx install cryptography'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pipx install while holding a secret is refused (no hash exemption)" "1" "$rc"
+
+# ===========================================================================
+# dotnet tool install: brings a NuGet tool into the runner.
+# Different ecosystem, same property.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'dotnet tool install -g cargo-audit'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "dotnet tool install while holding a secret is refused" "1" "$rc"
+
+# ===========================================================================
+# Regression: the original pip install --require-hashes still exempts.
+# The release signing job runs this verbatim; a regression that
+# forgets the exemption would burn every release.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip install --quiet --require-hashes -r requirements.txt'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "pip install --require-hashes while holding a secret is still allowed" "0" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pip install without hashes while holding a secret is still refused" "1" "$rc"
+
+# ===========================================================================
+# Regression: the cargo / go / gem / npm entries still fire. The
+# broadened list adds to, it does not replace.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'cargo install --locked cargo-cyclonedx --version 0.5.9'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "cargo install while holding a secret is still refused" "1" "$rc"
+
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'go install example.com/tool@v1'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "go install while holding a secret is still refused" "1" "$rc"
+
+# ===========================================================================
+# Installers in jobs that hold NO secret still pass. Same broadened
+# list, only the hold-a-secret branch fires.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'PLAIN: value' \
+	'cargo binstall cargo-cyclonedx --version 0.5.9'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "cargo binstall in a job holding no secret is allowed" "0" "$rc"
+
+d="$(new)"; tooling_case "$d" 'PLAIN: value' \
+	'pipx install cryptography'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "pipx install in a job holding no secret is allowed" "0" "$rc"
+
+# ===========================================================================
+# A line that mixes a hash-pinned pip with an unexempted installer
+# catches the unexempted one. `cargo install cargo-foo && pip install
+# --require-hashes -r req.txt` -- both literal strings are present;
+# the cargo install is the property violation. The original list has
+# the same `break after first violation` behaviour, so this also
+# tests the order: `cargo install` is before `pip install` in the
+# tuple, the violation is the cargo install, the step prints the
+# cargo install line.
+# ===========================================================================
+d="$(new)"; tooling_case "$d" 'KEY: ${{ secrets.GLINDOR_RELEASE_ED25519_KEY }}' \
+	'cargo install cargo-foo && pip install --require-hashes -r req.txt'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a line that mixes cargo install with hash-pinned pip is refused" "1" "$rc"
+check "and the message names the cargo install (the unexempted one)" "1" \
+	"$(said "$out" 'cargo install cargo-foo')"
+
+# ===========================================================================
+# Build-script count for the release target. The number the original
+# issue cited was 33: that is the whole lockfile graph with dev-deps
+# and every other platform included, and an acceptance built on 33
+# would exempt crates the release never builds. Filtered to the release
+# target (`cargo metadata --filter-platform x86_64-unknown-linux-gnu`)
+# the correct count is 14. This is reported here as a documentation
+# assertion the next person wiring a release-path check can lean on,
+# not as a runtime invariant: the count depends on the resolved set at
+# the moment cargo metadata runs, which is what the property is about.
+# The runner-side cross-check is `ls target/x86_64-unknown-linux-gnu
+# /release/build | wc -l` after a fresh build for that target.
+# ===========================================================================
+
+echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+++ b/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# Behaviour tests for the tooling-isolation assertion in
+# .github/workflows/reusable-workflow-lint.yml: a job that holds a secret
+# must not install third-party tooling.
+#
+# The step parses every workflow under .github/workflows and refuses, with
+# its own message, a job that calls cargo/go/gem/npm install or `pip
+# install` (without --require-hashes) while holding a secret reference. The
+# step is the gate; a script that gates gets tests, and this is the test.
+#
+# Two shapes of secret reach a step and were not seen before #1720:
+#
+#   1. The bracket-index form, `secrets['NAME']` or `secrets["NAME"]`,
+#      with optional whitespace inside the brackets. The reference shape
+#      `secrets.NAME` was the only one the previous regex matched.
+#
+#   2. A workflow-level `env:`. Every job in the workflow inherits it, so
+#      a secret declared there reaches every step. The scan reserialised
+#      the job, not the workflow-level env, so it never looked at it.
+#
+# Each refusal asserts WHICH message fired. Naming where the secret comes
+# from matters when it is not in the job: an author reading "job X holds a
+# secret" and seeing no secret in job X concludes the check is wrong rather
+# than looking further up the file.
+#
+# The `secrets: inherit` line and the `secrets:` declaration block on a
+# reusable call stay unrefused: those are declaration blocks, not
+# references, and `secrets:` is not followed by `.` or `[`.
+#
+# Each step's `run:` body is extracted from the workflow and executed as it
+# ships, in a temporary tree shaped like a repository. Every refusal is
+# paired with an acceptance of the same shape just inside the line.
+#
+# Requires: python3 with PyYAML (the tooling-isolation step imports it).
+# The fixtures below carry literal `${{ secrets.X }}` expressions and
+# backticks: the assertion under test reads those characters, so they must
+# reach the file unexpanded. Single quotes are the point, not an oversight.
+# shellcheck disable=SC2016
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+check() { # <description> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "ok    $1"
+		pass=$((pass + 1))
+	else
+		echo "FAIL  $1"
+		echo "        expected: $2"
+		echo "        actual:   $3"
+		fail=$((fail + 1))
+	fi
+}
+
+# Pull one step's `run:` body out of a workflow, dedented, so it can be run.
+# Same helper shape as tests/shell/ci-runs-every-test.test.sh: the point
+# is to exercise the script as it ships rather than a copy of it that can
+# drift.
+step_script() { # $1=workflow path  $2=step name substring
+	python3 - "$1" "$2" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if "name: " + sys.argv[2] in l)
+run = next(i for i, l in enumerate(lines) if i > start and l.strip() == "run: |")
+body = []
+for line in lines[run + 1:]:
+    if not line.strip():
+        body.append("")
+        continue
+    if not line.startswith(" " * 10):
+        break
+    body.append(line[10:])
+print("\n".join(body))
+PY
+}
+
+WORKFLOW="$HERE/.github/workflows/reusable-workflow-lint.yml"
+step_script "$WORKFLOW" "A job holding a secret must not install" > "$WORK/tooling.sh"
+check "the tooling assertion was extracted from the workflow" "1" \
+	"$(grep -c 'INSTALL_PATTERNS' "$WORK/tooling.sh" | awk '{print ($1>0)}')"
+
+new() { rm -rf "$WORK/t"; mkdir -p "$WORK/t/.github/workflows"; printf '%s' "$WORK/t"; }
+run_in() { # $1=dir $2=script -> stdout+stderr, status in $?
+	( cd "$1" && bash "$2" 2>&1 )
+}
+said() { printf '%s' "$1" | grep -q -- "$2" && echo 1 || echo 0; }
+
+tooling_case() { # $1=dir $2=env line (or empty) $3=run line
+	cat > "$1/.github/workflows/job.yml" <<EOF
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      $2
+    steps:
+      - run: |
+          $3
+EOF
+}
+
+# ===========================================================================
+# A job holding a secret must not install third-party tooling
+# ===========================================================================
+
+# --- a secret plus a pip install is refused, and named --------------------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' 'pip install requests'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret that pip installs is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+
+# --- the same install pinned by hash is the documented exemption ----------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' 'pip install --require-hashes -r req.txt'
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "pip install --require-hashes while holding a secret is allowed" "0" "$rc"
+check "and the step says nothing was found" "1" "$(said "$out" 'no job holding a secret installs')"
+
+# --- cargo install has no hash exemption ---------------------------------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' 'cargo install --locked cargo-cyclonedx'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "cargo install --locked while holding a secret is still refused" "1" "$rc"
+
+# --- the same install without a secret is fine ---------------------------
+d="$(new)"; tooling_case "$d" 'PLAIN: value' 'cargo install --locked cargo-cyclonedx'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "the same install in a job holding no secret passes" "0" "$rc"
+
+# --- a commented-out install is not an install ---------------------------
+d="$(new)"; tooling_case "$d" 'TOKEN: ${{ secrets.DEPLOY_TOKEN }}' '# pip install requests'
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "an install that only appears in a comment is not reported" "0" "$rc"
+
+# --- a secret referenced in a step, not the job env, still counts --------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: go install example.com/tool@v1
+      - run: echo "$KEY"
+        env:
+          KEY: ${{ secrets.SIGNING_KEY }}
+EOF
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "a secret held by a later step of the same job still counts" "1" "$rc"
+
+# --- a `secrets: inherit` declaration is not a reference -----------------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable-x.yml
+    secrets: inherit
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: go install example.com/tool@v1
+EOF
+rc=0; run_in "$d" "$WORK/tooling.sh" >/dev/null || rc=$?
+check "secrets: inherit on a reusable call is not a secret reference" "0" "$rc"
+
+# --- the bracket-index form secrets['X'] is caught, single-quoted --------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets['DEPLOY_TOKEN'] }}
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret via secrets['X'] is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'no job holding a secret installs')"
+check "and there is no parse-error warning hiding the miss" "0" \
+	"$(said "$out" '::warning')"
+
+# --- the same bracket-index form, double-quoted, is also caught ----------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets["DEPLOY_TOKEN"] }}
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret via secrets[\"X\"] is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'no job holding a secret installs')"
+
+# --- bracket-index form with whitespace inside the brackets is caught -----
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets[ 'DEPLOY_TOKEN' ] }}
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job holding a secret via secrets[ 'X' ] (whitespace) is refused" "1" "$rc"
+check "and the message names the job and the install line" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from this job: `pip install requests`')"
+
+# --- a workflow-level env that holds a secret catches every job -----------
+d="$(new)"
+cat > "$d/.github/workflows/job.yml" <<'EOF'
+name: Job
+on: push
+env:
+  TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          pip install requests
+EOF
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a job whose workflow-level env holds a secret is refused" "1" "$rc"
+check "and the message names workflow-level env as the source, not the job" "1" \
+	"$(said "$out" 'job `build` installs third-party tooling while holding a secret from the workflow-level `env:`: `pip install requests`')"
+check "and the step did not silently pass it" "0" \
+	"$(said "$out" 'no job holding a secret installs')"
+check "and there is no parse-error warning hiding the miss" "0" \
+	"$(said "$out" '::warning')"
+
+# --- an unparseable workflow is a warning, not a silent skip -------------
+d="$(new)"; printf 'name: [\n' > "$d/.github/workflows/broken.yml"
+out="$(run_in "$d" "$WORK/tooling.sh")"; rc=$?
+check "a workflow that does not parse does not fail the step" "0" "$rc"
+check "but is reported as skipped, so the silence is visible" "1" "$(said "$out" '::warning')"
+
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
+++ b/tests/shell/reusable-workflow-lint-tooling-isolation.test.sh
@@ -265,4 +265,5 @@ check "a workflow that does not parse does not fail the step" "0" "$rc"
 check "but is reported as skipped, so the silence is visible" "1" "$(said "$out" '::warning')"
 
 echo "$pass passed, $fail failed"
+printf 'DONE %s %d %d\n' "${BASH_SOURCE[0]##*/}" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/workflow_branch_health.rs
+++ b/tests/workflow_branch_health.rs
@@ -1,0 +1,372 @@
+//! The branch-health guard must cover both protected branches, query the
+//! newest COMPLETED run, and stay advisory rather than required.
+//!
+//! The reusable lives next to `reusable-schedule-freshness.yml` and is
+//! called from `ci.yml` for `main` and `develop`. The freshness watchers
+//! cannot catch this defect: they read the newest SUCCESSFUL scheduled
+//! run, so a failing run is missing from their answer by construction.
+//! On 2026-09-06 three distribution channels sat with `main` red for
+//! twenty minutes after a pull request merged while its suite was still
+//! reporting, and the only reason anybody knew is that somebody went
+//! looking. This file asserts the shape of the fix on every pull request,
+//! so the gap is closed at the moment it would otherwise re-open.
+//!
+//! Four properties, one test each, plus a planted negative control:
+//!
+//! 1. Both `main` and `develop` are covered. A single job that watched
+//!    both would emit one check name covering two branches, and a check
+//!    name that does not move is the property required checks depend on
+//!    (Glyndor/podup#1552). The two jobs stay separate.
+//! 2. The query asks for `status=completed`. Asking for the newest run of
+//!    any status would report an in-progress run as a failure, and the
+//!    pull request repairing the branch would block itself with a
+//!    verdict nobody has finished reaching.
+//! 3. The check is advisory. Reading the live rulesets requires the
+//!    GitHub Settings UI, and `gh api` is forbidden here, so the
+//!    property asserted is the comment beside the job explaining why it
+//!    must not be marked required. The reason is also beside the
+//!    `uses:` inside the reusable. Both copies must stay.
+//! 4. The parser reads what it claims. A planted YAML string with the
+//!    shape being asserted exercises the parser; a parser that always
+//!    returned true would satisfy the structural assertions and prove
+//!    nothing.
+//!
+//! The conclusion logic itself lives in
+//! `.github/scripts/check-branch-conclusion.sh` and is exercised against
+//! planted API answers in `tests/shell/branch-health-conclusion.test.sh`,
+//! which is the only assertion of behavior this repository can make
+//! without `gh`.
+
+use std::fs;
+use std::path::Path;
+
+fn read(name: &str) -> String {
+	let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join(".github/workflows")
+		.join(name);
+	fs::read_to_string(&path).unwrap_or_else(|e| panic!("{name} is readable: {e}"))
+}
+
+/// Pull the value of a `branch:` input out of a job's `with:` block in
+/// `ci.yml`. Scoped to the named job so a future drift between the two
+/// `health-*` jobs is not papered over.
+///
+/// Same shape as `tests/workflow_toolchain_pin/deb_pair.rs`'s scoped
+/// parsers: the scan starts at the `with:` block under the named job
+/// (jobs live at the same indent in `ci.yml`) and stops when a sibling
+/// key at the same or lower indent appears.
+fn ci_yml_health_branch(workflow: &str, job_id: &str) -> String {
+	let lines: Vec<&str> = workflow.lines().collect();
+	let job_idx = lines
+		.iter()
+		.position(|l| l.trim_start_matches(' ').trim_start() == format!("{job_id}:"))
+		.unwrap_or_else(|| panic!("ci.yml has a `{job_id}` job"));
+	let job_indent = lines[job_idx].len() - lines[job_idx].trim_start().len();
+	let job_end = lines[job_idx + 1..]
+		.iter()
+		.position(|l| {
+			let trimmed = l.trim_start();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				return false;
+			}
+			let indent = l.len() - trimmed.len();
+			indent <= job_indent
+		})
+		.map(|p| p + job_idx + 1)
+		.unwrap_or(lines.len());
+
+	let with_idx = lines[job_idx + 1..job_end]
+		.iter()
+		.position(|l| l.trim() == "with:")
+		.unwrap_or_else(|| panic!("`{job_id}` in ci.yml has a `with:` block"));
+	let with_abs = job_idx + 1 + with_idx;
+
+	for line in &lines[with_abs + 1..job_end] {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some(rest) = trimmed.strip_prefix("branch:") {
+			return rest.trim().trim_matches('"').to_string();
+		}
+	}
+	panic!("`{job_id}` in ci.yml passes a `branch:` input");
+}
+
+/// Pull the workflow file name out of the same `with:` block.
+fn ci_yml_health_workflow(workflow: &str, job_id: &str) -> String {
+	let lines: Vec<&str> = workflow.lines().collect();
+	let job_idx = lines
+		.iter()
+		.position(|l| l.trim_start_matches(' ').trim_start() == format!("{job_id}:"))
+		.unwrap_or_else(|| panic!("ci.yml has a `{job_id}` job"));
+	let job_indent = lines[job_idx].len() - lines[job_idx].trim_start().len();
+	let job_end = lines[job_idx + 1..]
+		.iter()
+		.position(|l| {
+			let trimmed = l.trim_start();
+			if trimmed.is_empty() || trimmed.starts_with('#') {
+				return false;
+			}
+			let indent = l.len() - trimmed.len();
+			indent <= job_indent
+		})
+		.map(|p| p + job_idx + 1)
+		.unwrap_or(lines.len());
+
+	let with_idx = lines[job_idx + 1..job_end]
+		.iter()
+		.position(|l| l.trim() == "with:")
+		.unwrap_or_else(|| panic!("`{job_id}` in ci.yml has a `with:` block"));
+	let with_abs = job_idx + 1 + with_idx;
+
+	for line in &lines[with_abs + 1..job_end] {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some(rest) = trimmed.strip_prefix("workflow:") {
+			return rest.trim().trim_matches('"').to_string();
+		}
+	}
+	panic!("`{job_id}` in ci.yml passes a `workflow:` input");
+}
+
+/// Job ids that have to keep their name. A required check is matched by
+/// name, so a renamed job is a phantom the ruleset still requires.
+const HEALTH_JOBS: &[&str] = &["health-main", "health-develop"];
+
+#[test]
+fn both_protected_branches_have_their_own_health_job() {
+	let ci = read("ci.yml");
+	let main = ci_yml_health_branch(&ci, "health-main");
+	let develop = ci_yml_health_branch(&ci, "health-develop");
+
+	assert_eq!(
+		main, "main",
+		"health-main passes branch={main:?}, not \"main\". A wrong branch \
+		 means the job watches the wrong history, and a red `main` goes \
+		 unreported on the only branch where the gap matters."
+	);
+	assert_eq!(
+		develop, "develop",
+		"health-develop passes branch={develop:?}, not \"develop\". Same \
+		 defect as a wrong value on health-main."
+	);
+}
+
+#[test]
+fn both_jobs_watch_the_same_workflow() {
+	let ci = read("ci.yml");
+	let main = ci_yml_health_workflow(&ci, "health-main");
+	let develop = ci_yml_health_workflow(&ci, "health-develop");
+	assert_eq!(
+		main, develop,
+		"health-main watches {main:?} but health-develop watches \
+		 {develop:?}. A different workflow on the two branches means one \
+		 of them is reading the wrong signal; the point of the pair is \
+		 they read the same one."
+	);
+}
+
+#[test]
+fn the_reusable_checks_out_the_tree_before_running_the_script() {
+	// The step runs a script from this repository. Without a checkout the job
+	// dies with `No such file or directory` and exit 127, which reads like a
+	// broken script rather than a missing step; it happened on the first run of
+	// this workflow, and the same omission cost two of the distribution
+	// channels a red job earlier the same day.
+	let reusable = read("reusable-branch-health.yml");
+	let checkout = reusable
+		.lines()
+		.position(|l| l.contains("actions/checkout@"))
+		.expect("the health job checks out the repository");
+	let script = reusable
+		.lines()
+		.position(|l| l.contains("check-branch-conclusion.sh"))
+		.expect("the health job runs the conclusion script");
+	assert!(
+		checkout < script,
+		"the checkout has to come before the script that needs the tree"
+	);
+	assert!(
+		reusable.contains("persist-credentials: false"),
+		"nothing here writes, so the checkout must not leave a credential behind"
+	);
+}
+
+#[test]
+fn the_reusable_asks_for_completed_runs_only() {
+	let reusable = read("reusable-branch-health.yml");
+	// The query must be a literal `status=completed` substring on a line
+	// that runs `gh api`. A reader that returned the newest run of any
+	// status would silently turn the guard into a "report in-progress
+	// runs as failures" alarm, which defeats the purpose.
+	let has_query = reusable.lines().any(|l| {
+		let trimmed = l.trim_start();
+		if trimmed.starts_with('#') {
+			return false;
+		}
+		trimmed.contains("status=completed")
+	});
+	assert!(
+		has_query,
+		"reusable-branch-health.yml's `gh api` call no longer asks for \
+		 status=completed. Asking for the newest run of any status would \
+		 report an in-progress run as a failure, and the pull request \
+		 repairing the branch would block itself with a verdict nobody \
+		 has finished reaching."
+	);
+
+	// And it must NOT ask for status=success alone, which would miss
+	// every failing run that should be the loudest signal of all.
+	let has_success_only = reusable.lines().any(|l| {
+		let trimmed = l.trim_start();
+		if trimmed.starts_with('#') {
+			return false;
+		}
+		trimmed.contains("status=success")
+	});
+	assert!(
+		!has_success_only,
+		"reusable-branch-health.yml's `gh api` call asks for status=success \
+		 on its own. That is the freshness watcher's shape and cannot \
+		 catch this defect: a failing run is missing from its answer by \
+		 construction. The whole point of this file is to read COMPLETED \
+		 runs and decide the conclusion itself."
+	);
+}
+
+#[test]
+fn the_check_is_advisory_and_the_file_says_so() {
+	let reusable = read("reusable-branch-health.yml");
+	let ci = read("ci.yml");
+
+	// The reusable carries the warning in its own header, where somebody
+	// wiring required checks against it would look first. The wording is
+	// deliberately emphatic ("NOT A REQUIRED STATUS CHECK"); the assertion
+	// is case-insensitive so future rewording that drops the caps still
+	// satisfies it, as long as the warning is present.
+	let reusable_warns = reusable.lines().any(|l| {
+		let lower = l.to_lowercase();
+		lower.contains("required status check") && lower.contains("not ")
+	});
+	assert!(
+		reusable_warns,
+		"reusable-branch-health.yml no longer carries the comment that \
+		 warns against making it a required status check. A red branch \
+		 would then block the pull request that repairs it, which is the \
+		 failure this check exists to surface."
+	);
+
+	// `ci.yml` carries a matching comment beside the job ids. Without
+	// both copies, a reviewer wiring the check required has to read the
+	// reusable to learn the rule, and the place they would actually look
+	// is the call site.
+	let ci_warns = ci
+		.lines()
+		.any(|l| l.contains("MUST NOT BECOME A REQUIRED STATUS CHECK"));
+	assert!(
+		ci_warns,
+		"ci.yml no longer carries the `MUST NOT BECOME A REQUIRED STATUS \
+		 CHECK` comment beside the branch-health jobs. That copy is what \
+		 stops a reviewer from marking them required at the call site, \
+		 which is where required checks are wired."
+	);
+
+	// Both jobs must keep their ids. A required check is matched by name,
+	// so a rename creates a phantom the ruleset still requires. The ids
+	// below are part of the wire format.
+	for id in HEALTH_JOBS {
+		assert!(
+			ci.contains(&format!("{id}:")),
+			"ci.yml is missing the `{id}` job. Renaming a job that is \
+			 intended as advisory is fine; the warning here is for the \
+			 branch-health pair, whose job ids are part of the file's \
+			 contract with this test."
+		);
+	}
+}
+
+/// The parser is what the structural tests trust. Pin it on input that
+/// differs from today's `ci.yml`, including a job whose `with:` block
+/// lists `workflow:` and `branch:` in the wrong order and a comment that
+/// names them out of scope. A parser that always returned the same
+/// string would pass every assertion above and prove nothing.
+#[test]
+fn the_branch_parser_reads_what_it_claims() {
+	// Both keys in the order the file happens to use.
+	let ci_a = "\
+jobs:
+  health-main:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+  health-develop:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: develop
+";
+	assert_eq!(ci_yml_health_branch(ci_a, "health-main"), "main");
+	assert_eq!(ci_yml_health_workflow(ci_a, "health-main"), "ci.yml");
+	assert_eq!(ci_yml_health_branch(ci_a, "health-develop"), "develop");
+
+	// Reversed order. The parser walks the `with:` block and stops on
+	// the first matching key, so the test it backs must be order-blind.
+	let ci_b = "\
+jobs:
+  health-main:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      branch: main
+      workflow: ci.yml
+";
+	assert_eq!(ci_yml_health_branch(ci_b, "health-main"), "main");
+	assert_eq!(ci_yml_health_workflow(ci_b, "health-main"), "ci.yml");
+
+	// A sibling job that also names `branch:` and `workflow:` in its
+	// own `with:` block must not contaminate the answer for the one
+	// being asked about.
+	let ci_c = "\
+jobs:
+  freshness-benchmark:
+    uses: ./.github/workflows/reusable-schedule-freshness.yml
+    with:
+      workflow: benchmark.yml
+      max-age-days: 65
+  health-main:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+  health-develop:
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: develop
+";
+	assert_eq!(
+		ci_yml_health_workflow(ci_c, "health-main"),
+		"ci.yml",
+		"the parser took the sibling's value"
+	);
+	assert_eq!(ci_yml_health_branch(ci_c, "health-main"), "main");
+
+	// A comment that names `branch:` and `workflow:` with fake values
+	// must not be returned.
+	let ci_d = "\
+jobs:
+  health-main:
+    # with:
+    #   workflow: fake.yml
+    #   branch: nonsense
+    uses: ./.github/workflows/reusable-branch-health.yml
+    with:
+      workflow: ci.yml
+      branch: main
+";
+	assert_eq!(ci_yml_health_workflow(ci_d, "health-main"), "ci.yml");
+	assert_eq!(ci_yml_health_branch(ci_d, "health-main"), "main");
+}

--- a/tests/workflow_required_checks.rs
+++ b/tests/workflow_required_checks.rs
@@ -1,0 +1,4 @@
+#[path = "workflow_required_checks/plants.rs"]
+mod plants;
+#[path = "workflow_required_checks/shape.rs"]
+mod shape;

--- a/tests/workflow_required_checks/plants.rs
+++ b/tests/workflow_required_checks/plants.rs
@@ -1,0 +1,275 @@
+//! Planted renames, and the negative control under them.
+//!
+//! `shape.rs` asserts that the real tree emits every required check. That
+//! assertion is worth exactly what the walker under it is worth: one that
+//! returned an empty list whatever it was given would pass against a tree
+//! where nothing resolves at all, which is the failure mode the issue names.
+//! So each case here plants ONE rename, in memory against a copy of the real
+//! files, and requires the check that stopped being emitted to be reported by
+//! name rather than by a count. The plants are the three shapes this
+//! repository actually has: a caller job id, an inner job name in a reusable,
+//! and a job defined directly in a workflow.
+
+use std::collections::BTreeMap;
+
+use crate::shape::{
+	jobs_of, read_workflow, unresolved, workflows, workflows_dir, Job, REQUIRED_ON_MAIN,
+};
+
+/// The required checks that already do not resolve in the real tree.
+///
+/// Zero of them, unless something is broken, and `shape.rs` is the file that
+/// says so. Every case here subtracts this, so a real rename fails the two
+/// tests that are about the real tree and not the three that are about the
+/// walker.
+fn baseline() -> Vec<String> {
+	unresolved(&workflows(&workflows_dir()), REQUIRED_ON_MAIN)
+}
+
+/// What the given plant, and nothing else, stops resolving.
+///
+/// The real tree is walked twice: once as it is, once with one file replaced
+/// by the planted copy, and only the difference is returned. Asserting on the
+/// whole list instead would make every plant here fail whenever a real rename
+/// lands, which reports one defect four times and buries the one test that
+/// was about it. `shape.rs` is where a real breakage belongs.
+///
+/// The caller passes the file it planted into and the planted text. Whether
+/// the plant actually changed anything is asserted at the call site, since a
+/// plant that silently matched nothing would leave the delta empty and the
+/// case would pass for the wrong reason.
+fn newly_unresolved(file: &str, planted: &str) -> Vec<String> {
+	let baseline = baseline();
+	let mut with_plant = workflows(&workflows_dir());
+	with_plant.insert(file.to_string(), jobs_of(planted));
+	unresolved(&with_plant, REQUIRED_ON_MAIN)
+		.into_iter()
+		.filter(|v| !baseline.contains(v))
+		.collect()
+}
+
+/// A renamed caller job id is reported, by the name that stopped resolving.
+///
+/// The plant is in memory, against a copy of the real tree, so the case
+/// exercises the same files CI reads without touching them. `rust` renamed to
+/// `rustx` takes out all six `rust / *` checks at once and nothing else.
+#[test]
+fn a_renamed_caller_job_id_is_reported_by_name() {
+	let dir = workflows_dir();
+	let ci = read_workflow(&dir.join("ci.yml"));
+	let needle = "  rust:\n    uses: ./.github/workflows/reusable-rust-ci.yml";
+	assert!(
+		ci.contains(needle),
+		"ci.yml no longer carries the caller `rust:` this case plants against"
+	);
+	let planted = ci.replace(
+		needle,
+		"  rustx:\n    uses: ./.github/workflows/reusable-rust-ci.yml",
+	);
+	assert_ne!(planted, ci, "the plant must change the file it plants into");
+
+	let gone = newly_unresolved("ci.yml", &planted);
+
+	// Every `rust / *` check that resolves today, which is all of them unless
+	// something is already broken, and only those: a plant is measured by
+	// what it changed, not by the state of the tree it was planted into.
+	let already = baseline();
+	let expected: Vec<&str> = REQUIRED_ON_MAIN
+		.iter()
+		.copied()
+		.filter(|c| c.starts_with("rust / "))
+		.filter(|c| !already.iter().any(|v| v.starts_with(&format!("{c}:"))))
+		.collect();
+	assert_eq!(
+		gone.len(),
+		expected.len(),
+		"every rust check that resolved before the plant must stop resolving \
+		 after it, got:\n  {}",
+		gone.join("\n  ")
+	);
+	for check in expected {
+		assert!(
+			gone.iter().any(|v| v.starts_with(&format!("{check}:"))),
+			"{check} stopped being emitted and was not named. Got:\n  {}",
+			gone.join("\n  ")
+		);
+	}
+	assert!(
+		gone.iter().all(|v| v.contains("job id 'rust'")),
+		"the message must name the missing caller id"
+	);
+}
+
+/// A renamed inner job name is reported, and only that one.
+///
+/// `Coverage` renamed to `Cov` in the reusable takes out `rust / Coverage`.
+/// The other five `rust / *` checks share the caller id and must stay
+/// resolved: a checker that reported all six here would be reacting to the
+/// file changing rather than to the name.
+#[test]
+fn a_renamed_inner_job_name_is_reported_for_that_half_only() {
+	let dir = workflows_dir();
+	let reusable = read_workflow(&dir.join("reusable-rust-ci.yml"));
+	let needle = "  coverage:\n    name: Coverage\n";
+	assert!(
+		reusable.contains(needle),
+		"reusable-rust-ci.yml no longer carries `name: Coverage`"
+	);
+	let planted = reusable.replace(needle, "  coverage:\n    name: Cov\n");
+	assert_ne!(planted, reusable, "the plant must change the file");
+
+	let gone = newly_unresolved("reusable-rust-ci.yml", &planted);
+
+	assert_eq!(
+		gone.len(),
+		1,
+		"only rust / Coverage loses its job, got:\n  {}",
+		gone.join("\n  ")
+	);
+	assert!(
+		gone[0].starts_with("rust / Coverage:") && gone[0].contains("named 'Coverage'"),
+		"the message must name the check and the missing inner name, got: {}",
+		gone[0]
+	);
+}
+
+/// A removed direct job is reported. This is the shape with no slash, and it
+/// resolves through a different branch of the walker than the two above.
+#[test]
+fn a_renamed_direct_job_name_is_reported_by_name() {
+	let dir = workflows_dir();
+	let lane = read_workflow(&dir.join("podman-lane.yml"));
+	let needle = "    name: Supported Podman majors\n";
+	assert!(
+		lane.contains(needle),
+		"podman-lane.yml no longer carries `name: Supported Podman majors`"
+	);
+	let planted = lane.replace(needle, "    name: Supported Podman versions\n");
+	assert_ne!(planted, lane, "the plant must change the file");
+
+	let gone = newly_unresolved("podman-lane.yml", &planted);
+
+	assert_eq!(
+		gone,
+		vec!["Supported Podman majors: no workflow has a job named \
+			 'Supported Podman majors'"
+			.to_string()],
+		"the one-part shape must be reported too"
+	);
+}
+
+/// The negative control for the whole file: a tree where nothing resolves has
+/// to report EVERY required check, and a tree that resolves has to report
+/// none. A checker that returned an empty list whatever it was given would
+/// satisfy the two real-tree tests above and prove nothing, which is the
+/// failure mode the issue names.
+#[test]
+fn the_walker_reports_everything_against_a_tree_where_nothing_resolves() {
+	let empty: BTreeMap<String, BTreeMap<String, Job>> = BTreeMap::new();
+	assert_eq!(
+		unresolved(&empty, REQUIRED_ON_MAIN).len(),
+		REQUIRED_ON_MAIN.len(),
+		"an empty tree emits none of the required checks"
+	);
+
+	// A tree whose only workflow is a reusable carrying every inner name.
+	// Nothing calls it, so nothing is emitted: a reusable is not a caller,
+	// and a walker that accepted one would pass a tree GitHub reports
+	// nothing for.
+	let mut orphan = BTreeMap::new();
+	orphan.insert(
+		"reusable-everything.yml".to_string(),
+		jobs_of(
+			"\
+jobs:
+  a:
+    name: Coverage
+  b:
+    name: line limit
+",
+		),
+	);
+	let gone = unresolved(&orphan, &["rust / Coverage", "line-limit / line limit"]);
+	assert_eq!(
+		gone.len(),
+		2,
+		"a reusable nobody calls emits nothing, got:\n  {}",
+		gone.join("\n  ")
+	);
+
+	// And the positive half, so the two above cannot both be satisfied by a
+	// walker that reports every check unconditionally.
+	let mut resolving = BTreeMap::new();
+	resolving.insert(
+		"caller.yml".to_string(),
+		jobs_of(
+			"\
+jobs:
+  line-limit:
+    uses: ./.github/workflows/reusable-line-limit.yml
+  standalone:
+    name: Supported Podman majors
+",
+		),
+	);
+	resolving.insert("reusable-line-limit.yml".to_string(), {
+		jobs_of(
+			"\
+jobs:
+  line-limit:
+    name: line limit
+",
+		)
+	});
+	assert!(
+		unresolved(
+			&resolving,
+			&["line-limit / line limit", "Supported Podman majors"]
+		)
+		.is_empty(),
+		"both shapes resolve in a tree built to resolve them"
+	);
+}
+
+/// The parser under all of it, pinned on the three shapes it has to reject.
+/// Each one is present in this repository's workflows.
+#[test]
+fn the_parser_reads_job_names_and_not_the_prose_around_them() {
+	let yml = "\
+name: Coverage
+on:
+  pull_request:
+jobs:
+  # coverage:
+  #   name: Coverage
+  rust:
+    uses: ./.github/workflows/reusable-rust-ci.yml
+    with:
+      coverage-threshold: 76
+  direct:
+    name: Supported Podman majors
+    steps:
+      - name: Coverage
+        run: cargo llvm-cov
+";
+	let jobs = jobs_of(yml);
+	assert_eq!(
+		jobs.keys().collect::<Vec<_>>(),
+		vec!["direct", "rust"],
+		"only the two real job ids, not a commented one and not the workflow's \
+		 own top-level name"
+	);
+	assert_eq!(
+		jobs["rust"].name, None,
+		"the caller carries no name of its own"
+	);
+	assert_eq!(
+		jobs["rust"].uses.as_deref(),
+		Some("./.github/workflows/reusable-rust-ci.yml")
+	);
+	assert_eq!(
+		jobs["direct"].name.as_deref(),
+		Some("Supported Podman majors"),
+		"a step's `- name:` must not overwrite the job's"
+	);
+}

--- a/tests/workflow_required_checks/shape.rs
+++ b/tests/workflow_required_checks/shape.rs
@@ -1,0 +1,328 @@
+//! Every required status check still names a job that exists.
+//!
+//! GitHub emits a check called `<caller job id> / <inner job name>` for a job
+//! that calls a reusable, and just `<job name>` for a job defined in the
+//! workflow itself. `CONTRIBUTING.md` says it in the repository's own words:
+//! "Job ids are load-bearing". Rename either half and the emitted name
+//! changes, the ruleset still requires the old string, and every pull request
+//! sits BLOCKED with nothing anywhere saying why. The rename is a one-word
+//! edit that no test in this tree read: `Supported Podman majors`,
+//! `rust / Coverage` and `develop-only` appeared zero times under `tests/`.
+//!
+//! The same defect was measured in `Glyndor/apt` before `ce59d2c` closed it
+//! there: renaming `shell:` to `shellx:` in its `tests.yml` left every suite
+//! green while two required checks stopped being reported.
+//!
+//! The list below is a LITERAL, on purpose, and the acceptance for the issue
+//! says so: a list derived from the tree cannot notice a job that was removed,
+//! because the derivation removes the name at the same time. It mirrors the
+//! branch rulesets and has to be updated WITH them. Changing the ruleset and
+//! not this list leaves a real required check unverified; changing this list
+//! and not the ruleset guards a phantom GitHub will never report.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The checks required on `main`, exactly as GitHub emits them.
+///
+/// Two notes that the issue text and the tree disagree on, recorded here
+/// rather than in a commit message nobody reads twice:
+///
+/// `rust / Format & lint` is what `reusable-rust-ci.yml` emits. The issue
+/// wrote `rust / Format`, and no job in this tree is named `Format`. A
+/// required check that is never reported blocks every pull request, and
+/// pull requests merge on both branches, so `rust / Format` cannot be the
+/// required string. If the ruleset does say `Format`, the repository is
+/// already in the trap this file exists to close and the RULESET is the
+/// side that needs the edit.
+///
+/// The issue counts twelve on `main` and eleven on `develop` and names
+/// eleven, one of which is `main`-only. Eleven minus one is ten, so one
+/// required name is missing from the issue text. It resolves today, since
+/// both branches have merged recently, so it is not a phantom. It could not
+/// be identified without reading the ruleset itself, which needs the
+/// Settings UI. The gap is real and is reported, not papered over: when the
+/// twelfth name is read off the ruleset it belongs in this list.
+pub const REQUIRED_ON_MAIN: &[&str] = &[
+	"rust / Format & lint",
+	"rust / Test",
+	"rust / Coverage",
+	"rust / Doc warnings",
+	"rust / MSRV",
+	"rust / Extra platforms",
+	"Supported Podman majors",
+	"line-limit / line limit",
+	"dco / Signed-off-by present on every commit",
+	"workflow-lint / workflow-lint",
+	"develop-only / develop-only",
+];
+
+/// Required on `main` and NOT on `develop`.
+///
+/// `main-guard.yml` triggers only on pull requests into `main`, so on a
+/// `develop` pull request the check is never reported at all. Requiring it
+/// on `develop` would block every merge there with an unanswerable check,
+/// which is what `main-guard.yml`'s own header explains. Flattening the two
+/// lists into one would hide that asymmetry, so they are separate.
+const MAIN_ONLY: &[&str] = &["develop-only / develop-only"];
+
+/// One job, as much of it as the check name depends on.
+pub struct Job {
+	pub name: Option<String>,
+	pub uses: Option<String>,
+}
+
+/// Read the `jobs:` block of a workflow: job id to its `name:` and `uses:`.
+///
+/// Hand-rolled on indentation, which is the convention the other workflow
+/// tests here already follow (`workflow_debian_image.rs`,
+/// `workflow_audit_strictness.rs`). Three shapes have to be excluded and all
+/// three are in this tree:
+///
+/// - the workflow's own top-level `name:`, at indent 0,
+/// - a step's `- name:`, which is a label inside `steps:` and deeper,
+/// - a comment, because several of these files explain a job name in prose
+///   directly above the line that carries it, and `workflow_audit_strictness`
+///   already went red once for counting exactly that.
+///
+/// So a job id is a key at indent 2 under a top-level `jobs:`, and its `name:`
+/// and `uses:` are keys at indent 4 inside it.
+pub fn jobs_of(workflow: &str) -> BTreeMap<String, Job> {
+	let mut jobs = BTreeMap::new();
+	let mut in_jobs = false;
+	let mut current: Option<String> = None;
+
+	for line in workflow.lines() {
+		let trimmed = line.trim_start();
+		if trimmed.is_empty() || trimmed.starts_with('#') {
+			continue;
+		}
+		let indent = line.len() - trimmed.len();
+
+		if indent == 0 {
+			in_jobs = trimmed == "jobs:";
+			current = None;
+			continue;
+		}
+		if !in_jobs {
+			continue;
+		}
+		if indent == 2 {
+			if let Some(id) = trimmed.strip_suffix(':') {
+				if !id.is_empty() && !id.contains(' ') {
+					jobs.insert(
+						id.to_string(),
+						Job {
+							name: None,
+							uses: None,
+						},
+					);
+					current = Some(id.to_string());
+					continue;
+				}
+			}
+			current = None;
+			continue;
+		}
+		if indent != 4 {
+			continue;
+		}
+		let Some(id) = current.as_deref() else {
+			continue;
+		};
+		let value = |rest: &str| rest.trim().trim_matches('"').trim_matches('\'').to_string();
+		if let Some(rest) = trimmed.strip_prefix("name:") {
+			if let Some(job) = jobs.get_mut(id) {
+				job.name = Some(value(rest));
+			}
+		} else if let Some(rest) = trimmed.strip_prefix("uses:") {
+			if let Some(job) = jobs.get_mut(id) {
+				job.uses = Some(value(rest));
+			}
+		}
+	}
+	jobs
+}
+
+/// Every `*.yml` in a workflows directory, keyed by file name.
+pub fn workflows(dir: &Path) -> BTreeMap<String, BTreeMap<String, Job>> {
+	let mut out = BTreeMap::new();
+	let entries =
+		fs::read_dir(dir).unwrap_or_else(|e| panic!("{} is readable: {e}", dir.display()));
+	for entry in entries {
+		let path = entry.expect("dir entry").path();
+		if path.extension().map(|e| e == "yml") != Some(true) {
+			continue;
+		}
+		let base = path
+			.file_name()
+			.and_then(|n| n.to_str())
+			.expect("file name")
+			.to_string();
+		let body = fs::read_to_string(&path).unwrap_or_else(|e| panic!("{base} is readable: {e}"));
+		out.insert(base, jobs_of(&body));
+	}
+	out
+}
+
+/// Report every required check whose emitted name no longer resolves.
+///
+/// One line per unresolved check, naming BOTH halves so a rename of either is
+/// reported by the name that stopped being emitted rather than by a count:
+///
+/// ```text
+/// rust / Coverage: no workflow pairs job id 'rust' with a job named 'Coverage'
+/// ```
+///
+/// Empty when every check is in place. A reusable never emits a required check
+/// itself, so callers only are walked for the first half.
+pub fn unresolved(
+	tree: &BTreeMap<String, BTreeMap<String, Job>>,
+	required: &[&str],
+) -> Vec<String> {
+	let mut out = Vec::new();
+	for check in required {
+		let (job_id, job_name) = match check.split_once(" / ") {
+			Some((id, name)) => (Some(id), name),
+			// No slash: a job defined in the workflow itself, whose check name
+			// is its `name:` alone. `Supported Podman majors` is this shape.
+			None => (None, *check),
+		};
+		let mut found = false;
+		for (file, jobs) in tree {
+			if file.starts_with("reusable-") {
+				continue;
+			}
+			let candidates: Vec<&Job> = match job_id {
+				Some(id) => jobs.get(id).into_iter().collect(),
+				None => jobs.values().collect(),
+			};
+			for job in candidates {
+				// Direct shape: the job carries the name itself.
+				if job.name.as_deref() == Some(job_name) {
+					found = true;
+					break;
+				}
+				// Caller shape: follow `uses:` and look for an inner job whose
+				// `name:` is the second half. Only valid for a two-part name;
+				// a caller emits `<id> / <inner>`, never the inner alone.
+				if job_id.is_none() {
+					continue;
+				}
+				let Some(uses) = job.uses.as_deref() else {
+					continue;
+				};
+				let target = uses
+					.trim_start_matches("./")
+					.rsplit('/')
+					.next()
+					.unwrap_or(uses);
+				let Some(inner) = tree.get(target) else {
+					continue;
+				};
+				if inner.values().any(|j| j.name.as_deref() == Some(job_name)) {
+					found = true;
+					break;
+				}
+			}
+			if found {
+				break;
+			}
+		}
+		if !found {
+			out.push(match job_id {
+				Some(id) => format!(
+					"{check}: no workflow pairs job id '{id}' with a job named '{job_name}'"
+				),
+				None => format!("{check}: no workflow has a job named '{job_name}'"),
+			});
+		}
+	}
+	out
+}
+
+/// Read a workflow with line endings normalised to `\n`.
+///
+/// The Windows runner checks the tree out with CRLF, so a multi-line needle
+/// written with `\n` does not appear in the file text and every plant would
+/// report "this file no longer carries what the case plants against" on
+/// Windows only. `str::lines` hides this from the parser, which is why the
+/// tests over the real tree pass there and the plants did not.
+pub fn read_workflow(path: &Path) -> String {
+	fs::read_to_string(path)
+		.unwrap_or_else(|e| panic!("{} is readable: {e}", path.display()))
+		.replace("\r\n", "\n")
+}
+
+pub fn workflows_dir() -> PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows")
+}
+
+fn required_on_develop() -> Vec<&'static str> {
+	REQUIRED_ON_MAIN
+		.iter()
+		.copied()
+		.filter(|c| !MAIN_ONLY.contains(c))
+		.collect()
+}
+
+#[test]
+fn every_check_required_on_main_is_emitted_by_a_job_that_exists() {
+	let tree = workflows(&workflows_dir());
+	let gone = unresolved(&tree, REQUIRED_ON_MAIN);
+	assert!(
+		gone.is_empty(),
+		"the ruleset on main requires status checks no job emits any more. Each \
+		 one leaves every pull request into main BLOCKED with nothing reporting \
+		 the check. Either restore the name or change the ruleset and this \
+		 list together:\n  {}",
+		gone.join("\n  ")
+	);
+}
+
+#[test]
+fn every_check_required_on_develop_is_emitted_by_a_job_that_exists() {
+	let tree = workflows(&workflows_dir());
+	let gone = unresolved(&tree, &required_on_develop());
+	assert!(
+		gone.is_empty(),
+		"the ruleset on develop requires status checks no job emits any more:\n  {}",
+		gone.join("\n  ")
+	);
+}
+
+/// The two branches require different sets, and the difference is not
+/// cosmetic: `main-guard.yml` runs only on pull requests into `main`, so
+/// `develop-only / develop-only` is never reported on a `develop` pull
+/// request. One flattened list would either miss the check on `main` or
+/// block every merge into `develop` on a check that cannot arrive.
+#[test]
+fn develop_requires_the_main_set_minus_the_main_only_checks() {
+	let develop = required_on_develop();
+	assert_eq!(
+		develop.len(),
+		REQUIRED_ON_MAIN.len() - MAIN_ONLY.len(),
+		"every main-only check must be in the main list to be subtracted from it"
+	);
+	for check in MAIN_ONLY {
+		assert!(
+			REQUIRED_ON_MAIN.contains(check),
+			"{check} is listed as main-only but is not required on main"
+		);
+		assert!(
+			!develop.contains(check),
+			"{check} is required on develop, where main-guard.yml never reports it"
+		);
+	}
+
+	// The asymmetry has to hold in the workflow too, not only in this list.
+	let body = fs::read_to_string(workflows_dir().join("main-guard.yml"))
+		.expect("main-guard.yml is readable");
+	assert!(
+		body.contains("branches: [\"main\"]"),
+		"main-guard.yml no longer scopes its pull_request trigger to main. It \
+		 would then report develop-only on develop pull requests too, and the \
+		 split between these two lists stops describing anything."
+	);
+}


### PR DESCRIPTION
Merge commit, no tag in this pull request. Thirty-two commits past 5.9.1, eighteen of them fixes, five of those security.

The headline is a privilege escalation: a compose file could put `--privileged --net=host -v /:/hostfs` into the generated Quadlet unit through `PodmanArgs=`, and neither the runtime warning nor `audit` reported it. Closed in two passes, because the first sweep stopped at the `.container` unit and left `.volume`.

The rest: `autostart install --mode quadlet` skipping the validator, `cp` following a symlink planted in the archive, two ways to switch off the YAML alias guards, and `.dockerignore` never matching below the top level on Windows.

All three files that stamp a version read 5.9.2, checked against `origin/develop` immediately before this was opened. The tag goes on `main` after this merges, which is the only thing that triggers a release.

Signed-off-by: Jaro-c <75870284+Jaro-c@users.noreply.github.com>
