### PR TITLE
release: 5.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "podup"
-version = "5.9.2"
+version = "5.9.3"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podup"
-version = "5.9.2"
+version = "5.9.3"
 edition = "2021"
 rust-version = "1.85"
 # podup is a binary that happens to build a library, not a library that ships a

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+podup (5.9.3) unstable; urgency=medium
+
+  * A build context, a `cp` payload or a watch sync containing a file with
+    holes on disk no longer fails the whole transfer. Podman refuses the GNU
+    sparse tar entries podup was writing, so a build died with `unhandled tar
+    header type 83`, a `cp` with `unrecognized Typeflag S`, and a watch sync
+    logged a warning and silently never delivered the file. Sparse files
+    arrive on their own, as database files, disk images, virtual machine state
+    or anything preallocated with `fallocate`, and `ls` shows nothing unusual,
+    so the failure read as arbitrary. Every release from 0.3.0 onwards had
+    this on Linux, Android and FreeBSD hosts.
+
+ -- Jaro-c <75870284+Jaro-c@users.noreply.github.com>  Fri, 11 Sep 2026 05:30:00 -0500
+
 podup (5.9.2) unstable; urgency=medium
 
   * SECURITY: a compose file could smuggle arbitrary `podman run` and

--- a/internal/engine/build/context.rs
+++ b/internal/engine/build/context.rs
@@ -145,7 +145,7 @@ pub(super) fn stream_build_context<W: std::io::Write>(
 ) -> Result<()> {
 	let (ignore_name, ignore_patterns) = ignore_file(context);
 	let encoder = GzEncoder::new(writer, Compression::default());
-	let mut tar = tar::Builder::new(encoder);
+	let mut tar = crate::engine::tar_stream::builder(encoder);
 
 	// Force-include the active Dockerfile so an ignore file that matches it
 	// cannot drop it from the context the builder receives (Docker parity).
@@ -184,7 +184,7 @@ pub(super) fn stream_build_context_with_inline<W: std::io::Write>(
 ) -> Result<()> {
 	let (ignore_name, ignore_patterns) = ignore_file(context);
 	let encoder = GzEncoder::new(writer, Compression::default());
-	let mut tar = tar::Builder::new(encoder);
+	let mut tar = crate::engine::tar_stream::builder(encoder);
 
 	let mut header = tar::Header::new_gnu();
 	header.set_size(inline.len() as u64);

--- a/internal/engine/copy/archive.rs
+++ b/internal/engine/copy/archive.rs
@@ -19,7 +19,7 @@ pub(super) fn pack_path(
 	name_override: Option<&str>,
 ) -> Result<Vec<u8>> {
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
-	let mut tar = tar::Builder::new(encoder);
+	let mut tar = crate::engine::tar_stream::builder(encoder);
 	// `-L/--follow-link`: archive the symlink target's contents instead of the
 	// link itself.
 	tar.follow_symlinks(follow_link);

--- a/internal/engine/mod.rs
+++ b/internal/engine/mod.rs
@@ -52,6 +52,7 @@ mod staging;
 mod stats;
 pub use staging::is_safe_project_name;
 pub use stats::StatsOptions;
+mod tar_stream;
 mod volume;
 pub use volume::{VolumesDisplayOptions, VolumesOptions};
 mod volume_mounts;

--- a/internal/engine/tar_stream.rs
+++ b/internal/engine/tar_stream.rs
@@ -1,0 +1,50 @@
+//! The one place a `tar::Builder` is constructed.
+//!
+//! Three paths pack a tar and hand it to Podman: the build context, `cp`, and
+//! the watch sync. All three land in the same server-side reader, so all three
+//! need the same archive dialect, and the way to guarantee that is to have a
+//! single constructor rather than three that agree today.
+//!
+//! `tests/tar_builder_single_site.rs` keeps it single.
+
+/// A `tar::Builder` writing the dialect Podman's archive reader accepts.
+///
+/// `tar::Builder::new` enables sparse-file support by default. With it on, a
+/// file that has holes on disk is written as a GNU sparse entry, whose typeflag
+/// is `b'S'`, decimal 83. Podman refuses that type and the whole transfer dies
+/// on account of one file. Podman's own client packs in Go and never emits the
+/// type, which is why a context `podman build` accepts could be one
+/// `podup build` rejected (#1775).
+///
+/// The refusal has two spellings, measured on Podman 5.7.0, and a search for
+/// either one alone misses half the damage:
+///
+/// - the build endpoint answers `unhandled tar header type 83`, from
+///   `containers/storage/pkg/archive`, and `podup build` exits 1;
+/// - the archive endpoint that `cp` and the watch sync both PUT to answers
+///   `unrecognized Typeflag S`. `cp` exits 1; `watch` only logs
+///   `watch action failed`, keeps running and never delivers the file, so
+///   there the loss is silent.
+///
+/// Nobody puts a sparse file in a build context on purpose. They arrive on
+/// their own, as database files, disk images, virtual machine state, or
+/// anything preallocated with `fallocate`, and `ls` shows nothing unusual, so
+/// the failure reads as arbitrary.
+///
+/// Storing the holes expanded costs bytes on the wire and nothing in memory:
+/// every caller wraps the writer in a `GzEncoder`, where a run of zeroes
+/// compresses to almost nothing, and the build path streams to the socket
+/// instead of buffering the archive.
+pub(super) fn builder<W: std::io::Write>(writer: W) -> tar::Builder<W> {
+	let mut tar = tar::Builder::new(writer);
+	tar.sparse(false);
+	tar
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[path = "tar_stream_tests.rs"]
+mod tests;

--- a/internal/engine/tar_stream_tests.rs
+++ b/internal/engine/tar_stream_tests.rs
@@ -1,0 +1,139 @@
+//! The archive dialect Podman accepts, measured on a real sparse file.
+
+use std::fs::File;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+use super::builder;
+
+/// Write a file that is `hole` bytes of nothing followed by `tail`.
+///
+/// Returns whether a sparse entry can be expected of the crate for this file:
+/// the hole has to be real, and the target has to be one the crate looks on.
+/// A test that packs a file the crate will never call sparse and then finds no
+/// sparse entry has measured nothing, so the positive control is conditioned
+/// on this answer rather than assuming it.
+fn write_sparse(path: &Path, hole: u64, tail: &[u8]) -> bool {
+	let mut f = File::create(path).expect("create");
+	f.set_len(hole).expect("set_len");
+	// `set_len` does not move the cursor. Without the seek the tail lands at
+	// offset 0, the file keeps its `hole` length and the assertions below read
+	// a file that is not the one they describe.
+	f.seek(SeekFrom::Start(hole))
+		.expect("seek to the end of the hole");
+	f.write_all(tail).expect("write tail");
+	f.sync_all().expect("sync");
+	drop(f);
+	on_disk_is_smaller_than_apparent(path)
+}
+
+/// The three targets where the crate looks for holes at all.
+///
+/// `find_sparse_entries` in the `tar` crate is `cfg`'d to return "not sparse"
+/// on every other target, so this list is not about which filesystem can store
+/// a hole. macOS is the one that makes the difference visible: it is Unix, APFS
+/// really does leave the range unallocated, so a block count would report a
+/// sparse file, and the crate would still never write a sparse entry for it.
+/// Keying the answer on `cfg(unix)` would therefore have failed the positive
+/// control on the macOS runner for a reason that has nothing to do with this
+/// fix. Mirror the crate's own `cfg` instead.
+#[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
+fn on_disk_is_smaller_than_apparent(path: &Path) -> bool {
+	use std::os::unix::fs::MetadataExt;
+	let meta = std::fs::metadata(path).expect("metadata");
+	meta.blocks() * 512 < meta.size()
+}
+
+#[cfg(not(any(target_os = "android", target_os = "freebsd", target_os = "linux")))]
+fn on_disk_is_smaller_than_apparent(_path: &Path) -> bool {
+	false
+}
+
+/// Pack one file and report the entry types the archive carries.
+fn entry_types<F>(make: F, path: &Path, name: &str) -> Vec<tar::EntryType>
+where
+	F: FnOnce(Vec<u8>) -> tar::Builder<Vec<u8>>,
+{
+	let mut tar = make(Vec::new());
+	tar.follow_symlinks(false);
+	tar.append_path_with_name(path, name).expect("append");
+	let bytes = tar.into_inner().expect("finish");
+	tar::Archive::new(&bytes[..])
+		.entries()
+		.expect("entries")
+		.map(|e| e.expect("entry").header().entry_type())
+		.collect()
+}
+
+/// The defect: the crate's own default writes the type Podman refuses.
+///
+/// This is the positive control. Without it the test below is vacuous on any
+/// platform where the crate never detects a hole, and it would stay green with
+/// the fix reverted while reporting that it had checked something.
+#[test]
+fn the_crate_default_emits_the_type_podman_refuses_when_the_hole_is_real() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let path = dir.path().join("holey.bin");
+	if !write_sparse(&path, 1 << 20, b"data") {
+		// Either the filesystem stored the zeroes or this target is one the
+		// crate never inspects, so the control cannot be established here. Say
+		// so rather than pass quietly: the test below still checks the fix, it
+		// just cannot show on this runner that the fix was needed.
+		eprintln!("tar_stream: no sparse entry is possible here, positive control not established");
+		return;
+	}
+	let types = entry_types(tar::Builder::new, &path, "holey.bin");
+	assert!(
+		types.contains(&tar::EntryType::GNUSparse),
+		"the default builder was expected to write a GNU sparse entry for a file \
+		 with a 1 MiB hole; it wrote {types:?}. If the crate stopped emitting \
+		 sparse entries the fix in tar_stream.rs may be obsolete, but check that \
+		 before deleting it."
+	);
+}
+
+/// The fix: our constructor never writes it, hole or no hole.
+#[test]
+fn our_builder_never_writes_a_gnu_sparse_entry() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let path = dir.path().join("holey.bin");
+	let sparse = write_sparse(&path, 1 << 20, b"data");
+	let types = entry_types(builder, &path, "holey.bin");
+	assert!(
+		!types.contains(&tar::EntryType::GNUSparse),
+		"a sparse file ({sparse}) packed through engine::tar_stream::builder \
+		 produced {types:?}; Podman answers a GNU sparse entry with \
+		 `unhandled tar header type 83` on the build endpoint and \
+		 `unrecognized Typeflag S` on the archive endpoint, and fails the whole \
+		 transfer either way"
+	);
+}
+
+/// Expanding the holes has to preserve the bytes, not only the entry type.
+#[test]
+fn the_expanded_entry_carries_every_byte_the_file_had() {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let path = dir.path().join("holey.bin");
+	write_sparse(&path, 1 << 16, b"tail");
+	let mut tar = builder(Vec::new());
+	tar.append_path_with_name(&path, "holey.bin")
+		.expect("append");
+	let bytes = tar.into_inner().expect("finish");
+
+	let mut archive = tar::Archive::new(&bytes[..]);
+	let mut entries = archive.entries().expect("entries");
+	let mut entry = entries.next().expect("one entry").expect("entry");
+	assert_eq!(entry.header().size().expect("size"), (1 << 16) + 4);
+	let mut got = Vec::new();
+	std::io::Read::read_to_end(&mut entry, &mut got).expect("read");
+	assert_eq!(got.len(), (1 << 16) + 4, "the hole is stored as zeroes");
+	assert_eq!(
+		&got[(1 << 16)..],
+		b"tail",
+		"the tail survives the expansion"
+	);
+	assert!(
+		got[..(1 << 16)].iter().all(|b| *b == 0),
+		"the hole reads back as zeroes"
+	);
+}

--- a/internal/engine/watch/sync.rs
+++ b/internal/engine/watch/sync.rs
@@ -25,7 +25,7 @@ use crate::error::{ComposeError, Result};
 /// preserving the in-tree layout.
 pub(super) fn build_sync_tar(src: &Path, entry_name: &Path) -> Result<Vec<u8>> {
 	let encoder = GzEncoder::new(Vec::new(), Compression::default());
-	let mut tar = tar::Builder::new(encoder);
+	let mut tar = crate::engine::tar_stream::builder(encoder);
 	// Do not dereference symlinks: a symlink inside the watched tree would
 	// otherwise copy the contents of its (possibly out-of-tree) target into the
 	// container. Store the link itself instead.

--- a/tests/engine_integration.rs
+++ b/tests/engine_integration.rs
@@ -166,6 +166,8 @@ mod autostart_quadlet;
 mod build_images;
 #[path = "engine_integration/build_resources.rs"]
 mod build_resources;
+#[path = "engine_integration/build_sparse_context.rs"]
+mod build_sparse_context;
 #[path = "engine_integration/commands_networking.rs"]
 mod commands_networking;
 #[path = "engine_integration/cp_flags.rs"]
@@ -198,6 +200,10 @@ mod run_flags;
 #[cfg(feature = "test-helpers")]
 #[path = "engine_integration/watch.rs"]
 mod watch_tests;
+
+#[cfg(all(unix, feature = "test-helpers"))]
+#[path = "engine_integration/watch_sparse.rs"]
+mod watch_sparse;
 
 #[path = "engine_integration/x_podman_autoupdate.rs"]
 mod x_podman_autoupdate;

--- a/tests/engine_integration/build_sparse_context.rs
+++ b/tests/engine_integration/build_sparse_context.rs
@@ -1,0 +1,98 @@
+//! A build context holding a file with holes, uploaded to a live Podman.
+//!
+//! `internal/engine/tar_stream.rs` keeps GNU sparse entries out of the archive
+//! and `tests/tar_builder_single_site.rs` keeps the constructor single, but
+//! both read bytes we wrote ourselves. Neither asks Podman. This one does: it
+//! is the only test that would have caught #1775 as the user met it, an
+//! `unhandled tar header type 83` from the far end of the socket.
+use super::*;
+
+use std::io::{Seek, SeekFrom, Write};
+
+/// Write `hole` bytes of nothing followed by `tail`, and report whether the
+/// filesystem left the range unallocated.
+///
+/// `set_len` does not move the cursor, so the seek is what puts the tail at the
+/// end instead of at offset 0. Without a real hole the upload below carries an
+/// ordinary file and proves nothing, so the caller checks this before drawing
+/// any conclusion from a pass.
+fn write_sparse(path: &std::path::Path, hole: u64, tail: &[u8]) -> bool {
+	let mut f = fs::File::create(path).unwrap();
+	f.set_len(hole).unwrap();
+	f.seek(SeekFrom::Start(hole)).unwrap();
+	f.write_all(tail).unwrap();
+	f.sync_all().unwrap();
+	drop(f);
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::MetadataExt;
+		let meta = fs::metadata(path).unwrap();
+		meta.blocks() * 512 < meta.size()
+	}
+	#[cfg(not(unix))]
+	{
+		false
+	}
+}
+
+const HOLE: u64 = 1 << 20;
+const TAIL: &[u8] = b"tail-marker";
+
+#[tokio::test]
+async fn build_uploads_a_context_that_holds_a_sparse_file() {
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let sparse = dir.path().join("holey.bin");
+	if !write_sparse(&sparse, HOLE, TAIL) {
+		// The filesystem stored the zeroes, so the context carries an ordinary
+		// file and a green result would say nothing about sparse handling.
+		eprintln!("build_sparse_context: no hole on this filesystem, nothing measured");
+		return;
+	}
+	// `COPY` the file in and read its size back from inside the image: an upload
+	// that succeeded but truncated the expanded holes would pass a check that
+	// only asked whether the build returned Ok.
+	fs::write(
+		dir.path().join("Dockerfile"),
+		b"FROM alpine:latest\nCOPY holey.bin /holey.bin\nRUN stat -c %s /holey.bin > /size\n",
+	)
+	.unwrap();
+
+	let proj = proj("sparsectx");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let image_tag = format!("podup-test-sparsectx-{}:latest", std::process::id());
+	let yaml = format!(
+		"services:\n  app:\n    build:\n      context: .\n    image: {image_tag}\n    command: [\"sleep\", \"infinity\"]\n"
+	);
+	let file = parse_str(&yaml).unwrap();
+
+	let built = engine.up(&file).await;
+	let size = if built.is_ok() {
+		engine
+			.test_exec_capture(&format!("{proj}-app-1"), vec!["cat".into(), "/size".into()])
+			.await
+			.unwrap_or_default()
+	} else {
+		String::new()
+	};
+	let _ = engine.down(&file).await;
+	let _ = std::process::Command::new("podman")
+		.args(["rmi", "-f", &image_tag])
+		.status();
+
+	// The failure this guards against is server-side and reads
+	// `unhandled tar header type 83`, so the error text is worth printing: a
+	// different failure here is a different bug and should not be read as this
+	// one coming back.
+	built.unwrap_or_else(|e| {
+		panic!("a build context holding a sparse file must upload; podman said: {e}")
+	});
+	assert_eq!(
+		size.trim(),
+		(HOLE + TAIL.len() as u64).to_string(),
+		"the file arrived with the wrong length, so the holes were not expanded intact"
+	);
+}

--- a/tests/engine_integration/cp_flags.rs
+++ b/tests/engine_integration/cp_flags.rs
@@ -125,3 +125,153 @@ async fn engine_cp_to_container_renames_a_single_file() {
 		"cp to a new name must create a file with the source's content, not a directory"
 	);
 }
+
+/// A directory carrying one file with holes, copied to a live container.
+///
+/// The `cp` endpoint refuses a GNU sparse entry with its own wording,
+/// `unrecognized Typeflag S`, and refuses the archive rather than the entry, so
+/// the ordinary file travelling beside the sparse one is lost too. The
+/// directory branch is the one that matters here: it also creates the
+/// destination before the stream is rejected, which reads as success to
+/// anything that only checks the path exists. #1775.
+#[cfg(all(unix, feature = "test-helpers"))]
+#[tokio::test]
+async fn engine_cp_uploads_a_directory_holding_a_sparse_file() {
+	use std::io::{Seek, SeekFrom, Write};
+	use std::os::unix::fs::MetadataExt;
+
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let payload = dir.path().join("payload");
+	fs::create_dir(&payload).unwrap();
+	fs::write(payload.join("plain.txt"), b"beside-the-hole").unwrap();
+
+	let hole: u64 = 1 << 20;
+	let holey = payload.join("holey.bin");
+	let mut f = fs::File::create(&holey).unwrap();
+	f.set_len(hole).unwrap();
+	// `set_len` leaves the cursor at 0, so without the seek the tail lands at
+	// the start and the file is not the one this test describes.
+	f.seek(SeekFrom::Start(hole)).unwrap();
+	f.write_all(b"tail").unwrap();
+	f.sync_all().unwrap();
+	drop(f);
+	let meta = fs::metadata(&holey).unwrap();
+	if meta.blocks() * 512 >= meta.size() {
+		eprintln!("cp sparse: no hole on this filesystem, nothing measured");
+		return;
+	}
+
+	let proj = proj("cpsparse");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	engine.up(&file).await.unwrap();
+
+	let result = engine
+		.cp(&file, payload.to_str().unwrap(), "web:/tmp")
+		.await;
+	// Both files, and the length of the sparse one: an upload that arrived
+	// truncated would pass a check that only asked whether the call returned Ok.
+	let out = engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec![
+				"sh".into(),
+				"-c".into(),
+				"cat /tmp/payload/plain.txt && stat -c %s /tmp/payload/holey.bin".into(),
+			],
+		)
+		.await;
+	engine.down(&file).await.unwrap();
+
+	// The bytes in the container are the assertion, not the returned `Ok`.
+	//
+	// Podman 6 answers this endpoint by applying the archive and closing the
+	// connection without a response, and `cp` can only recover from that when
+	// it has something to re-verify. A directory has none: `uploaded_entry_size`
+	// returns `None` for anything that is not a regular file, so a directory
+	// copy against Podman 6 fails closed whatever it did on disk. That is
+	// unrelated to sparse files, it predates this test, and reading the
+	// destination is what tells the two apart. If the copy did not land, the
+	// error is printed below, so a real failure still says what happened.
+	let out = out.unwrap_or_default();
+	assert!(
+		out.contains("beside-the-hole"),
+		"the ordinary file beside the sparse one must arrive too, got {out:?}; \
+		 cp returned {result:?}"
+	);
+	assert!(
+		out.contains(&(hole + 4).to_string()),
+		"the sparse file must arrive at its full length, got {out:?}; \
+		 cp returned {result:?}"
+	);
+}
+
+/// One file with holes, copied to a live container.
+///
+/// The directory case above cannot assert on `cp`'s return value, because
+/// Podman 6 makes a directory copy unverifiable. A single file is verifiable,
+/// so this one holds `cp` to reporting success as well as to delivering the
+/// bytes, and keeps the sparse fix covered on the strict path too. #1775.
+#[cfg(all(unix, feature = "test-helpers"))]
+#[tokio::test]
+async fn engine_cp_uploads_a_sparse_file() {
+	use std::io::{Seek, SeekFrom, Write};
+	use std::os::unix::fs::MetadataExt;
+
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let hole: u64 = 1 << 20;
+	let holey = dir.path().join("holey.bin");
+	let mut f = fs::File::create(&holey).unwrap();
+	f.set_len(hole).unwrap();
+	// `set_len` leaves the cursor at 0, so the seek is what puts the tail at the
+	// end rather than at the start.
+	f.seek(SeekFrom::Start(hole)).unwrap();
+	f.write_all(b"tail").unwrap();
+	f.sync_all().unwrap();
+	drop(f);
+	let meta = fs::metadata(&holey).unwrap();
+	if meta.blocks() * 512 >= meta.size() {
+		eprintln!("cp sparse file: no hole on this filesystem, nothing measured");
+		return;
+	}
+
+	let proj = proj("cpsparsef");
+	let engine = Engine::new(client, proj.clone());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n",
+	)
+	.unwrap();
+	engine.up(&file).await.unwrap();
+
+	let result = engine
+		.cp(&file, holey.to_str().unwrap(), "web:/tmp/holey.bin")
+		.await;
+	// The length, not the presence: an upload that arrived truncated would pass
+	// a check that only asked whether the file exists.
+	let out = engine
+		.test_exec_capture(
+			&format!("{proj}-web-1"),
+			vec!["sh".into(), "-c".into(), "stat -c %s /tmp/holey.bin".into()],
+		)
+		.await;
+	engine.down(&file).await.unwrap();
+
+	result.unwrap_or_else(|e| panic!("cp of a sparse file must upload; podman said: {e}"));
+	let out = out.unwrap_or_default();
+	assert_eq!(
+		out.trim(),
+		(hole + 4).to_string(),
+		"the sparse file must arrive at its full length"
+	);
+}

