### PR TITLE
chore(release): bump to 5.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.9.2"
+version = "5.9.3"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.9.2"
+version = "5.9.3"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (5.9.3) unstable; urgency=medium
+
+  * A build context, a `cp` payload or a watch sync containing a file with
+    holes on disk no longer fails the whole transfer. Podman refuses the GNU
+    sparse tar entries podup was writing, so a build died with `unhandled tar
+    header type 83`, a `cp` with `unrecognized Typeflag S`, and a watch sync
+    logged a warning and silently never delivered the file. Sparse files
+    arrive on their own, as database files, disk images, virtual machine state
+    or anything preallocated with `fallocate`, and `ls` shows nothing unusual,
+    so the failure read as arbitrary. Every release from 0.3.0 onwards had
+    this on Linux, Android and FreeBSD hosts.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 11 Sep 2026 05:30:00 -0500
+
 podup (5.9.2) unstable; urgency=medium
 
   * SECURITY: a compose file could smuggle arbitrary `podman run` and


### PR DESCRIPTION
One fix landed since 5.9.2 and no published binary carries it, so it goes out as a patch.

#1776 stopped podup writing GNU sparse tar entries, which Podman refuses. A file with holes anywhere in a build context, a `cp` payload or a watched tree took the whole transfer down with it: `unhandled tar header type 83` on a build, `unrecognized Typeflag S` on a `cp`, and on a watch sync a warning and silent non-delivery. Every release from 0.3.0 onwards carried it on Linux, Android and FreeBSD hosts.

All three files that stamp a version move together, `Cargo.toml`, `debian/changelog` and `Cargo.lock`, because the release workflow refuses to build when they disagree. The reason that check exists is 1.9.0, which shipped `podup_1.8.0_*.deb` when only `Cargo.toml` had been touched, so apt saw the version it already had and reported nothing to upgrade.

The changelog entry names the three messages a user would have seen. The whole difficulty of this defect was that the failure read as arbitrary, so the wording a person will search for is the useful part of the entry.