--- a/tests/engine_integration/watch_sparse.rs
+++ b/tests/engine_integration/watch_sparse.rs
@@ -1,0 +1,91 @@
+//! A watched tree holding a file with holes (requires the test-helpers feature).
+//!
+//! This is the path where #1775 was silent. A failed sync is a `warn!` and the
+//! loop is meant to survive one, so `watch` kept running, kept saying it was
+//! watching, exited 0, and the file never reached the container. An exit code
+//! proves nothing here: the assertion has to be that the bytes arrived.
+use std::time::Duration;
+
+use super::*;
+
+const HOLE: u64 = 1 << 20;
+
+#[tokio::test]
+async fn watch_initial_sync_carries_a_sparse_file() {
+	use std::io::{Seek, SeekFrom, Write};
+	use std::os::unix::fs::MetadataExt;
+
+	let client = match podman().await {
+		Some(d) => d,
+		None => return,
+	};
+	let dir = tempfile::tempdir().unwrap();
+	let src = dir.path().join("src");
+	fs::create_dir(&src).unwrap();
+	fs::write(src.join("plain.txt"), b"beside-the-hole").unwrap();
+
+	let holey = src.join("holey.bin");
+	let mut f = fs::File::create(&holey).unwrap();
+	f.set_len(HOLE).unwrap();
+	// `set_len` leaves the cursor at 0, so the seek is what puts the tail at the
+	// end rather than at the start.
+	f.seek(SeekFrom::Start(HOLE)).unwrap();
+	f.write_all(b"tail").unwrap();
+	f.sync_all().unwrap();
+	drop(f);
+	let meta = fs::metadata(&holey).unwrap();
+	if meta.blocks() * 512 >= meta.size() {
+		eprintln!("watch sparse: no hole on this filesystem, nothing measured");
+		return;
+	}
+
+	let proj = proj("wsparse");
+	let engine = Engine::with_base_dir(client, proj.clone(), dir.path().to_path_buf());
+	let file = parse_str(
+		"services:\n  web:\n    image: alpine:latest\n    command: [\"sleep\", \"infinity\"]\n    develop:\n      watch:\n        - path: src\n          action: sync\n          target: /app\n          initial_sync: true\n",
+	)
+	.unwrap();
+
+	engine.up(&file).await.unwrap();
+
+	let client2 = podup::podman::connect_from_env()
+		.or_else(|_| podup::podman::connect(None))
+		.unwrap();
+	let engine2 = Engine::with_base_dir(client2, proj.clone(), dir.path().to_path_buf());
+	let file2 = file.clone();
+	let handle = tokio::spawn(async move { engine2.watch(&file2).await });
+
+	// The size of the arrived file, not merely its presence: a transfer that
+	// succeeded and truncated the expanded holes would pass a `test -f`.
+	let cname = format!("{proj}-web-1");
+	let want = (HOLE + 4).to_string();
+	let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+	let mut arrived = false;
+	while tokio::time::Instant::now() < deadline {
+		if let Ok(out) = engine
+			.test_exec_capture(
+				&cname,
+				vec![
+					"sh".into(),
+					"-c".into(),
+					"cat /app/plain.txt && stat -c %s /app/holey.bin".into(),
+				],
+			)
+			.await
+		{
+			if out.contains("beside-the-hole") && out.contains(&want) {
+				arrived = true;
+				break;
+			}
+		}
+		tokio::time::sleep(Duration::from_millis(200)).await;
+	}
+
+	handle.abort();
+	engine.down(&file).await.unwrap();
+	assert!(
+		arrived,
+		"the initial sync of a tree holding a sparse file never delivered it; \
+		 this failure is a warning inside watch, so nothing else reports it"
+	);
+}

--- a/tests/tar_builder_single_site.rs
+++ b/tests/tar_builder_single_site.rs
@@ -1,0 +1,115 @@
+//! Every tar podup uploads is built by one constructor.
+//!
+//! `tar::Builder::new` turns sparse-file support on. A file with holes then
+//! goes out as a GNU sparse entry, typeflag `b'S'`, decimal 83, which Podman
+//! refuses: `unhandled tar header type 83` on the build endpoint,
+//! `unrecognized Typeflag S` on the archive endpoint that `cp` and the watch
+//! sync use. That is #1775: a build context Podman's own CLI packs and accepts
+//! was one `podup build` could not upload, and a `podup cp` of the same file
+//! failed too.
+//!
+//! Four call sites had the default, in three unrelated files, and they were
+//! wrong the same way because each was written on its own. Turning the flag off
+//! four times would leave the fifth site free to be written the same way again,
+//! and nothing would say so until somebody with a sparse file reported it. So
+//! the constructor moved to `engine::tar_stream::builder` and this is the gate
+//! that keeps it the only one.
+//!
+//! Test code is exempt: a test that feeds an archive to the unpacking side has
+//! to build that archive, and what it builds never reaches Podman.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The single file allowed to name the crate's constructor.
+const HOME: &str = "internal/engine/tar_stream.rs";
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+	for entry in fs::read_dir(dir).unwrap_or_else(|e| panic!("{} is readable: {e}", dir.display()))
+	{
+		let path = entry.expect("entry is readable").path();
+		if path.is_dir() {
+			rust_sources(&path, out);
+		} else if path.extension().is_some_and(|e| e == "rs") {
+			out.push(path);
+		}
+	}
+}
+
+#[test]
+fn only_tar_stream_constructs_a_tar_builder() {
+	let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+	let mut sources = Vec::new();
+	rust_sources(&root.join("internal"), &mut sources);
+	assert!(
+		sources.len() > 50,
+		"expected to scan the whole crate, found {} files; the walk is broken \
+		 and a gate that reads nothing reports nothing",
+		sources.len()
+	);
+
+	let mut offenders = Vec::new();
+	let mut saw_home = false;
+	for path in &sources {
+		let rel = path
+			.strip_prefix(root)
+			.expect("under the manifest dir")
+			.to_string_lossy()
+			.replace('\\', "/");
+		let name = path.file_name().unwrap().to_string_lossy().into_owned();
+		// A sibling `*_tests.rs` is test code even though it lives beside the
+		// module it tests, which is the convention this crate uses.
+		if name.ends_with("_tests.rs") {
+			continue;
+		}
+		let text = fs::read_to_string(path).unwrap_or_else(|e| panic!("{rel} is readable: {e}"));
+		// Comments are stripped: `tar_stream.rs` explains the defect by naming
+		// the call, and the docs of a rule must not read as a breach of it.
+		let code: String = text
+			.lines()
+			.filter(|l| !l.trim_start().starts_with("//"))
+			.collect::<Vec<_>>()
+			.join("\n");
+		// Two spellings, because closing only the first one leaves the rule
+		// looking enforced while the ordinary way to write it walks past.
+		// `use tar::Builder;` followed by a bare `Builder::new(writer)` is
+		// idiomatic Rust and constructs exactly the same sparse-enabled
+		// builder, and a bare `Builder::new(` cannot be matched on its own:
+		// `std::thread::Builder` and `std::fs::DirBuilder` are both in this
+		// crate already. So the import is what gets refused, which leaves
+		// `tar::Builder::new(` as the only way to reach the constructor and
+		// makes that literal worth searching for.
+		let imports_builder = code
+			.lines()
+			.map(str::trim_start)
+			.any(|l| l.starts_with("use tar::") && l.contains("Builder"));
+		// `use tar as t;` would put the constructor back within reach under a
+		// name this test cannot predict.
+		let renames_crate = code
+			.lines()
+			.map(str::trim_start)
+			.any(|l| l.starts_with("use tar as"));
+		if !code.contains("tar::Builder::new(") && !imports_builder && !renames_crate {
+			continue;
+		}
+		if rel == HOME {
+			saw_home = true;
+		} else {
+			offenders.push(rel);
+		}
+	}
+
+	assert!(
+		saw_home,
+		"{HOME} no longer constructs a tar::Builder. Either it moved, and this \
+		 gate has to follow it, or the crate stopped building tars and the gate \
+		 is dead weight. It is not a pass either way."
+	);
+	assert!(
+		offenders.is_empty(),
+		"these files construct a tar::Builder directly instead of calling \
+		 engine::tar_stream::builder, so the sparse default is back on and a \
+		 sparse file will fail the transfer, with `unhandled tar header type 83` \
+		 or `unrecognized Typeflag S` depending on the endpoint: {offenders:?}"
+	);
+}


### PR DESCRIPTION
Merge commit, no tag in this pull request. Two commits past 5.9.2: one fix and its version bump.

podup wrote GNU sparse tar entries, which Podman refuses, so one file with holes on disk took down the whole transfer it travelled in. A build died with `unhandled tar header type 83`, a `cp` with `unrecognized Typeflag S`, and a watch sync logged a warning and silently never delivered the file, exit code 0 and all. The rejection is per archive rather than per entry, so ordinary files beside the sparse one were lost with it.

Nobody puts a sparse file in a build context deliberately. They arrive as database files, disk images, virtual machine state or anything preallocated with `fallocate`, and `ls` shows nothing unusual, so the failure read as arbitrary. Podman's own client packs in Go and never emits the type, which is why `podman build` accepted a context `podup build` rejected.

Not a regression: every release from 0.3.0 onwards carried it, on Linux, Android and FreeBSD hosts, which are the three targets where the `tar` crate looks for holes at all.

The fix routes all four `tar::Builder` construction sites through one constructor that turns sparse off, with a test gate keeping it the only one, and four tests against a live Podman covering build, `cp` as a file and as a directory, and the watch sync. Each was verified red by reverting the fix.

All three files that stamp a version read 5.9.3 on `origin/develop`, checked immediately before this was opened. The tag goes on `main` after this merges, which is the only thing that triggers a release.